### PR TITLE
refactor: Extract skills, concurrent PR monitoring, retro fixes

### DIFF
--- a/commands/6hats-team.md
+++ b/commands/6hats-team.md
@@ -32,13 +32,14 @@ If called without arguments, respond with:
 
 Assess the topic to determine:
 
-1. **Team size** (2-5 members, default 3). More members = richer dialogue but higher cost.
-2. **Professional lenses** that create productive tension for THIS topic. Pick identities whose perspectives will surface genuinely different observations.
+1. **Team size** (2-4 members, default 3). Prefer 3 - a fourth only adds value when perspectives are truly orthogonal. More members = longer phases and more nudging required.
+2. **Professional lenses** that create productive tension for THIS topic. Pick identities whose perspectives will surface genuinely different observations. Avoid overlapping lenses (e.g., SRE + Platform Engineer have high overlap - pick one).
 3. **Hat sequence** based on problem type (reuse sequences from `/6hats`):
-   - Simple: White → Black
-   - Moderate: White → Black → Yellow → Green
-   - Complex: White → Red → Black → Yellow → Green
-   - Or domain-specific sequences (Innovation, Debugging, UX, etc.)
+   - Simple: White → Black (2 phases, ~20 min)
+   - Moderate: White → Black → Yellow → Green (4 phases, ~45 min)
+   - Complex: White → Black → Yellow → Green (4 phases, ~60 min)
+   - Skip Red Hat for technical reviews - gut reactions overlap with Black Hat for code/architecture topics. Reserve Red Hat for people/process/culture decisions where emotional signals matter.
+   - **Target 45-90 minutes total.** If it's taking longer, reduce phases or team size.
 
 **Lens selection examples** (not exhaustive — choose what fits):
 
@@ -65,7 +66,9 @@ TeamCreate(
 
 ### Step 3: Spawn Team Members
 
-Spawn each member as a general-purpose agent (so they can call hat agents) with their professional identity and meeting instructions.
+Spawn ALL members in parallel (single message with multiple Agent tool calls). Each member is a general-purpose agent with their professional identity and **explicit first-phase instructions**.
+
+**CRITICAL**: Include the first hat phase instructions directly in the spawn prompt. Do NOT send a separate broadcast to start the first phase - members should begin investigating immediately after reading the source material. This eliminates the idle-then-nudge cycle that wastes time.
 
 For each member, use the Agent tool:
 
@@ -89,21 +92,26 @@ You are a [PROFESSIONAL ROLE] participating in a Six Thinking Hats team meeting 
 
 You are a [ROLE] with deep expertise in [DOMAIN]. This identity persists across ALL phases of the meeting. You see everything through the lens of your professional experience.
 
-## How the Meeting Works
+## IMMEDIATE FIRST TASK
 
-Blue Hat (the team lead) chairs this meeting and will announce hat phases. When a phase is announced:
+Read [SOURCE FILES]. Then immediately begin the [FIRST HAT COLOR] Hat phase:
 
-1. **Call the hat agent** — Use the Agent tool to spawn the relevant hat agent (e.g., subagent_type="white-hat") with a prompt shaped by YOUR professional lens. Ask it to investigate what matters from YOUR perspective.
+1. Spawn the [hat-color]-hat agent: Agent(subagent_type="[hat-color]-hat", prompt="As a [ROLE] investigating [TOPIC], focus on [SPECIFIC LENS-SHAPED QUESTIONS]. Read [SOURCE FILES] and investigate: [2-3 CONCRETE QUESTIONS FROM YOUR LENS].")
 
-2. **Share findings with the team** — After your hat agent returns, share your key findings with the team via SendMessage(to="*"). Lead with what's most important from your professional perspective.
+2. When the agent returns, share your key findings with the team via SendMessage(to="*"). Lead with what's most important from your professional perspective.
 
-3. **Discuss with peers** — Read what other team members share. Respond directly to specific members via SendMessage when you:
-   - See something they missed from your vantage point
-   - Want to build on their observation
-   - Disagree based on your expertise
-   - Have a question about their findings
+3. Read what other team members share. Respond directly to specific members via SendMessage when you see something they missed, want to build on their observation, disagree based on your expertise, or have a question.
 
-4. **Follow Blue's direction** — When Blue Hat says to move on, move on. When Blue asks you a direct question, answer it.
+4. After peer discussion, wait for Blue Hat to announce the next phase.
+
+## How Subsequent Phases Work
+
+Blue Hat (the team lead) will announce each new phase. When announced:
+
+1. **Spawn the hat agent** with a prompt shaped by YOUR professional lens
+2. **Share findings** via SendMessage(to="*")
+3. **Discuss with peers** — 2-3 substantive messages max per phase
+4. **Follow Blue's direction** — when Blue says move on, move on
 
 ## Communication Style
 
@@ -112,12 +120,12 @@ Blue Hat (the team lead) chairs this meeting and will announce hat phases. When 
 - Challenge other members respectfully when your expertise says otherwise.
 - Build on others' observations — "Adding to what [member] said..."
 - Keep exchanges focused — 2-3 substantive messages per phase, not endless back-and-forth.
-- **Never re-broadcast findings you already shared.** If Blue or a peer asks you to elaborate, add NEW detail or nuance — don't repeat your initial summary. Reference it: "As I mentioned, [brief pointer] — the additional context is..."
+- **Never re-broadcast findings you already shared.** If Blue or a peer asks you to elaborate, add NEW detail or nuance.
 - When Blue announces a new phase, commit fully to the new hat. Don't continue cross-discussing the prior phase.
 
 ## Hat Agent Prompts
 
-When calling a hat agent, shape the prompt through your lens:
+Shape every hat agent prompt through your lens:
 - DON'T: "Investigate the facts about X" (generic)
 - DO: "As a security engineer investigating X, I need you to focus on authentication flows, token handling, and access control. What are the facts about [specific security concern]?" (lens-shaped)
 
@@ -130,7 +138,7 @@ For each hat in your chosen sequence, facilitate a phase:
 
 **4a. Announce the phase**
 
-Send a broadcast to all members:
+Note: The first phase is embedded in the member spawn prompts (Step 3). For subsequent phases, send a broadcast:
 
 ```
 SendMessage(
@@ -139,28 +147,32 @@ SendMessage(
 
   Spawn the [hat-color]-hat agent with a prompt shaped by your professional expertise. Share your findings, then discuss with your peers.
 
-  [Optional: specific focus areas or questions relevant to accumulated context]",
+  [Specific focus areas or key tensions from prior phases]",
   summary: "[Hat] phase — [brief focus]"
 )
 ```
+
+**Include specific questions and prior-phase context in every announcement.** Vague prompts like "share your gut reactions" produce idle members. Concrete prompts like "the dunning race condition and the demo conflict are the two biggest risks - what else?" produce immediate action.
 
 **4b. Monitor the discussion**
 
 As messages come in from team members:
 - Let them discuss peer-to-peer — don't relay messages
 - Intervene if someone drifts off the current hat's focus
-- Ask a quiet member to weigh in if their perspective is missing
+- If a member goes idle without sharing findings, send ONE direct nudge with an explicit agent spawn prompt. If they don't respond after the nudge, move on - don't block the meeting on one member.
 - Note consensus and dissent internally
-- Extend the phase if dialogue is particularly productive
+- Extend the phase if dialogue is producing genuine insight
 
 **4c. Move to next phase**
 
-When sufficient signal has been gathered (typically after each member has shared findings and had 1-2 exchanges):
+Move on when you have findings from at least N-1 members (e.g., 2 of 3). Do not wait indefinitely for every member. Announce the transition with a summary:
 
 ```
 SendMessage(
   to: "*",
-  message: "Good discussion. [1-2 sentence summary of key takeaway from this phase]. Moving to [NEXT HAT] phase.",
+  message: "[1-2 sentence summary of key takeaway from this phase]. Moving to [NEXT HAT] phase.
+
+  [Specific framing questions informed by what was just surfaced]",
   summary: "Phase summary, moving to [next hat]"
 )
 ```
@@ -240,25 +252,38 @@ Do this for each member.
 - Max ~2-3 substantive messages per member per phase
 - Extend if the dialogue is producing genuine insight
 - Cut short if responses are repetitive or circular
+- **Move on after N-1 members have contributed** - don't block on stragglers
+- One direct nudge per straggler per phase. If they don't respond, proceed.
 - Trust your judgment as chair
 
 ### Adapt the Sequence
 - If White Hat reveals the problem is simpler than expected, skip some phases
 - If Black Hat surfaces a critical risk, give Green Hat more time
+- **Skip Red Hat for technical reviews** - gut reactions overlap with Black Hat for code/architecture. Use Red Hat for people, process, or culture topics where emotional signals add unique information.
 - The sequence is a guide, not a straitjacket
+- **Target total meeting time**: 45-90 minutes. If approaching 90 min, compress remaining phases or go straight to verdict.
 
 ## Differences from /6hats
 
 | Aspect | /6hats (parallel) | /6hats-team (meeting) |
 |--------|-------------------|----------------------|
-| Speed | Fast (all hats parallel) | Slower (sequential phases) |
+| Speed | Fast (~5 min) | 45-90 min target |
 | Interaction | None (isolated agents) | Rich (peer-to-peer dialogue) |
 | Diversity | Hat methodology only | Hat methodology x professional lens |
 | Emergence | None | Ideas build on each other |
 | Blue Hat | Synthesizer at end | Active facilitator throughout |
 | Faithfulness to De Bono | Low | High |
 
-Use `/6hats` for quick assessments. Use `/6hats-team` when you want the deliberation.
+Use `/6hats` for quick assessments. Use `/6hats-team` when the topic warrants deliberation and you have 60-90 minutes.
+
+## Lessons Learned
+
+- **Embed first phase in spawn prompt.** Members who are spawned with "read the material and wait" go idle. Members who are spawned with "read the material and immediately investigate X" start working.
+- **3 members is the sweet spot.** A fourth member adds ~50% more wall clock time but only ~15% more signal. Use 4 only when perspectives are truly orthogonal.
+- **Skip Red Hat for technical reviews.** Gut reactions and critical judgment overlap heavily for code/architecture topics. Red Hat adds unique value for people/process/culture decisions.
+- **Move on without stragglers.** One nudge per straggler. If they don't respond, proceed with N-1 findings. Don't block the meeting.
+- **Concrete phase prompts, not vague ones.** "What are the risks?" produces confusion. "The dunning race condition and demo conflict are the two biggest risks from Black Hat - how do we fix them?" produces action.
+- **4 phases (W-B-Y-G) is the default.** 5 phases (with Red) is only for non-technical topics. 2 phases (W-B) is enough for simple questions.
 
 ## Usage
 `/6hats-team [topic or problem to analyze]`

--- a/commands/fix-develop.md
+++ b/commands/fix-develop.md
@@ -90,23 +90,6 @@ EOF
 
 ## Step 4: Loop Until Green
 
-### Check for Ralph Plugin
-
-```bash
-ls ~/.claude/plugins/cache/claude-plugins-official/ralph-loop/*/commands/ralph-loop.md 2>/dev/null && echo "RALPH_AVAILABLE" || echo "RALPH_NOT_AVAILABLE"
-```
-
-**If Ralph available:**
-
-```
-Skill(
-  skill: "ralph-loop:ralph-loop",
-  args: "Fix develop CI PR. EACH iteration: check CI status, inline comments, conversation comments. Fix issues, commit, push, wait 60s, repeat. Output \\<promise\\>DEVELOP_FIXED\\</promise\\> when CI passes and all comments addressed. --max-iterations 10 --completion-promise DEVELOP_FIXED"
-)
-```
-
-**If Ralph NOT available:** Use manual loop below.
-
 ### Each Iteration
 
 ```bash

--- a/commands/fix-pr.md
+++ b/commands/fix-pr.md
@@ -22,25 +22,6 @@ Enter autonomous PR review loop for the current branch's PR. Loops until the PR 
 
 ---
 
-## Check for Ralph Plugin
-
-```bash
-ls ~/.claude/plugins/cache/claude-plugins-official/ralph-loop/*/commands/ralph-loop.md 2>/dev/null && echo "RALPH_AVAILABLE" || echo "RALPH_NOT_AVAILABLE"
-```
-
-**If Ralph available:** Use Ralph for iteration (preserves context between iterations).
-
-```
-Skill(
-  skill: "ralph-loop:ralph-loop",
-  args: "Fix PR autonomously. Get PR number. EACH iteration: merge origin/develop first, then check all 5 green criteria -- no merge conflicts, CI passing, no unresolved inline comments, conversation addressed, all review threads resolved. Fix issues, commit, push, then block on CI with gh pr checks <number> --watch --fail-fast before checking threads. Output \\<promise\\>PR_READY\\</promise\\> when ALL 5 criteria are met. --max-iterations 10 --completion-promise PR_READY"
-)
-```
-
-**If Ralph NOT available:** Use manual loop below (may burn context on many iterations).
-
----
-
 ## Shell Pitfalls
 **Never use `gh ... --jq` with complex filters.** Always pipe to `jq` separately.
 
@@ -67,16 +48,17 @@ git fetch origin develop && git merge origin/develop --no-edit
 - **Barrel exports** (e.g., shared/index.ts): Accept both sides — each adds its own export
 - **Config/manifest files**: Accept both sides unless the same key is modified differently (then ask)
 
-### Step 2: Check remaining criteria
+### Step 2: Check all criteria concurrently
 
 ```bash
 PR=$(gh pr view --json number --jq '.number')
 
-# CI status
-gh pr checks $PR --json name,state | jq '.[] | select(.state == "FAILURE" or .state == "CANCELLED")'
+# Start CI watch in background
+gh pr checks $PR --watch --fail-fast &
+CI_PID=$!
 
+# While CI runs, check threads and comments (don't wait for CI)
 # Unresolved review threads (covers inline comments from all reviewers)
-# Include path and line so we can check if the concern is already fixed locally
 gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") {
   pullRequest(number: '$PR') { reviewThreads(first: 50) { nodes {
     id isResolved path line comments(first: 1) { nodes { author { login } body } }
@@ -85,7 +67,7 @@ gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") {
   | {id, author: .comments.nodes[0].author.login, path, line, body: .comments.nodes[0].body[0:200]}'
 
 # For each unresolved thread with a path, check current local code to see if already fixed:
-# Read the local file at the referenced line — if the concern is addressed in the current
+# Read the local file at the referenced line - if the concern is addressed in the current
 # working tree, resolve the thread directly (for bot threads) instead of pushing and waiting
 # for a re-review cycle.
 # Example: sed -n '<line-5>,<line+5>p' <path>
@@ -94,17 +76,21 @@ gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") {
 gh pr view $PR --comments
 ```
 
-### Step 3: Fix and loop
+### Step 3: Fix and batch
 
-**Decision tree:**
-- Merge conflicts → Resolve using patterns above, or report blocked if ambiguous
-- CI failing → Fix code, commit, push
-- Unresolved bot threads (CodeRabbit, claude[bot]) → **Check local code first** at the referenced path:line. If the concern is already addressed in the working tree, resolve the thread directly via GraphQL (saves a push→wait→re-review cycle). If not addressed, fix the code, then push.
-- Unresolved human threads → Fix code, reply inline, @mention reviewer
-- Actionable conversation comments → Respond or fix
-- **ALL 5 criteria met** → Report ready, STOP
+**Fix issues locally while CI runs** - stage changes but don't push yet:
+- Unresolved bot threads (CodeRabbit, claude[bot]) - **Check local code first** at the referenced path:line. If already addressed, resolve via GraphQL immediately (no push needed). If not, fix the code and `git add`.
+- Unresolved human threads - Fix code, reply inline, @mention reviewer
+- Actionable conversation comments - Respond or fix
+- Merge conflicts - Resolve using patterns above, or report blocked if ambiguous
 
-After pushing, block on CI with `gh pr checks <number> --watch --fail-fast` instead of blind sleep. Only check threads after CI settles.
+**When CI finishes** (`wait $CI_PID`):
+- CI passed + no local fixes staged: evaluate whether all 5 criteria are met
+- CI passed + local fixes staged: push once (batches all thread fixes into one CI cycle)
+- CI failed: fix CI issues too, then push everything together
+- **ALL 5 criteria met** - Report ready, STOP
+
+**This batches fixes into fewer pushes.** A 15-min CI run where CodeRabbit posts at minute 2 no longer wastes 13 minutes idle - thread fixes are ready before CI finishes, saving a full CI cycle.
 
 ---
 

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -7,7 +7,7 @@ argument-hint: [tag [task-id] | feature description] (optional - derives context
 
 **$ARGUMENTS**
 
-> Thin orchestrator. Uses Ralph Loop for iteration when available, falls back to subagents.
+> Thin orchestrator. Delegates to subagents for implementation and review loops.
 >
 > **Planning Mode** (`/tm use stripe as kyc provider`): When args don't match an existing tag, explores the codebase, writes a PRD, creates a tag, generates tasks, runs complexity analysis, and expands. Stops after planning — run `/tm <tag>` to start work.
 >
@@ -21,17 +21,11 @@ argument-hint: [tag [task-id] | feature description] (optional - derives context
 ## Phase 0: Detect Capabilities
 
 ```bash
-# Ralph plugin
-ls ~/.claude/plugins/cache/claude-plugins-official/ralph-loop/*/commands/ralph-loop.md 2>/dev/null && echo "RALPH_AVAILABLE" || echo "RALPH_NOT_AVAILABLE"
-
 # Agent Teams
 echo $CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
 ```
 
-Set `$RALPH_AVAILABLE` and `$TEAMS_AVAILABLE` (`true` if result is `"1"`).
-
-If Ralph not available, warn once:
-> ⚠️ Ralph Loop plugin not installed. Using subagents (may burn context on long test runs). Install: `/plugin install ralph-loop`
+Set `$TEAMS_AVAILABLE` (`true` if result is `"1"`).
 
 ---
 
@@ -104,11 +98,11 @@ Is current directory a TM worktree?
 gh pr view --json number,state,mergedAt 2>/dev/null
 ```
 
-| Condition | Action (Ralph) | Action (Fallback) |
-|-----------|----------------|-------------------|
-| `mergedAt` is set | cleanup-specialist | cleanup-specialist |
-| PR exists, open | Ralph review loop | review-specialist |
-| No PR | Ralph full cycle | implement-specialist |
+| Condition | Action |
+|-----------|--------|
+| `mergedAt` is set | CLEANUP mode |
+| PR exists, open | REVIEW mode |
+| No PR | IMPLEMENT mode |
 
 ---
 
@@ -288,7 +282,7 @@ Task(
 PR merged. Clean up in this order:
 1. Mark task done: `cd ~/dev/github.com/<org>/<repo> && task-master tags use "<tag>" && task-master set-status --id=<task-id> --status=done`
 2. Remove worktree from <repo>-main: `cd <repo>-main && git worktree remove --force ../worktree/<tag>/<task-id>--<slug>`
-3. Delete branch: `git branch -d <tag>--<task-id>--<slug>`
+3. Delete branch: `git branch -D <tag>--<task-id>--<slug>`
 """
 )
 ```
@@ -354,21 +348,10 @@ gh pr view <number> --comments
 - Unresolved human threads → Fix code, reply inline, @mention reviewer
 - ALL clear → Output `<promise>PR_READY</promise>`
 
-#### Review Loop (Ralph or Fallback)
+#### Review Loop
 
-**CRITICAL**: Ralph args are passed to bash UNQUOTED. Shell special chars will break. Reference tasks by ID only.
-
-**If Ralph available:**
 ```
-Skill(
-  skill: "ralph-loop:ralph-loop",
-  args: "Review PR <number> for <tag>.<task-id> in <worktree-path>. FIRST merge origin/develop to stay in sync. Then loop until ALL green -- no merge conflicts, CI passing, no unresolved inline comments, conversation addressed, your review threads resolved. Fix issues, push, then block on CI with gh pr checks <number> --watch --fail-fast before checking threads. --max-iterations 10 --completion-promise PR_READY --tag <tag> --task <task-id>"
-)
-```
-
-**If Ralph NOT available:**
-```
-Task(
+Agent(
   subagent_type: "general-purpose",
   model: "sonnet",
   prompt: """
@@ -380,7 +363,7 @@ Each iteration: merge origin/develop first. Loop until ALL green:
 1. No merge conflicts  2. CI passing  3. No unresolved inline comments
 4. No unaddressed conversation comments  5. All YOUR review threads resolved
 
-Fix issues, push, wait for CI, repeat. Spawn opus for complex code changes.
+Fix issues, push, block on CI with `gh pr checks <number> --watch --fail-fast` before checking threads.
 Report: ready, waiting, or blocked.
 """
 )
@@ -390,24 +373,14 @@ Report: ready, waiting, or blocked.
 
 ### Mode: Implement or Create PR
 
-**If Ralph available:**
 ```
-Skill(
-  skill: "ralph-loop:ralph-loop",
-  args: "Complete <tag>.<task-id> in <worktree-path>. Run task-master show <task-id> for requirements. TDD -- test, fix, commit. Push, create PR, then loop until ALL green. Each iteration merge origin/develop first, then check -- no merge conflicts, CI passing, no unresolved inline comments, conversation addressed, your review threads resolved. --max-iterations 20 --completion-promise PR_READY --tag <tag> --task <task-id>"
-)
-```
-
-**If Ralph NOT available:**
-```
-Task(
+Agent(
   subagent_type: "general-purpose",
   model: "sonnet",
   prompt: """
 # Implement <tag>.<task-id>: <task-title>
 
 Working directory: <worktree-path>
-You're an orchestrator. Spawn opus for complex code changes.
 
 ## Requirements
 <task-description-and-subtasks>
@@ -415,8 +388,9 @@ You're an orchestrator. Spawn opus for complex code changes.
 ## Flow
 1. Implement using TDD (run tests, fix failures, commit)
 2. Push and create PR
-3. Monitor CI, fix issues
-4. Report: PR ready, waiting, or blocked
+3. Review loop: merge origin/develop first each iteration, then check all 5 criteria (no merge conflicts, CI passing, no unresolved inline comments, no unaddressed conversation comments, all review threads resolved)
+4. Block on CI with `gh pr checks <number> --watch --fail-fast` before checking threads
+5. Report: PR ready, waiting, or blocked
 """
 )
 ```
@@ -652,19 +626,47 @@ gh pr view --json reviews | jq '.reviews[] | select(.state == "CHANGES_REQUESTED
      gh pr view <number> --json state,mergeStateStatus | jq '{state, mergeStateStatus}'
      ```
      If DIRTY or BLOCKED, fix before entering review loop.
-4. **Review loop**: Merge origin/develop first each iteration. Check all 5 green criteria:
-   - No merge conflicts — resolve using patterns above
+4. **Review loop** - concurrent monitoring after each push. All 5 green criteria must be met:
+   - No merge conflicts with develop
    - CI passing
-   - No unresolved inline comments (fix for CodeRabbit — never reply in threads; reply to humans)
+   - No unresolved inline comments (fix for CodeRabbit - never reply in threads; reply to humans)
    - No unaddressed conversation comments
    - All your review threads resolved
-5. Fix issues, push, then **block on CI** (don't blind-sleep):
+5. **After pushing, monitor CI and reviews concurrently** (don't wait for CI to check threads):
    ```bash
-   gh pr checks <number> --watch --fail-fast
+   # Start CI watch in background
+   gh pr checks <number> --watch --fail-fast &
+   CI_PID=$!
+
+   # While CI runs, check for review threads, comments, and develop drift
+   git fetch origin develop
+   git diff --stat origin/develop...HEAD | tail -1  # check for drift
+
+   # Check unresolved threads (CodeRabbit posts within 2-5 min of push)
+   gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") {
+     pullRequest(number: <number>) { reviewThreads(first: 50) { nodes {
+       id isResolved path line comments(first: 1) { nodes { author { login } body } }
+     }}}}}'  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+     | select(.isResolved == false)
+     | {id, author: .comments.nodes[0].author.login, path, line, body: .comments.nodes[0].body[0:200]}'
+
+   # Check conversation comments
+   gh pr view <number> --comments
    ```
-   This blocks until CI completes — no wasted wait time. Only check threads AFTER CI settles.
-   - **Contradictory bot comments** (e.g., CodeRabbit suggests X, Claude bot suggests opposite) — resolve yourself using your best judgment. Do NOT escalate as BLOCKED. Pick the approach that best fits the codebase patterns and explain your choice in the commit message.
-   - **Merge conflicts are routine** — resolve using Known Conflict Patterns. Only escalate if genuinely ambiguous.
+   **Fix issues locally while CI runs** - stage changes but batch them:
+   - Review threads with code fixes: fix locally, `git add` but don't push yet
+   - Develop drift: `git merge origin/develop --no-edit`
+   - Bot threads already addressed in local code: resolve via GraphQL immediately (no push needed)
+
+   **When CI finishes** (`wait $CI_PID`):
+   - CI passed + no local fixes staged: check threads one final time, then evaluate REVIEW_CLEAR
+   - CI passed + local fixes staged: push once (batches all thread fixes into one CI cycle)
+   - CI failed: fix CI issues too, then push everything together
+
+   **This batches fixes into fewer pushes, saving full CI cycles.** A 15-min CI run where CodeRabbit posts at minute 2 no longer wastes 13 minutes of idle time.
+
+   - **Contradictory bot comments** (e.g., CodeRabbit suggests X, Claude bot suggests opposite) - resolve yourself using your best judgment. Do NOT escalate as BLOCKED. Pick the approach that best fits the codebase patterns and explain your choice in the commit message.
+   - **Merge conflicts are routine** - resolve using Known Conflict Patterns. Only escalate if genuinely ambiguous.
    - **After each push**, dismiss stale bot CHANGES_REQUESTED reviews:
      ```bash
      gh api repos/<owner>/<repo>/pulls/<number>/reviews \
@@ -676,21 +678,21 @@ gh pr view --json reviews | jq '.reviews[] | select(.state == "CHANGES_REQUESTED
    ```bash
    # Merge state
    gh pr view <number> --json mergeStateStatus,state | jq '{mergeStateStatus, state}'
+   # CI fully complete (0 pending - don't report while checks still running)
+   PENDING=$(gh pr checks <number> --json state | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED")] | length')
+   echo "Pending checks: $PENDING"
    # Unresolved thread count (MUST be 0)
    UNRESOLVED=$(gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") {
      pullRequest(number: <number>) { reviewThreads(first: 100) { nodes { isResolved } } }
    }}' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
    echo "Unresolved threads: $UNRESOLVED"
    ```
-   Only report REVIEW_CLEAR if `mergeStateStatus` is CLEAN/UNSTABLE **AND** `$UNRESOLVED` = 0. If either fails, fix and loop again. **Do NOT report REVIEW_CLEAR and then go idle** — the lead trusts this signal to merge without re-verifying threads.
+   Only report REVIEW_CLEAR if `mergeStateStatus` is CLEAN/UNSTABLE **AND** `$PENDING` = 0 **AND** `$UNRESOLVED` = 0. If any fail, fix and loop again. **Do NOT report REVIEW_CLEAR and then go idle** - the lead trusts this signal to merge without re-verifying.
 
 ## Communication
 Only message the lead for **meaningful events**:
 - PR created: `SendMessage(type: "message", recipient: "lead", content: "PR_CREATED: PR #<number> for <tag>.<task-id>", summary: "PR created <task-id>")`
 - Review clear: `SendMessage(type: "message", recipient: "lead", content: "REVIEW_CLEAR: PR #<number> for <tag>.<task-id> — all criteria met", summary: "Review clear <task-id>")`
-- Clarification needed (use sparingly — never exercised across 15+ marathons, so default to making a judgment call yourself):
-  `SendMessage(type: "message", recipient: "lead", content: "CLARIFICATION_NEEDED: <tag>.<task-id> — <what's unclear and your two interpretations>", summary: "Clarification needed <task-id>")`
-  Only if requirements genuinely conflict with the codebase AND you cannot make a reasonable judgment call.
 - Blocked: `SendMessage(type: "message", recipient: "lead", content: "BLOCKED: <tag>.<task-id> — <reason>", summary: "Blocked <task-id>")`
 - Too complex: `SendMessage(type: "message", recipient: "lead", content: "TOO_COMPLEX: <tag>.<task-id> — <brief reasoning>", summary: "Too complex <task-id>")`
 
@@ -735,6 +737,8 @@ Report team status after spawning:
 1. Shutdown teammate, clean up failed worktree/branch
 2. Decompose: `task-master expand --id=<task-id> --research` (subtasks) or cancel + create new peer tasks (sibling split)
 3. Spawn fresh teammates for resulting tasks
+
+**Lead conflict resolution**: When a teammate is idle and their PR is DIRTY (merge conflict), resolve it directly instead of nudging the teammate. Pull develop, resolve the conflict, push. Faster than round-tripping to an idle teammate (~10 min saved per conflict, validated in tenant-branding and economy-generator).
 
 **Non-responsive teammate escalation**: If a teammate ignores a direct instruction (nudge to fix CI, address review feedback, follow lead guidance) or sends a false REVIEW_CLEAR (claims ready but criteria aren't met), don't keep nudging. Shut it down and respawn the same task on opus. One strike — don't give sonnet a second chance on the same task.
 
@@ -814,7 +818,7 @@ Trust the API, not the message.
 cd ~/dev/github.com/<org>/<repo>
 task-master tags use "<tag>" && task-master set-status --id=<task-id> --status=done
 cd <repo>-main && git worktree remove --force ../worktree/<tag>/<task-id>--<slug>
-git branch -d <tag>--<task-id>--<slug>
+git branch -D <tag>--<task-id>--<slug>
 ```
 
 Then:
@@ -972,8 +976,8 @@ When `$MARATHON_MODE` but `$TEAMS_AVAILABLE` is `false`, use parallel subagents 
   │
   ├─ Marathon + Teams → AGENT TEAMS (spawn teammates, smart-merge, waves)
   │
-  ├─ No PR → IMPLEMENT (Ralph or subagent)
-  ├─ PR open → REVIEW (Ralph or subagent)
+  ├─ No PR → IMPLEMENT (subagent)
+  ├─ PR open → REVIEW (subagent)
   ├─ PR merged → CLEANUP → (marathon? check next ready)
   │
   └─ No context → report ready tasks


### PR DESCRIPTION
## Summary

- Replace sequential CI-then-threads checking with concurrent monitoring in `/tm` teammate prompts and `/fix-pr` (batch thread fixes while CI runs, saving full CI cycles)
- Fix `git branch -d` to `-D` in tm.md cleanup (squash merges require force delete)
- Add 0-pending-checks gate to REVIEW_CLEAR verification (prevents false signals when CI still running)
- Remove CLARIFICATION_NEEDED from teammate comms (never exercised across 15+ marathons)
- Add lead conflict resolution pattern for idle teammates with DIRTY PRs
- Trim 6hats-team: fewer phases, skip Red Hat for technical reviews, cap at 90 min
- Remove Ralph fallback from fix-develop (redundant with manual loop)

## Test plan

- [ ] Run `/tm` marathon and verify teammates check threads concurrently with CI
- [ ] Verify `-D` branch deletion works on squash-merged branches
- [ ] Confirm REVIEW_CLEAR gate catches pending CI checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated team meeting guidance with explicit team size limits (2–4 members) and 45–90 minute time constraints.
  * Refined PR fixing workflow to run CI checks concurrently with issue resolution.
  * Enhanced Task Master role documentation with streamlined agent-based workflows.

* **Chores**
  * Removed optional plugin dependencies from multiple command workflows.
  * Optimized team spawn process for parallel execution and faster phase transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->