### PR TITLE
Reduce rigidity: 5 surgical fixes from huddle review

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Personal Claude Code configuration, customizations, and workflow tools.
 
 ## Contents
 
-### Task Master Commands
-
-Workflow commands for managing tasks with [Task Master](https://github.com/eyaltoledano/claude-task-master):
+### Commands
 
 | Command | Description |
 |---------|-------------|
-| `/tm` | Unified context-aware command - starts, reviews, or cleans up tasks based on current state |
+| `/tm` | Task Master orchestration — context-aware: starts, reviews, or cleans up tasks based on current state |
+| `/tm-marathon-config-example` | Reference configuration block to drop into a project's `CLAUDE.md` for marathon-mode `/tm` |
+| `/huddle` | Multi-perspective analysis with persistent professional lenses cycling through Six Hats phases |
+| `/6hats` | Solo Six Hats analysis — alias for `/huddle` with team size 1 |
+| `/assess` | Layered codebase assessment for AI-agent contributor readiness |
+| `/understand` | Deep understanding mode (nemawashi) — exhaustive context-gathering before action |
+| `/fix-pr` | Autonomous PR fixing loop — iterates on CI failures and review comments until green |
+| `/fix-develop` | Autonomous fix loop for failing CI on the repo's default branch |
 
 The `/tm` command detects context automatically:
 - **Not in worktree** → Start mode (begin next task or specified task)
@@ -20,15 +25,12 @@ The `/tm` command detects context automatically:
 
 ### Six Thinking Hats Framework
 
-A blind spot detector for high-stakes decisions, based on Edward de Bono's Six Thinking Hats method.
-
-#### How to Run
+A blind spot detector for high-stakes decisions, based on Edward de Bono's Six Thinking Hats method. Use `/6hats` for a quick parallel analysis or `/huddle` for a multi-perspective deliberation.
 
 ```
 /6hats Should we rewrite our monolith in microservices?
+/huddle Should we migrate our monolith to microservices?
 ```
-
-This spawns six independent agents that analyze your question from different angles, then synthesizes their perspectives into an opinionated recommendation.
 
 | Agent | Role |
 |-------|------|
@@ -38,6 +40,7 @@ This spawns six independent agents that analyze your question from different ang
 | `yellow-hat` | Benefits and opportunities |
 | `green-hat` | Creative alternatives |
 | `blue-hat` | Synthesis and recommendation |
+| `scribe` | Structures hat output into actionable documentation (invoke directly via `Task(subagent_type="scribe")`) |
 
 #### The Trade-off: Tokens vs Blind Spots
 
@@ -70,11 +73,16 @@ Use Six Hats when the stakes justify the token cost. Skip it for debugging, impl
 ```
 claude-config/
 ├── README.md
-├── CLAUDE.md           # Personal guidelines and instructions
+├── CLAUDE.md                          # Personal guidelines and instructions
 ├── commands/
-│   ├── tm.md           # Task Master unified command
-│   ├── 6hats.md        # Six Hats orchestration
-│   └── ...
+│   ├── tm.md                          # Task Master unified command
+│   ├── tm-marathon-config-example.md  # CLAUDE.md snippet for marathon mode
+│   ├── huddle.md                      # Multi-lens Six Hats deliberation
+│   ├── 6hats.md                       # Solo Six Hats (alias for huddle)
+│   ├── assess.md                      # Codebase readiness assessment
+│   ├── understand.md                  # Nemawashi context-gathering
+│   ├── fix-pr.md                      # Autonomous PR fix loop
+│   └── fix-develop.md                 # Autonomous default-branch fix loop
 └── agents/
     ├── white-hat.md
     ├── red-hat.md
@@ -82,7 +90,7 @@ claude-config/
     ├── yellow-hat.md
     ├── green-hat.md
     ├── blue-hat.md
-    └── scribe.md
+    └── scribe.md                      # Structures hat output into docs
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `/tm` command detects context automatically:
 
 A blind spot detector for high-stakes decisions, based on Edward de Bono's Six Thinking Hats method. Use `/6hats` for a quick parallel analysis or `/huddle` for a multi-perspective deliberation.
 
-```
+```text
 /6hats Should we rewrite our monolith in microservices?
 /huddle Should we migrate our monolith to microservices?
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration, customizations, and workflow tools.
 
-> **Note**: This setup is opinionated. See [Git Workflow](#git-workflow) below for details.
+> **Heads up — not portable.** This config is tuned to one author's daily setup: a `<repo>-main/` + `worktree/` directory layout, GitHub + `gh` CLI, Task Master, CodeRabbit/claude[bot] review threads, and the Agent Teams capability flag. The opinionated framework agents (`/huddle`, `/6hats`, `/assess`, `/understand`) are reasonably portable; the workflow commands (`/tm`, `/fix-pr`, `/fix-develop`) bake in those assumptions and may need editing before they work for you. See [Git Workflow](#git-workflow) and [Adapting for Your Workflow](#adapting-for-your-workflow) below.
 
 ## Contents
 
@@ -169,9 +169,13 @@ The `/tm` command handles worktree creation and cleanup automatically based on t
 
 ### Adapting for Your Workflow
 
-If you prefer a different structure, you'll need to modify:
-- `commands/tm.md` - the path patterns and worktree creation logic
-- Your `CLAUDE.md` - any references to the directory structure
+The framework agents (`/huddle`, `/6hats`, `/assess`, `/understand`) are reusable as-is. The workflow commands embed assumptions you will likely need to override:
+
+- **Directory layout** — `commands/tm.md`, `commands/fix-pr.md`, `commands/fix-develop.md` all assume `~/dev/github.com/<org>/<repo>/<repo>-main/` + sibling `worktree/`. Edit the path patterns to match your structure.
+- **Default branch** — `/fix-develop` derives the branch via `gh repo view --json defaultBranchRef`. `/tm` uses a `$BASE_BRANCH` variable. Other commands may still reference `develop` in prose; check before relying on them on a `main`-default repo.
+- **Required external tools** — `gh` CLI for GitHub, Task Master for `/tm`, optional Agent Teams capability flag (`$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) for `/tm` marathon mode.
+- **Review-bot conventions** — PR-loop logic in `/tm`, `/fix-pr`, `/fix-develop` distinguishes CodeRabbit, claude[bot], and human threads. Adjust if your repo uses different bots.
+- **CLAUDE.md** — your global / project `CLAUDE.md` references to the directory structure need to match.
 
 ## License
 

--- a/commands/fix-develop.md
+++ b/commands/fix-develop.md
@@ -73,8 +73,9 @@ set -euo pipefail
 cd ~/dev/github.com/$ORG/$REPO/$REPO-main
 git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
 
-# Create fix branch and worktree
-BRANCH_NAME="fix-${DEFAULT_BRANCH}-$(date +%Y%m%d)-$(echo '<brief-description>' | tr ' ' '-')"
+# Create fix branch and worktree (slug the default branch in case it contains '/')
+DEFAULT_BRANCH_SLUG="${DEFAULT_BRANCH//\//-}"
+BRANCH_NAME="fix-${DEFAULT_BRANCH_SLUG}-$(date +%Y%m%d)-$(echo '<brief-description>' | tr ' ' '-')"
 git branch $BRANCH_NAME
 git worktree add ../worktree/$BRANCH_NAME $BRANCH_NAME
 cd ../worktree/$BRANCH_NAME

--- a/commands/fix-develop.md
+++ b/commands/fix-develop.md
@@ -9,11 +9,18 @@ Assess failing CI on develop (or nightly build), create a worktree with a fix, p
 ## Step 1: Assess Develop Health
 
 ```bash
+set -euo pipefail
+
 # Identify the repo
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 REPO_NAME=$(basename "$REPO_ROOT")
 ORG=$(gh repo view --json owner --jq '.owner.login')
 REPO=$(gh repo view --json name --jq '.name')
+
+# Fail fast if any of the above came back empty (wrong pane, no gh auth, not a repo)
+: "${REPO_ROOT:?Not inside a git repo — re-run from the target repo}"
+: "${ORG:?gh repo view returned no owner — check gh auth and current directory}"
+: "${REPO:?gh repo view returned no name — check gh auth and current directory}"
 
 # Get latest develop CI status
 gh api repos/$ORG/$REPO/commits/develop/status --jq '{state: .state, total: .total_count}'
@@ -55,7 +62,11 @@ Proceeding to create fix PR...
 ## Step 3: Create Worktree and Fix
 
 ```bash
-# From repo-main (sacred, always on develop)
+set -euo pipefail
+: "${ORG:?ORG unset — re-run Step 1 to derive repo identity}"
+: "${REPO:?REPO unset — re-run Step 1 to derive repo identity}"
+
+# From repo-main (sacred, always on default branch)
 cd ~/dev/github.com/$ORG/$REPO/$REPO-main
 git checkout develop && git pull origin develop
 

--- a/commands/fix-develop.md
+++ b/commands/fix-develop.md
@@ -1,12 +1,12 @@
-# Fix Develop Branch
+# Fix Default Branch
 
-Assess failing CI on develop (or nightly build), create a worktree with a fix, push a PR, and loop until CI passes and review comments are addressed.
+Assess failing CI on the repo's default branch (main / develop / etc., or nightly build), create a worktree with a fix, push a PR, and loop until CI passes and review comments are addressed.
 
-**Usage**: `/fix-develop [repo-path]` — defaults to current repo context.
+**Usage**: `/fix-develop [repo-path]` — defaults to current repo context. (Command name is historical; works on whichever branch the repo treats as default.)
 
 ---
 
-## Step 1: Assess Develop Health
+## Step 1: Assess Default Branch Health
 
 ```bash
 set -euo pipefail
@@ -16,21 +16,23 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 REPO_NAME=$(basename "$REPO_ROOT")
 ORG=$(gh repo view --json owner --jq '.owner.login')
 REPO=$(gh repo view --json name --jq '.name')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 
 # Fail fast if any of the above came back empty (wrong pane, no gh auth, not a repo)
 : "${REPO_ROOT:?Not inside a git repo — re-run from the target repo}"
 : "${ORG:?gh repo view returned no owner — check gh auth and current directory}"
 : "${REPO:?gh repo view returned no name — check gh auth and current directory}"
+: "${DEFAULT_BRANCH:?gh repo view returned no defaultBranchRef — check gh auth}"
 
-# Get latest develop CI status
-gh api repos/$ORG/$REPO/commits/develop/status --jq '{state: .state, total: .total_count}'
+# Get latest CI status on the default branch
+gh api repos/$ORG/$REPO/commits/$DEFAULT_BRANCH/status --jq '{state: .state, total: .total_count}'
 
-# Get failing workflow runs on develop
-gh run list --branch develop --status failure --limit 5 --json databaseId,name,conclusion,createdAt \
+# Get failing workflow runs on the default branch
+gh run list --branch $DEFAULT_BRANCH --status failure --limit 5 --json databaseId,name,conclusion,createdAt \
   | jq '.[] | {id: .databaseId, name, conclusion, created: .createdAt}'
 ```
 
-If develop is green, report "Develop is healthy, nothing to fix" and STOP.
+If the default branch is green, report "$DEFAULT_BRANCH is healthy, nothing to fix" and STOP.
 
 ## Step 2: Diagnose Failures
 
@@ -49,9 +51,9 @@ gh run view $RUN_ID --log-failed 2>&1 | tail -100
 
 Report diagnosis to user before proceeding:
 ```
-## Develop Diagnosis
+## Default Branch Diagnosis
 
-Branch: develop
+Branch: <DEFAULT_BRANCH>
 Failing runs: <list>
 Root cause: <assessment>
 Proposed fix: <plan>
@@ -65,13 +67,14 @@ Proceeding to create fix PR...
 set -euo pipefail
 : "${ORG:?ORG unset — re-run Step 1 to derive repo identity}"
 : "${REPO:?REPO unset — re-run Step 1 to derive repo identity}"
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH unset — re-run Step 1 to derive repo identity}"
 
 # From repo-main (sacred, always on default branch)
 cd ~/dev/github.com/$ORG/$REPO/$REPO-main
-git checkout develop && git pull origin develop
+git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
 
 # Create fix branch and worktree
-BRANCH_NAME="fix-develop-$(date +%Y%m%d)-$(echo '<brief-description>' | tr ' ' '-')"
+BRANCH_NAME="fix-${DEFAULT_BRANCH}-$(date +%Y%m%d)-$(echo '<brief-description>' | tr ' ' '-')"
 git branch $BRANCH_NAME
 git worktree add ../worktree/$BRANCH_NAME $BRANCH_NAME
 cd ../worktree/$BRANCH_NAME
@@ -85,8 +88,8 @@ git add <specific-files>
 git commit -m "fix: <description of what was failing and why>"
 git push -u origin $BRANCH_NAME
 
-# Create PR targeting develop
-gh pr create --base develop --title "fix: Resolve failing CI on develop" --body "$(cat <<'EOF'
+# Create PR targeting the default branch
+gh pr create --base $DEFAULT_BRANCH --title "fix: Resolve failing CI on $DEFAULT_BRANCH" --body "$(cat <<'EOF'
 ## Summary
 - <What was failing>
 - <Root cause>
@@ -142,13 +145,13 @@ Wait 60s between iterations for CI to start.
    ```
    PR #X: CI passing, all comments addressed. Ready for merge.
 
-   This fixes the following develop failures:
+   This fixes the following $DEFAULT_BRANCH failures:
    - <list of what was broken>
 
    ---
    ## Current Work
 
-   PR: #X - Fix failing CI on develop
+   PR: #X - Fix failing CI on $DEFAULT_BRANCH
       https://github.com/org/repo/pull/X
 
    Latest: All green after N iterations

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -851,8 +851,11 @@ For each that was exercised: did it help, hurt, or not apply? Mark validated.>
 - <decision>: <alternatives considered> -> <chosen> because <reason>
 (task combinations, dependency changes, merge ordering, model upgrades, interventions)
 
-**Suggested /tm changes**
-- <concrete change with rationale>
+**Where does this learning belong?** (specific command / cross-cutting rule / README / don't capture)
+- <target file or section>: <concrete change with rationale>
+
+**What clause is no longer earning its place?**
+- <existing rule or block>: <reason it can be removed or demoted>
 
 **Stats**
 - Tasks: <N> completed, <N> cancelled/deferred


### PR DESCRIPTION
## Summary

Five small, independently-revertible fixes surfaced by a `/huddle` review of this config. Two huddle-proposed items (delete the 6hats thinking-level matrix; extract the meridian-specific retro path) were already shipped in earlier commits and are not in this PR.

The team explicitly recommended landing these as separate PRs over time rather than one big diff. This PR is a compromise: one PR, but each commit stands alone so reviewers can take all of it, take some of it, or revert any piece individually.

## Commits

1. **`fix(tm)`: Redirect retro suggestions away from tm.md by default**
   The retro template named tm.md as the default edit target ("Suggested /tm changes"), creating an accretion engine. Replaced with a target-naming prompt and a paired deletion prompt.

2. **`fix(fix-develop)`: Fail fast on empty derived variables**
   Adds `set -euo pipefail` and `:` parameter expansion guards to the bash blocks that derive and consume `\$ORG`/`\$REPO`. Prevents silent wrong-pane wrong-repo writes.

3. **`fix(fix-develop)`: Derive default branch instead of hardcoding develop**
   Replaces hardcoded `develop` with `\$DEFAULT_BRANCH` derived via `gh repo view --json defaultBranchRef`. Command name kept as `/fix-develop` for muscle memory.

4. **`docs(readme)`: Document all commands and the scribe agent**
   README listed only `/tm` and `/6hats`. Now covers all eight commands and explains the `scribe` agent (auto-registered via directory scan, callable via `Task(subagent_type="scribe")`).

5. **`docs(readme)`: Strengthen portability disclaimer**
   Replaces the soft "this is opinionated" note with an explicit list of baked-in assumptions (directory layout, `gh`, Task Master, review-bot conventions, Agent Teams flag) and which commands are portable vs need editing.

## Background

Findings come from a `/huddle` analysis with three lenses (prompt engineer, daily-use power user, information architect). Headline finding: the retro template at `tm.md` was the accretion engine driving every "lesson learned" back into the same already-overgrown file. Commit 1 dismantles that.

## Test plan

- [ ] Read each commit individually; revert any you disagree with
- [ ] Sanity-check `/fix-develop` still works on a `develop`-default repo (Sky/Meridian) — `\$DEFAULT_BRANCH` should resolve to `develop` via `gh`
- [ ] Sanity-check `/fix-develop` works on a `main`-default repo — should resolve to `main` and target the right branch
- [ ] Confirm the next `/tm` retrospective uses the new prompts (check what gets captured under "Where does this learning belong?" and "What clause is no longer earning its place?")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and expanded command reference with comprehensive descriptions of all available commands
  * Enhanced setup documentation with explicit prerequisites and environment assumptions
  * Improved guidance for adapting the system to your development workflow
  * Strengthened robustness of default branch handling throughout the system
  * Refined learning-capture structure for capturing and implementing improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->