### PR TITLE
feat(tm): Add three-state review outcomes and inline comment guidance

### DIFF
--- a/commands/fix-pr.md
+++ b/commands/fix-pr.md
@@ -17,7 +17,7 @@ ls ~/.claude/plugins/cache/claude-plugins-official/ralph-loop/*/commands/ralph-l
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Fix PR autonomously. Get PR number, check CI, check inline comments, check conversation. Fix issues, commit, push, wait 30s, repeat. Report each iteration. Output <promise>PR_READY</promise> when all checks pass and no unresolved comments. --max-iterations 10 --completion-promise PR_READY"
+  args: "Fix PR autonomously. Get PR number, check CI, check inline comments, check conversation. Fix issues, commit, push, wait 30s, repeat. Report each iteration. Output \\<promise\\>PR_READY\\</promise\\> when all checks pass and no unresolved comments. --max-iterations 10 --completion-promise PR_READY"
 )
 ```
 

--- a/commands/fix-pr.md
+++ b/commands/fix-pr.md
@@ -10,31 +10,14 @@ Enter autonomous PR fixing loop for the current branch's PR until all checks pas
 ls ~/.claude/plugins/cache/claude-plugins-official/ralph-loop/*/commands/ralph-loop.md 2>/dev/null && echo "RALPH_AVAILABLE" || echo "RALPH_NOT_AVAILABLE"
 ```
 
-**If Ralph available:** Use Ralph for iteration (preserves context between iterations):
+**If Ralph available:** Use Ralph for iteration (preserves context between iterations).
+
+**IMPORTANT**: Keep prompt SIMPLE - no multi-line args with special characters.
 
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: """
-Fix PR autonomously until all checks pass.
-
-## Each Iteration
-1. Get PR: `gh pr view --json number,title,headRefName`
-2. Check CI: `gh pr checks <number>`
-3. Check inline comments: `gh api repos/{owner}/{repo}/pulls/<number>/comments`
-4. Check conversation: `gh pr view <number> --comments`
-5. If failures or unresolved bot comments:
-   - Analyze and fix
-   - Commit and push
-   - Wait 30s for CI
-   - Continue loop
-6. If all passing and no bot comments, done
-
-Report each iteration: 🔄 Iteration N: Fixed X issues
-
-Output <promise>PR_READY</promise> when all checks pass and no unresolved comments.
---max-iterations 10 --completion-promise PR_READY
-"""
+  args: "Fix PR autonomously. Get PR number, check CI, check inline comments, check conversation. Fix issues, commit, push, wait 30s, repeat. Report each iteration. Output <promise>PR_READY</promise> when all checks pass and no unresolved comments. --max-iterations 10 --completion-promise PR_READY"
 )
 ```
 

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -170,7 +170,7 @@ cd ~/dev/github.com/<org>/<repo>
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Fix issues, push, wait 60s, repeat. Output <promise>PR_READY</promise> when CI passes and no unaddressed feedback. --max-iterations 30 --completion-promise PR_READY"
+  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Fix issues, push, wait 60s, repeat. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and no unaddressed feedback. --max-iterations 30 --completion-promise PR_READY"
 )
 ```
 
@@ -204,7 +204,7 @@ Report: ready, waiting, or blocked.
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD: test, fix, commit. Then push, create PR, monitor CI, address feedback. Output <promise>PR_READY</promise> when CI passes and no unaddressed feedback. --max-iterations 50 --completion-promise PR_READY"
+  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD: test, fix, commit. Then push, create PR, monitor CI, address feedback. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and no unaddressed feedback. --max-iterations 50 --completion-promise PR_READY"
 )
 ```
 

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -136,6 +136,14 @@ TASK_ID="${TASK_DIR%%--*}"
 
 ### Mode: CLEANUP → Launch cleanup-specialist
 
+**CRITICAL: cd to repo root BEFORE launching cleanup-specialist.** The subagent will delete the current worktree directory, and if the parent's cwd is invalid when the subagent completes, stop hooks will fail with ENOENT.
+
+**Step 1: cd to repo root first**
+```bash
+cd ~/dev/github.com/<org>/<repo> && pwd
+```
+
+**Step 2: Then launch cleanup-specialist**
 ```
 Task(
   subagent_type: "general-purpose",
@@ -144,24 +152,62 @@ Task(
 # Cleanup <tag>.<task-id>
 
 PR merged. Clean up in this order:
-1. cd to <repo>-main FIRST (you're about to delete current directory)
-2. Mark task done: `task-master tags use "<tag>" && task-master set-status --id=<task-id> --status=done`
-3. Remove worktree: `git worktree remove ../worktree/<tag>/<task-id>--<slug>`
-4. Delete branch: `git branch -d <branch-name>`
+1. Mark task done: `task-master tags use "<tag>" && task-master set-status --id=<task-id> --status=done`
+2. Remove worktree from <repo>-main: `git worktree remove ../worktree/<tag>/<task-id>--<slug>`
+3. Delete branch: `git branch -d <branch-name>`
 
 Report complete.
 """
 )
-```
-
-After subagent completes, cd to repo root (worktree was deleted, cwd is invalid):
-```bash
-cd ~/dev/github.com/<org>/<repo>
-```
 
 ---
 
 ### Mode: REVIEW (PR open)
+
+#### Review Outcomes (Three States)
+
+When reviewing code, categorize findings into three distinct outcomes:
+
+| State | Icon | Meaning | GitHub Action |
+|-------|------|---------|---------------|
+| **Blockers** | 🔴 | Must address before merge - bugs, security issues, correctness problems | Request changes, post inline comments with "MUST FIX" |
+| **Suggestions** | 🟡 | Should address - style, performance, maintainability concerns | Comment (don't approve), post inline comments as suggestions |
+| **Approve** | 🟢 | Ready to merge, possibly with minor notes | Approve with optional comments |
+
+**Decision criteria:**
+- **Blocker**: Would this cause a bug, security issue, or break functionality?
+- **Suggestion**: Is this a style/performance improvement that doesn't affect correctness?
+- **Approve**: Does the code meet requirements and pass tests?
+
+#### Posting Inline Comments
+
+Use `gh api` to post inline review comments on specific lines:
+
+```bash
+# Post a single inline comment
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments \
+  --method POST \
+  -f body="🔴 **MUST FIX**: Description of the blocker issue" \
+  -f commit_id="$(gh pr view <pr-number> --json headRefOid -q '.headRefOid')" \
+  -f path="path/to/file.go" \
+  -f line=42
+
+# For multi-line comments (start_line to line)
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments \
+  --method POST \
+  -f body="🟡 **Suggestion**: Consider using X instead of Y for better performance" \
+  -f commit_id="$(gh pr view <pr-number> --json headRefOid -q '.headRefOid')" \
+  -f path="path/to/file.go" \
+  -f start_line=40 \
+  -f line=45
+```
+
+**Comment prefix conventions:**
+- `🔴 **MUST FIX**:` - Blocker that must be addressed
+- `🟡 **Suggestion**:` - Non-blocking improvement
+- `🟢 **Note**:` - Informational, no action needed
+
+#### Review Workflow
 
 **If `$RALPH_AVAILABLE`:** Invoke Ralph for review loop.
 
@@ -170,7 +216,7 @@ cd ~/dev/github.com/<org>/<repo>
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Fix issues, push, wait 60s, repeat. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and no unaddressed feedback. --max-iterations 30 --completion-promise PR_READY"
+  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Categorize issues as blockers (must fix) or suggestions (nice to have). Fix blockers first, then suggestions. Push, wait 60s, repeat. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and all blockers addressed. --max-iterations 30 --completion-promise PR_READY"
 )
 ```
 
@@ -185,10 +231,29 @@ Task(
 
 Working directory: <worktree-path>
 
-Check CI and feedback. Fix issues, push, wait for CI, repeat until ready.
-Spawn opus for complex code changes.
+## Review Process
+1. Check CI status first
+2. Read inline comments (gh api repos/<owner>/<repo>/pulls/<number>/comments)
+3. Read conversation comments (gh pr view <number> --comments)
 
-Report: ready, waiting, or blocked.
+## Categorize Issues
+- 🔴 **Blockers**: Bugs, security issues, correctness - MUST fix
+- 🟡 **Suggestions**: Style, performance - SHOULD fix if quick
+- 🟢 **Approve-worthy**: Ready with optional notes
+
+## Actions
+- Fix all blockers
+- Fix suggestions if quick (<5 min each)
+- Defer suggestions needing design decisions to user
+- Post inline comments using gh api for new findings
+
+## Report Format
+Report one of:
+- **READY**: All blockers fixed, suggestions addressed or deferred
+- **WAITING**: CI running, will check again
+- **BLOCKED**: Need user decision on <specific issue>
+
+Spawn opus for complex code changes.
 """
 )
 ```

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -158,34 +158,14 @@ Report complete.
 
 ### Mode: REVIEW (PR open)
 
-**If `$RALPH_AVAILABLE`:** Invoke Ralph for review loop:
+**If `$RALPH_AVAILABLE`:** Invoke Ralph for review loop.
+
+**IMPORTANT**: Keep prompt SIMPLE - no multi-line args with special characters.
 
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: """
-Review PR #<number> for <tag>.<task-id>
-
-Working directory: <worktree-path>
-
-## Review Loop
-1. Check CI: `gh pr checks <number>`
-2. Check inline feedback: `gh api repos/<owner>/<repo>/pulls/<number>/comments`
-3. Check conversation: `gh pr view <number> --comments`
-4. If CI fails or unaddressed feedback:
-   - Fix issues (check TM before creating new tasks for suggestions)
-   - Commit and push
-   - Wait 60s for CI
-   - Go to step 1
-5. If CI passes and no unaddressed feedback, done
-
-## Completion Criteria
-- CI passing
-- No unaddressed review feedback
-
-Output <promise>PR_READY</promise> when done.
---max-iterations 30 --completion-promise PR_READY
-"""
+  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Fix issues, push, wait 60s, repeat. Output <promise>PR_READY</promise> when CI passes and no unaddressed feedback. --max-iterations 30 --completion-promise PR_READY"
 )
 ```
 
@@ -212,48 +192,14 @@ Report: ready, waiting, or blocked.
 
 ### Mode: IMPLEMENT or CREATE_PR (no PR exists)
 
-**If `$RALPH_AVAILABLE`:** Invoke Ralph for full cycle:
+**If `$RALPH_AVAILABLE`:** Invoke Ralph for full cycle.
+
+**IMPORTANT**: Keep the Ralph prompt SIMPLE to avoid bash parsing issues. Do NOT embed task descriptions inline - they contain backticks and special characters that break parsing.
 
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: """
-Complete <tag>.<task-id>: <task-title>
-
-Working directory: <worktree-path>
-
-## Requirements
-<task-description-and-subtasks>
-
-## Phase 1: Implementation (TDD) - skip if commits already exist
-1. Run tests for affected code
-2. If tests fail, fix the code
-3. If coverage low, add tests
-4. Commit incrementally
-
-## Phase 2: Create PR (when local tests pass)
-1. Push branch: `git push -u origin <branch>`
-2. Create PR: `gh pr create --title '<title>' --body '<TM reference + summary>'`
-3. Note the PR number
-
-## Phase 3: Review Loop (after PR created)
-1. Wait 60s for CI to start
-2. Check CI: `gh pr checks <number>`
-3. Check feedback: `gh api repos/<owner>/<repo>/pulls/<number>/comments`
-4. If CI fails or feedback exists:
-   - Fix issues
-   - Commit and push
-   - Go to step 1
-5. If CI passes and no unaddressed feedback, done
-
-## Completion Criteria
-- PR created and pushed
-- CI passing
-- No unaddressed review feedback
-
-Output <promise>PR_READY</promise> when done.
---max-iterations 50 --completion-promise PR_READY
-"""
+  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD: test, fix, commit. Then push, create PR, monitor CI, address feedback. Output <promise>PR_READY</promise> when CI passes and no unaddressed feedback. --max-iterations 50 --completion-promise PR_READY"
 )
 ```
 

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -179,6 +179,11 @@ When reviewing code, categorize findings into three distinct outcomes:
 - **Suggestion**: Is this a style/performance improvement that doesn't affect correctness?
 - **Approve**: Does the code meet requirements and pass tests?
 
+**Bias toward action**: "Non-blocking" suggestions should still be fixed if quick. Only defer to user if:
+- Suggestion requires design decision
+- Fix is controversial or risky
+- Suggestion is genuinely wrong (explain why)
+
 #### Posting Inline Comments
 
 Use `gh api` to post inline review comments on specific lines:
@@ -216,7 +221,7 @@ gh api repos/<owner>/<repo>/pulls/<pr-number>/comments \
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Categorize issues as blockers (must fix) or suggestions (nice to have). Fix blockers first, then suggestions. Push, wait 60s, repeat. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and all blockers addressed. --max-iterations 30 --completion-promise PR_READY"
+  args: "Review PR #<number> in <worktree-path>. Check CI, inline comments, conversation. Categorize as blockers (must fix) or suggestions (fix if quick). Fix all blockers, then suggestions. Push, wait 60s, repeat. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and all actionable feedback addressed. --max-iterations 10 --completion-promise PR_READY"
 )
 ```
 
@@ -241,9 +246,12 @@ Working directory: <worktree-path>
 - 🟡 **Suggestions**: Style, performance - SHOULD fix if quick
 - 🟢 **Approve-worthy**: Ready with optional notes
 
+## Bias Toward Action
+Fix ALL suggestions, even "non-blocking" ones, unless they require design decisions. "Non-blocking" means "safe to fix" not "safe to ignore."
+
 ## Actions
-- Fix all blockers
-- Fix suggestions if quick (<5 min each)
+- Fix all blockers first
+- Fix suggestions if quick
 - Defer suggestions needing design decisions to user
 - Post inline comments using gh api for new findings
 
@@ -269,7 +277,7 @@ Spawn opus for complex code changes.
 ```
 Skill(
   skill: "ralph-loop:ralph-loop",
-  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD: test, fix, commit. Then push, create PR, monitor CI, address feedback. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and no unaddressed feedback. --max-iterations 50 --completion-promise PR_READY"
+  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD: test, fix, commit. Then push, create PR, monitor CI, address feedback. Output \\<promise\\>PR_READY\\</promise\\> when CI passes and no unaddressed feedback. --max-iterations 20 --completion-promise PR_READY"
 )
 ```
 

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -154,6 +154,11 @@ Report complete.
 )
 ```
 
+After subagent completes, cd to repo root (worktree was deleted, cwd is invalid):
+```bash
+cd ~/dev/github.com/<org>/<repo>
+```
+
 ---
 
 ### Mode: REVIEW (PR open)


### PR DESCRIPTION
## Summary

- Adds three-state review outcome system (blockers/suggestions/approve)
- Adds detailed inline comment posting instructions using gh api
- Fixes cleanup mode cd ordering to prevent stop hook errors

## Problem

The /tm review mode was confusing about:
1. How to categorize review findings (binary blocked/ready vs nuanced states)
2. How to post inline comments to GitHub PRs

## Solution

### Three-State Review Outcomes

| State | Icon | Meaning | GitHub Action |
|-------|------|---------|---------------|
| **Blockers** | 🔴 | Must address before merge | Request changes with "MUST FIX" |
| **Suggestions** | 🟡 | Should address, not blocking | Comment with suggestions |
| **Approve** | 🟢 | Ready to merge | Approve with optional notes |

### Inline Comment Instructions

Added complete gh api commands for posting inline review comments:
```bash
gh api repos/<owner>/<repo>/pulls/<pr-number>/comments \
  --method POST \
  -f body="🔴 **MUST FIX**: Description" \
  -f commit_id="$(gh pr view <pr-number> --json headRefOid -q '.headRefOid')" \
  -f path="path/to/file.go" \
  -f line=42
```

### Cleanup Fix

Also includes the fix for cleanup mode - now cds to repo root BEFORE launching the cleanup subagent, preventing ENOENT errors when the worktree is deleted.

## Test Plan

- [ ] Run /tm in review mode on an open PR
- [ ] Verify inline comment posting works
- [ ] Test cleanup mode doesn't error on worktree deletion