### PR TITLE
feat(skills): Add complexity hotspot to /assess; convert assess + huddle to skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/.gitignore
 !/agents/
 !/commands/
+!/skills/
 
 # Still ignore .DS_Store files everywhere
 **/.DS_Store

--- a/README.md
+++ b/README.md
@@ -74,12 +74,17 @@ Use Six Hats when the stakes justify the token cost. Skip it for debugging, impl
 claude-config/
 ├── README.md
 ├── CLAUDE.md                          # Personal guidelines and instructions
+├── skills/
+│   ├── assess/
+│   │   ├── SKILL.md                   # Codebase readiness assessment + complexity hotspot
+│   │   └── scripts/
+│   │       └── complexity-treemap.py  # Codecov-style hotspot SVG generator
+│   └── huddle/
+│       └── SKILL.md                   # Multi-lens Six Hats deliberation
 ├── commands/
 │   ├── tm.md                          # Task Master unified command
 │   ├── tm-marathon-config-example.md  # CLAUDE.md snippet for marathon mode
-│   ├── huddle.md                      # Multi-lens Six Hats deliberation
 │   ├── 6hats.md                       # Solo Six Hats (alias for huddle)
-│   ├── assess.md                      # Codebase readiness assessment
 │   ├── understand.md                  # Nemawashi context-gathering
 │   ├── fix-pr.md                      # Autonomous PR fix loop
 │   └── fix-develop.md                 # Autonomous default-branch fix loop
@@ -92,6 +97,12 @@ claude-config/
     ├── blue-hat.md
     └── scribe.md                      # Structures hat output into docs
 ```
+
+### Skills vs commands
+
+Skills (`skills/<name>/SKILL.md`) carry an instruction file *plus* bundled assets (scripts, templates). The Claude Code runtime auto-discovers them and the agent invokes the relevant skill when its `description` matches the user's request. `/assess` ships `complexity-treemap.py` alongside its SKILL.md so the agent can run the treemap without external setup.
+
+Commands (`commands/<name>.md`) are slash-only prompts with no bundled assets — kept for workflows that don't need supporting scripts.
 
 ## Installation
 

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -172,16 +172,23 @@ ls "$REPO_ROOT"/.swiftlint.yml 2>/dev/null
 - Exhaustive matching? (exhaustive, strict unions)
 - Import boundary rules? (depguard, no-restricted-imports)
 
-**Cross-reference treemap evidence.** Read the stats sidecar to see what the linter actually catches in the wild:
+**Cross-reference treemap evidence.** Read the stats sidecar to see what the linter actually catches in the wild — but only if Step 2 produced it. The sidecar is missing whenever the treemap script failed (no `uv`, non-git path, no scoreable files, etc.).
 
 ```bash
-jq '{
-  loc_p95: .loc.p95, loc_max: .loc.max,
-  ccn_p95: .ccn.p95, ccn_max: .ccn.max,
-  worst_complex: .top_complex[:3] | map(.path),
-  worst_large: .top_large[:3] | map(.path)
-}' "$REPO_ROOT/.assess/complexity-stats.json"
+STATS="$REPO_ROOT/.assess/complexity-stats.json"
+if [ -f "$STATS" ]; then
+  jq '{
+    loc_p95: .loc.p95, loc_max: .loc.max,
+    ccn_p95: .ccn.p95, ccn_max: .ccn.max,
+    worst_complex: .top_complex[:3] | map(.path),
+    worst_large: .top_large[:3] | map(.path)
+  }' "$STATS"
+else
+  echo "complexity-stats.json not present; scoring Layer 2 on linter config alone."
+fi
 ```
+
+If the sidecar is missing, skip the combined-scoring matrix below and fall back to the original Layer 2 rule: Present if linter config includes AI-relevant rules (including complexity/length), Partial if linter exists without them, Missing if no linter at all. Record "treemap unavailable" in the Evidence column so the gap is auditable.
 
 Thresholds for "high" (based on industry conventions — adjust for context):
 

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -1,15 +1,20 @@
 ---
-description: "Assess a codebase's readiness for AI agent contributors using the layered contract model"
-argument-hint: "[path to repo] (defaults to current directory)"
+name: assess
+description: "Assess a codebase's readiness for AI agent contributors using the layered contract model, and generate a complexity hotspot SVG treemap (size = LOC, hue = cyclomatic complexity, saturation = recent git churn). TRIGGER when the user types /assess, asks for an AI-readiness review, wants a complexity heatmap or hotspot map, asks 'how complex is this code?', wants migration risk triage, or asks for a codebase snapshot/report. Produces an MD report + SVG that can be opened as a PR in the target repo."
 ---
 
-# AI Readiness Assessment
+# AI Readiness Assessment + Complexity Hotspot
 
-Assess how ready this codebase is for sustained AI agent contribution using the layered contract model from the AI-Native Codebase Architecture guide.
+Two artefacts in one pass against a target repo:
+
+1. **Layered contract assessment** — 0–7 score across breadcrumbs, types, linters, architecture tests, CI, coverage, review bots, AI project management.
+2. **Complexity hotspot SVG** — Codecov-style treemap. Size = LOC. Hue = cyclomatic complexity. Saturation = recent git churn. Vivid red = complex AND active = highest risk.
+
+Both land as files inside the target repo. The skill always writes them locally; after writing, **ask the user** whether to open a PR in the target repo with both artefacts.
 
 **$ARGUMENTS**
 
-## Step 1: Determine Repo Root
+## Step 1: Determine Repo Root and Output Directory
 
 ```bash
 # If arguments provided, use that path. Otherwise use pwd.
@@ -19,7 +24,35 @@ git rev-parse --show-toplevel
 
 Set `$REPO_ROOT` to the result. All scanning happens from here.
 
-## Step 2: Scan Each Layer
+Decide the output directory (default: `$REPO_ROOT/.assess/`). Create it if needed:
+
+```bash
+mkdir -p "$REPO_ROOT/.assess"
+```
+
+Artefacts will land at:
+- `$REPO_ROOT/.assess/complexity-heatmap.svg`
+- `$REPO_ROOT/.assess/assess-report.md`
+
+## Step 2: Generate Complexity Hotspot SVG
+
+Run the bundled treemap script. It produces a single self-contained SVG with hover tooltips on every block.
+
+```bash
+# Resolve the script path relative to this skill. The skill lives at
+# ~/.claude/skills/assess/SKILL.md, so the script is alongside it.
+SKILL_DIR="$(dirname "$(realpath ~/.claude/skills/assess/SKILL.md)")"
+uv run "$SKILL_DIR/scripts/complexity-treemap.py" "$REPO_ROOT" \
+    -o "$REPO_ROOT/.assess/complexity-heatmap.svg"
+```
+
+The script prints a one-line summary (file count, lizard vs scc coverage, churn window chosen, top 5 biggest files). Capture this output — it goes into the report's "Hotspot snapshot" section.
+
+**Dependencies:** the script uses PEP 723 inline metadata (`lizard`, `squarify`, `matplotlib`, `numpy`). `uv` resolves them on first run. Optional: `brew install scc` extends coverage to 200+ languages beyond what lizard handles natively.
+
+**If the script fails** (no `uv`, no scoreable files, etc.), record the error in the report under "Hotspot snapshot" as "could not be generated — <reason>" and continue with the layered assessment. The treemap is additive; assessment still runs without it.
+
+## Step 3: Scan Each Layer
 
 Run these checks in parallel where possible. For each layer, collect evidence and assess quality.
 
@@ -305,14 +338,31 @@ rg -i 'retrospective|retro|feedback loop|learnings|post.?mortem' "$REPO_ROOT"/{C
 - Partial: Some orchestration tooling exists but no systematic feedback loop, or ad-hoc retro notes without structured process
 - Missing: No AI-aware project management
 
-## Step 3: Score and Report
+## Step 4: Score and Write the Report
 
-Calculate the score (0-7 based on layers present, +0.5 for partial) and generate the report.
+Calculate the score (0-7 based on layers present, +0.5 for partial) and write the report to `$REPO_ROOT/.assess/assess-report.md`.
 
-**Output format:**
+**Report format** (write this to disk verbatim, filling in the placeholders):
 
 ```markdown
-# AI Readiness Assessment: <repo-name>
+# Codebase Assessment: <repo-name>
+
+_Generated <YYYY-MM-DD>._
+
+## Hotspot snapshot
+
+![Complexity hotspot](./complexity-heatmap.svg)
+
+- **Files scored:** <N>
+- **Churn window chosen:** <last 12mo | last 24mo | last 5y | all-time>
+- **Top hotspots** (size × complexity × churn):
+  1. `<path>` — <loc> LOC, ccn <N>, <M> commits in window
+  2. ...
+  3. ...
+
+Size encodes lines of code, hue encodes cyclomatic complexity (red = high), saturation encodes recent git churn (vivid = active). Vivid red blocks are the migration risk.
+
+## AI Readiness
 
 **Score: X / 7** — <maturity-label>
 
@@ -327,7 +377,7 @@ Calculate the score (0-7 based on layers present, +0.5 for partial) and generate
 | 6: Code Review Bots | Present/Partial/Missing | <what was found> | <what's missing> |
 | 7: AI Project Mgmt | Present/Partial/Missing | <what was found> | <what's missing> |
 
-## Maturity Level
+### Maturity Level
 
 | Score | Level | Description |
 |-------|-------|-------------|
@@ -338,9 +388,7 @@ Calculate the score (0-7 based on layers present, +0.5 for partial) and generate
 
 ## Top 3 Actions
 
-Prioritize by leverage: breadcrumbs and CI first, then linters and coverage,
-then architecture tests and retro loops. Each action should be completable
-in a single session.
+Prioritize by leverage: breadcrumbs and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session.
 
 | # | Action | Layer | Effort | Command / First Step |
 |---|--------|-------|--------|---------------------|
@@ -349,18 +397,30 @@ in a single session.
 | 3 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` |
 
 ### Why these three?
-<2-3 sentences explaining why these are highest leverage. Connect to specific
-gaps from the table above. Be concrete about what each action prevents.>
+<2-3 sentences explaining why these are highest leverage. Connect to specific gaps from the table above and to hotspot files where relevant. Be concrete about what each action prevents.>
 
 ## Additional Opportunities
 
-<If more than 3 gaps exist, list remaining as brief bullets. Keep to one line each.
-These are "after you've done the top 3" items.>
+<If more than 3 gaps exist, list remaining as brief bullets. Keep to one line each. These are "after you've done the top 3" items.>
 
 ## Strengths
 
-<3-5 bullet points. What this repo already does well. Be specific — name files,
-tools, and patterns. Acknowledge existing infrastructure.>
+<3-5 bullet points. What this repo already does well. Be specific — name files, tools, and patterns. Acknowledge existing infrastructure.>
 ```
 
 Complete the full assessment in under 2 minutes. Scan, don't deep-read.
+
+The SVG is referenced by relative path (`./complexity-heatmap.svg`) so GitHub renders it inline when the MD is viewed in a PR or on the file page.
+
+## Step 5: Ask Whether to Open a PR
+
+After writing both files, surface them and ask the user — verbatim — something like:
+
+> Wrote `.assess/assess-report.md` and `.assess/complexity-heatmap.svg` in `<repo-name>`. Want me to open a PR in this repo with both files, or leave them local for you to review first?
+
+If the user says **yes / PR**:
+1. Create a branch in the target repo: `assess/snapshot-<YYYY-MM-DD>` (use the existing worktree workflow if `<repo>-main` + `worktree/` layout is present; otherwise branch in place).
+2. Stage and commit both files. Commit message: `docs: Add AI-readiness assessment + complexity hotspot snapshot`.
+3. Push the branch and open a PR. Title: `docs: Codebase assessment — <YYYY-MM-DD>`. Body: paste the report's Top 3 Actions table and a one-line summary of the hotspot snapshot, then link to the full MD file in the PR diff.
+
+If the user says **no / leave it**: stop. Files stay in `.assess/` for them to review.

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -32,21 +32,23 @@ mkdir -p "$REPO_ROOT/.assess"
 
 Artefacts will land at:
 - `$REPO_ROOT/.assess/complexity-heatmap.svg`
+- `$REPO_ROOT/.assess/complexity-stats.json`
 - `$REPO_ROOT/.assess/assess-report.md`
 
-## Step 2: Generate Complexity Hotspot SVG
+## Step 2: Generate Complexity Hotspot SVG + Stats Sidecar
 
-Run the bundled treemap script. It produces a single self-contained SVG with hover tooltips on every block.
+Run the bundled treemap script. It produces a self-contained SVG with hover tooltips on every block **and** a JSON stats sidecar consumed by Layer 2 scoring and the Top 3 Actions table.
 
 ```bash
 # Resolve the script path relative to this skill. The skill lives at
 # ~/.claude/skills/assess/SKILL.md, so the script is alongside it.
 SKILL_DIR="$(dirname "$(realpath ~/.claude/skills/assess/SKILL.md)")"
 uv run "$SKILL_DIR/scripts/complexity-treemap.py" "$REPO_ROOT" \
-    -o "$REPO_ROOT/.assess/complexity-heatmap.svg"
+    -o "$REPO_ROOT/.assess/complexity-heatmap.svg" \
+    --stats "$REPO_ROOT/.assess/complexity-stats.json"
 ```
 
-The script prints a one-line summary (file count, lizard vs scc coverage, churn window chosen, top 5 biggest files). Capture this output — it goes into the report's "Hotspot snapshot" section.
+The script prints a one-line summary (file count, lizard vs scc coverage, churn window chosen, top 5 biggest files). The stats sidecar contains percentiles (p50/p95/max for LOC, CCN, churn) and ranked lists of the top 10 files by hotspot score, raw CCN, and raw LOC. Both feed the report.
 
 **Dependencies:** the script uses PEP 723 inline metadata (`lizard`, `squarify`, `matplotlib`, `numpy`). `uv` resolves them on first run. Optional: `brew install scc` extends coverage to 200+ languages beyond what lizard handles natively.
 
@@ -164,15 +166,43 @@ ls "$REPO_ROOT"/.swiftlint.yml 2>/dev/null
 **If found, assess AI-relevant rules** by reading the config:
 - Unexplained lint suppression rules? (nolintlint, no-restricted-syntax)
 - TODO/FIXME detection? (godox, no-warning-comments)
-- Function length limits? (funlen, max-lines-per-function)
-- Complexity limits? (cyclop, complexity)
+- **Function length limits?** (`funlen`, `max-lines-per-function`, `MethodLength`, `function-max-lines`)
+- **Cyclomatic complexity limits?** (`cyclop`, `gocognit`, `complexity`, `CyclomaticComplexity`, `too-many-statements`, `cognitive-complexity`, `cognitive_complexity`)
+- **File size limits?** (`max-lines`, `FileLength`, `file-max-lines`, `lines-per-file`)
 - Exhaustive matching? (exhaustive, strict unions)
 - Import boundary rules? (depguard, no-restricted-imports)
 
-**Scoring:**
-- Present: Linter configured with AI failure mode rules, strict enforcement
-- Partial: Linter exists but basic config, no AI-specific rules
-- Missing: No linter configuration found
+**Cross-reference treemap evidence.** Read the stats sidecar to see what the linter actually catches in the wild:
+
+```bash
+jq '{
+  loc_p95: .loc.p95, loc_max: .loc.max,
+  ccn_p95: .ccn.p95, ccn_max: .ccn.max,
+  worst_complex: .top_complex[:3] | map(.path),
+  worst_large: .top_large[:3] | map(.path)
+}' "$REPO_ROOT/.assess/complexity-stats.json"
+```
+
+Thresholds for "high" (based on industry conventions — adjust for context):
+
+| Signal | Watch | High |
+|---|---|---|
+| p95 cyclomatic complexity | ≥ 10 | ≥ 15 |
+| max cyclomatic complexity | ≥ 30 | ≥ 50 |
+| p95 file size (LOC) | ≥ 500 | ≥ 800 |
+| max file size (LOC) | ≥ 1500 | ≥ 2000 |
+
+**Combined scoring** (linter config ∩ treemap evidence):
+
+| Linter has complexity/length rules? | Treemap p95 / max in "High" range? | Score |
+|---|---|---|
+| Yes, enforced (CI blocks) | Either way — rules ratchet the legacy | **Present** |
+| Yes but lenient / excludes legacy | High | **Partial** — rules exist, legacy unfenced |
+| Linter exists, no complexity/length rules | Not high | **Partial** — gap but no evidence yet |
+| Linter exists, no complexity/length rules | High | **Missing** — concrete evidence of the gap |
+| No linter at all | Either | **Missing** |
+
+When scoring Partial or Missing on this combined check, name the top 3 worst offenders from `top_complex` / `top_large` in the report's Evidence/Gap columns. Those are the files the missing rule would have flagged.
 
 ### Layer 3: Architecture Tests (Conventions as Contracts)
 
@@ -349,13 +379,25 @@ Calculate the score (0-7 based on layers present, +0.5 for partial) and write th
 
 _Generated <YYYY-MM-DD>._
 
+## How to read this report
+
+This is an improvement roadmap, not a verdict. It pairs two views:
+
+- **Where the codebase is today** — the hotspot SVG shows current complexity and churn at a glance. Vivid red = complex AND actively changing = the files most likely to bite an agent (or a human) next week.
+- **What scaffolding is in place to keep it from getting worse** — the 7-layer AI Readiness score measures whether the system enforces contracts that catch the issues the hotspots reveal.
+
+A codebase can be 7/7 and still on fire (great scaffolding, legacy debt) — or 2/7 with a calm treemap (small codebase, no enforcement needed yet). The pair matters.
+
+The "Top 3 Actions" table at the bottom names specific files. Start there.
+
 ## Hotspot snapshot
 
 ![Complexity hotspot](./complexity-heatmap.svg)
 
 - **Files scored:** <N>
 - **Churn window chosen:** <last 12mo | last 24mo | last 5y | all-time>
-- **Top hotspots** (size × complexity × churn):
+- **Complexity profile:** p95 ccn <N> (max <M>); p95 LOC <N> (max <M>)
+- **Top hotspots** (composite: complexity × recent churn):
   1. `<path>` — <loc> LOC, ccn <N>, <M> commits in window
   2. ...
   3. ...
@@ -388,13 +430,22 @@ Size encodes lines of code, hue encodes cyclomatic complexity (red = high), satu
 
 ## Top 3 Actions
 
-Prioritize by leverage: breadcrumbs and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session.
+Prioritize by leverage: breadcrumbs and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session and reference **specific files** from the hotspot snapshot wherever possible — generic advice is the failure mode this report exists to prevent.
 
-| # | Action | Layer | Effort | Command / First Step |
-|---|--------|-------|--------|---------------------|
-| 1 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` |
-| 2 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` |
-| 3 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` |
+| # | Action | Layer | Effort | Command / First Step | Hotspot files this addresses |
+|---|--------|-------|--------|---------------------|------------------------------|
+| 1 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths from top_hotspots / top_complex / top_large, or "—" if not file-specific> |
+| 2 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> |
+| 3 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> |
+
+Good actions look like:
+
+> _"Add `cyclop` rule (threshold 15) to `.golangci.yml`. Current p95 ccn is 23; immediate offenders: `internal/import/parser.go` (ccn 67), `internal/sync/reconciler.go` (ccn 54)."_
+
+Generic actions to avoid:
+
+> ~~_"Improve code quality"_~~ — name the files and the threshold.
+> ~~_"Add a linter"_~~ — name the linter, the rule, and the first three files it will flag.
 
 ### Why these three?
 <2-3 sentences explaining why these are highest leverage. Connect to specific gaps from the table above and to hotspot files where relevant. Be concrete about what each action prevents.>

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -400,7 +400,7 @@ def write_svg(rects: list, root: Path, W: float, H: float,
             )
 
     parts.append('</svg>')
-    out_path.write_text("\n".join(parts))
+    out_path.write_text("\n".join(parts), encoding="utf-8")
 
 
 def _adaptive_cap(values: list[float]) -> tuple[float, str]:
@@ -549,7 +549,7 @@ def write_stats(files: list[tuple[Path, int, float, str]],
         "top_large": strip(by_loc[:10]),
     }
 
-    out_path.write_text(json.dumps(stats, indent=2))
+    out_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
     print(f"wrote {out_path}")
 
 

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -1,0 +1,503 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "lizard",
+#     "squarify",
+#     "matplotlib",
+#     "numpy",
+# ]
+# ///
+"""
+complexity-treemap.py - Codecov-style hotspot treemap for any folder.
+
+Each rectangle is one file, grouped by folder. The combined view encodes
+three signals on one canvas (Adam Tornhill "hotspot" pattern, CodeScene-
+style saturation):
+
+  - Size        -> lines of code
+  - Hue         -> cyclomatic complexity (red = complex, green = simple)
+  - Saturation  -> recent git churn (vivid = active, grey = stable)
+
+Vivid red = complex AND actively changing = highest migration risk.
+Faded grey = code that hasn't moved lately, regardless of complexity.
+
+Scoring tiers (size + complexity):
+  1. lizard    -> real per-function cyclomatic complexity (Java, Python, JS,
+                  TS, Go, C/C++, C#, Scala, Kotlin, Ruby, Swift, Rust, PHP).
+  2. scc       -> keyword-heuristic complexity, covers 200+ languages.
+                  Skipped for files lizard already scored. Optional.
+
+Churn window auto-widens (12mo -> 24mo -> 5y -> all-time) until at least
+10% of files have any activity. If the path isn't inside a git repo, the
+saturation signal is dropped and files render fully vivid.
+
+The hue and saturation gradients are independently capped at the 95th
+percentile when the distribution has wild outliers (max > 5x p95);
+otherwise the full max-of-data range is used so small/well-behaved data
+sees the full gradient.
+
+Output is a single self-contained SVG with hover tooltips on every block
+(file path, LOC, complexity, recent commit count). Pass --labels to also
+annotate large blocks with text.
+
+Usage:
+    uv run skills/assess/scripts/complexity-treemap.py <path> [-o out.svg] [--labels]
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import lizard
+import matplotlib.pyplot as plt
+import numpy as np
+import squarify
+
+
+EXCLUDE_DIRS = {".git", "node_modules", "dist", "build", "target", "vendor",
+                ".venv", "venv", "__pycache__", ".gradle", ".idea", ".mvn",
+                "worktree", ".understand-anything", ".obsidian",
+                ".taskmaster", ".claude"}
+
+
+def lizard_scores(root: Path) -> dict[Path, tuple[int, float]]:
+    scores: dict[Path, tuple[int, float]] = {}
+    for f in lizard.analyze(paths=[str(root)], exclude_pattern=[]):
+        path = Path(f.filename).resolve()
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDE_DIRS for part in rel.parts):
+            continue
+        ccn = sum(fn.cyclomatic_complexity for fn in f.function_list) or 1
+        scores[path] = (f.nloc, float(ccn))
+    return scores
+
+
+def scc_scores(root: Path) -> dict[Path, tuple[int, float]]:
+    if shutil.which("scc") is None:
+        return {}
+    excludes = ",".join(EXCLUDE_DIRS)
+    raw = subprocess.run(
+        ["scc", "--by-file", "--format", "json",
+         f"--exclude-dir={excludes}", str(root)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    scores: dict[Path, tuple[int, float]] = {}
+    for lang_block in json.loads(raw):
+        for f in lang_block.get("Files", []):
+            path = Path(f["Location"]).resolve()
+            scores[path] = (int(f["Code"]), float(f["Complexity"]))
+    return scores
+
+
+def git_churn_scores(root: Path, since: str | None = None) -> dict[Path, int]:
+    """Return {abs_path: commit_count} for files under root tracked in git.
+
+    Returns empty dict if root is not inside a git repo. Commit counts are
+    over the full history reachable from HEAD by default. Pass `since` as
+    a git-compatible date expression (e.g. "6 months ago") to window the
+    count. Renames are not followed - a file gets credit only under its
+    current name.
+    """
+    try:
+        repo_top = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+    repo = Path(repo_top).resolve()
+
+    cmd = ["git", "-C", repo_top, "log",
+           "--pretty=format:", "--name-only"]
+    if since:
+        cmd.append(f"--since={since}")
+    try:
+        raw = subprocess.run(
+            cmd, capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+
+    counts: dict[Path, int] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        path = (repo / line).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+# Time windows tried in order from narrowest to widest. The first one
+# that gives both gradient depth (max >= MIN_MAX) AND visual coverage
+# (>= MIN_COVERAGE_PCT of files touched) wins. If nothing qualifies, we
+# fall back to the widest window that returned any data. since=None
+# means "full history".
+CHURN_WINDOWS: list[tuple[str, str | None]] = [
+    ("last 12mo", "12 months ago"),
+    ("last 24mo", "24 months ago"),
+    ("last 5y",   "5 years ago"),
+    ("all-time",  None),
+]
+MIN_MAX = 3          # max commits per file must clear this for visible gradient
+MIN_COVERAGE_PCT = 10.0   # % of scored files with any activity in the window
+
+
+def _pick_churn_window(
+    root: Path, files: list,
+) -> tuple[dict[Path, int] | None, str | None]:
+    """Walk CHURN_WINDOWS narrowest-to-widest; return the first window
+    that gives both gradient depth and visual coverage. Falls back to
+    the widest non-empty window if none qualify."""
+    file_paths = [f[0] for f in files]
+    total_files = max(len(file_paths), 1)
+    widest_fallback: tuple[dict[Path, int], str] | None = None
+
+    for label, since in CHURN_WINDOWS:
+        data = git_churn_scores(root, since=since)
+        if not data:
+            continue
+        # restrict to files we actually scored - "touched" means touched
+        # AND scoreable, so coverage % is comparable across windows
+        scored_hits = {p: data[p] for p in file_paths if p in data}
+        if not scored_hits:
+            continue
+        if widest_fallback is None or label == CHURN_WINDOWS[-1][0]:
+            widest_fallback = (data, label)
+        coverage = 100.0 * len(scored_hits) / total_files
+        max_commits = max(scored_hits.values())
+        if max_commits >= MIN_MAX and coverage >= MIN_COVERAGE_PCT:
+            if label != CHURN_WINDOWS[0][0]:
+                print(f"note: activity sparse - widened window to "
+                      f"{label} ({coverage:.0f}% of files touched, "
+                      f"max {max_commits} commits).",
+                      file=sys.stderr)
+            return ({p: data.get(p, 0) for p in file_paths},
+                    f"commits ({label})")
+
+    if widest_fallback is not None:
+        data, label = widest_fallback
+        scored_hits = {p: data[p] for p in file_paths if p in data}
+        coverage = 100.0 * len(scored_hits) / total_files
+        max_commits = max(scored_hits.values()) if scored_hits else 0
+        print(f"note: activity below thresholds in every window; "
+              f"using {label} ({coverage:.0f}% coverage, "
+              f"max {max_commits}).", file=sys.stderr)
+        return ({p: data.get(p, 0) for p in file_paths},
+                f"commits ({label})")
+    return None, None
+
+
+def _git_not_found_warning(root: Path) -> None:
+    print(
+        f"warning: no git history found for {root}\n"
+        "         (path may not be a git repo, or the repo is "
+        "empty / has a broken HEAD).\n"
+        "         Rendering pure complexity (no saturation signal). "
+        "If your code lives in a subdirectory\n"
+        "         that IS a git repo (e.g. a -main subfolder), point "
+        "the path at that.",
+        file=sys.stderr,
+    )
+
+
+def collect(root: Path, by: str = "complexity"
+            ) -> tuple[list[tuple[Path, int, float, str]], str,
+                       dict[Path, int] | None, str | None]:
+    """Returns (files, effective_by, aux_data, aux_label).
+
+    - files: [(path, loc, metric, source)] - metric depends on mode
+    - effective_by: may differ from `by` if we fell back (e.g. no git)
+    - aux_data: secondary per-file signal (hotspot mode only); None otherwise
+    - aux_label: human label for aux signal in tooltips
+    """
+    lz = lizard_scores(root)
+    sc = scc_scores(root)
+    files: list[tuple[Path, int, float, str]] = []
+    for path, (loc, ccn) in lz.items():
+        files.append((path, loc, ccn, "lizard"))
+    for path, (loc, cx) in sc.items():
+        if path not in lz:
+            files.append((path, loc, cx, "scc"))
+    files = [f for f in files if f[1] > 0]
+
+    effective_by = by
+    aux_data: dict[Path, int] | None = None
+    aux_label: str | None = None
+
+    if by == "churn":
+        churn = git_churn_scores(root)
+        if not churn:
+            _git_not_found_warning(root)
+            effective_by = "complexity"
+        else:
+            files = [(p, loc, float(churn.get(p, 0)), src)
+                     for p, loc, _m, src in files]
+    elif by == "hotspot":
+        aux_data, aux_label = _pick_churn_window(root, files)
+        if aux_data is None:
+            _git_not_found_warning(root)
+            effective_by = "complexity"
+
+    return files, effective_by, aux_data, aux_label
+
+
+@dataclass
+class Node:
+    name: str
+    size: int = 0
+    color: tuple = (0.5, 0.5, 0.5, 1.0)
+    loc: int = 0
+    metric: float = 0.0
+    aux_metric: float = 0.0
+    aux_label: str = ""
+    rel_path: str = ""
+    children: list["Node"] = field(default_factory=list)
+    is_file: bool = False
+
+
+def build_tree(files_with_color, root: Path,
+               aux_data: dict[Path, int] | None = None,
+               aux_label: str = "") -> Node:
+    rootnode = Node(name=root.name)
+    by_path: dict[Path, Node] = {root: rootnode}
+    for path, loc, metric, _src, color in files_with_color:
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        parent = rootnode
+        cur = root
+        for part in rel.parts[:-1]:
+            cur = cur / part
+            if cur not in by_path:
+                n = Node(name=part)
+                by_path[cur] = n
+                parent.children.append(n)
+            parent = by_path[cur]
+        aux_val = float(aux_data.get(path, 0)) if aux_data else 0.0
+        parent.children.append(Node(
+            name=rel.parts[-1], size=loc, color=color,
+            loc=loc, metric=metric, aux_metric=aux_val,
+            aux_label=aux_label, rel_path=str(rel), is_file=True,
+        ))
+
+    def roll(n: Node) -> int:
+        if n.is_file:
+            return n.size
+        n.size = sum(roll(c) for c in n.children)
+        return n.size
+    roll(rootnode)
+    return rootnode
+
+
+def layout(node: Node, x: float, y: float, w: float, h: float,
+           out: list) -> None:
+    if node.is_file:
+        out.append((x, y, w, h, node))
+        return
+    kids = sorted([c for c in node.children if c.size > 0],
+                  key=lambda c: -c.size)
+    if not kids or w <= 0 or h <= 0:
+        return
+    sizes = [c.size for c in kids]
+    norm = squarify.normalize_sizes(sizes, w, h)
+    placed = squarify.squarify(norm, x, y, w, h)
+    for child, r in zip(kids, placed):
+        layout(child, r["x"], r["y"], r["dx"], r["dy"], out)
+
+
+def _rgba_to_hex(rgba: tuple) -> str:
+    r, g, b = rgba[0], rgba[1], rgba[2]
+    return f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}"
+
+
+GREY = (0.82, 0.82, 0.84)  # cool light grey for "stable" / no recent churn
+
+
+def _blend_to_grey(rgba: tuple, factor: float) -> tuple:
+    """factor=0 returns full grey, factor=1 returns the original colour."""
+    factor = max(0.0, min(1.0, factor))
+    return tuple(
+        GREY[i] + (rgba[i] - GREY[i]) * factor for i in range(3)
+    ) + (1.0,)
+
+
+def write_svg(rects: list, root: Path, W: float, H: float,
+              out_path: Path, show_labels: bool,
+              metric_label: str) -> None:
+    label_threshold = (W * H) / 200
+    parts: list[str] = [
+        f'<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {W:.0f} {H:.0f}" '
+        f'width="{W:.0f}" height="{H:.0f}" '
+        f'preserveAspectRatio="xMidYMid meet">',
+        '<style>',
+        '  rect:hover { stroke: #000; stroke-width: 1.5; }',
+        '  text { font-family: -apple-system, BlinkMacSystemFont, '
+        '"Segoe UI", sans-serif; fill: #1a1a1a; '
+        'pointer-events: none; text-anchor: middle; '
+        'dominant-baseline: middle; }',
+        '</style>',
+    ]
+
+    for x, y, w, h, node in rects:
+        rel = node.rel_path or node.name
+        line2 = f"{node.loc} loc · {metric_label} {node.metric:.0f}"
+        if node.aux_label:
+            line2 += f" · {node.aux_label} {node.aux_metric:.0f}"
+        tooltip = html.escape(f"{rel}\n{line2}", quote=False)
+        parts.append(
+            f'<rect x="{x:.2f}" y="{y:.2f}" '
+            f'width="{w:.2f}" height="{h:.2f}" '
+            f'fill="{_rgba_to_hex(node.color)}" '
+            f'stroke="white" stroke-width="0.5">'
+            f'<title>{tooltip}</title></rect>'
+        )
+
+    if show_labels:
+        for x, y, w, h, node in rects:
+            if w * h <= label_threshold:
+                continue
+            fs = max(7, min(int(min(w, h) / 6), 18))
+            cx, cy = x + w / 2, y + h / 2
+            name = html.escape(node.name)
+            parts.append(
+                f'<text x="{cx:.1f}" y="{cy - fs:.1f}" '
+                f'font-size="{fs}">{name}</text>'
+                f'<text x="{cx:.1f}" y="{cy + 2:.1f}" '
+                f'font-size="{max(6, fs - 2)}" fill="#444">'
+                f'{node.loc} loc</text>'
+                f'<text x="{cx:.1f}" y="{cy + fs + 4:.1f}" '
+                f'font-size="{max(6, fs - 2)}" fill="#444">'
+                f'{metric_label} {node.metric:.0f}</text>'
+            )
+
+    parts.append('</svg>')
+    out_path.write_text("\n".join(parts))
+
+
+def _adaptive_cap(values: list[float]) -> tuple[float, str]:
+    """Pick a sensible cap: max for well-behaved data, p95 for outlier-heavy."""
+    if not values:
+        return 1.0, "max"
+    mx = float(max(values))
+    if mx == 0:
+        return 1.0, "max"
+    p95 = float(np.percentile(values, 95))
+    if p95 > 0 and mx > 5 * p95:
+        return p95, "p95 (outlier-suppressed)"
+    return mx, "max"
+
+
+def render(files: list[tuple[Path, int, float, str]],
+           root: Path, out_path: Path, title: str,
+           show_labels: bool = False,
+           by: str = "complexity",
+           aux_data: dict[Path, int] | None = None,
+           aux_label: str | None = None) -> None:
+    metric_label = "commits" if by == "churn" else "ccn"
+    metrics = [f[2] for f in files]
+    cap, cap_kind = _adaptive_cap(metrics)
+    cmap = plt.get_cmap("RdYlGn_r")
+
+    aux_cap = 1.0
+    aux_cap_kind = ""
+    if aux_data is not None:
+        aux_values = [float(aux_data.get(f[0], 0)) for f in files]
+        aux_cap, aux_cap_kind = _adaptive_cap(aux_values)
+
+    files_colored = []
+    for f in files:
+        base = cmap(min(f[2] / cap, 1.0))
+        if aux_data is not None:
+            aux_val = float(aux_data.get(f[0], 0))
+            color = _blend_to_grey(base, aux_val / aux_cap)
+        else:
+            color = base
+        files_colored.append((f[0], f[1], f[2], f[3], color))
+
+    tree = build_tree(files_colored, root, aux_data, aux_label or "")
+    W, H = 1600.0, 1000.0
+    rects: list = []
+    layout(tree, 0, 0, W, H, rects)
+
+    write_svg(rects, root, W, H, out_path, show_labels, metric_label)
+
+    print(f"wrote {out_path}  ({len(files)} files, "
+          f"{sum(1 for f in files if f[3] == 'lizard')} lizard, "
+          f"{sum(1 for f in files if f[3] == 'scc')} scc)")
+    mx = float(max(metrics)) if metrics else 0.0
+    print(f"hue: {metric_label}; range 0-{mx:.0f}; "
+          f"cap {cap:.0f} ({cap_kind})")
+    if aux_data is not None:
+        aux_max = max((float(aux_data.get(f[0], 0)) for f in files),
+                       default=0.0)
+        print(f"saturation: {aux_label}; range 0-{aux_max:.0f}; "
+              f"cap {aux_cap:.0f} ({aux_cap_kind})")
+
+    biggest = sorted(files, key=lambda f: -f[1])[:5]
+    if biggest:
+        print("biggest files (size dominates layout):")
+        for path, loc, metric, src in biggest:
+            try:
+                rel = path.relative_to(root)
+            except ValueError:
+                rel = path
+            aux_str = ""
+            if aux_data is not None:
+                aux_str = f"  {aux_label} {aux_data.get(path, 0):>4d}"
+            print(f"  {loc:>7} loc  {metric_label} {metric:>5.0f}{aux_str}  "
+                  f"[{src:6}]  {rel}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Render a Codecov-style hotspot treemap of any folder. "
+            "Hue = cyclomatic complexity, saturation = recent git churn "
+            "(last 6 months). Vivid red = complex AND active = highest risk."
+        ))
+    ap.add_argument("path", type=Path, help="Directory to analyse")
+    ap.add_argument(
+        "-o", "--out", type=Path,
+        help=("Output SVG path. If omitted, writes "
+              "./hotspot-<folder>.svg in the current working directory."),
+    )
+    ap.add_argument("--labels", action="store_true",
+                    help="Annotate large blocks with filename, LOC and metric")
+    args = ap.parse_args()
+
+    root = args.path.resolve()
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 1
+
+    files, effective_by, aux_data, aux_label = collect(root, by="hotspot")
+    if not files:
+        print("error: no scoreable files found", file=sys.stderr)
+        return 1
+    default_name = f"hotspot-{root.name}.svg"
+    out = args.out or Path(default_name)
+    render(files, root, out, f"Hotspot: {root.name}",
+           show_labels=args.labels, by=effective_by,
+           aux_data=aux_data, aux_label=aux_label)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -86,13 +86,24 @@ def scc_scores(root: Path) -> dict[Path, tuple[int, float]]:
     if shutil.which("scc") is None:
         return {}
     excludes = ",".join(EXCLUDE_DIRS)
-    raw = subprocess.run(
-        ["scc", "--by-file", "--format", "json",
-         f"--exclude-dir={excludes}", str(root)],
-        capture_output=True, text=True, check=True,
-    ).stdout
+    try:
+        raw = subprocess.run(
+            ["scc", "--by-file", "--format", "json",
+             f"--exclude-dir={excludes}", str(root)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"warning: scc failed ({e}); continuing without scc scores",
+              file=sys.stderr)
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        print("warning: scc returned invalid JSON; continuing without scc scores",
+              file=sys.stderr)
+        return {}
     scores: dict[Path, tuple[int, float]] = {}
-    for lang_block in json.loads(raw):
+    for lang_block in payload:
         for f in lang_block.get("Files", []):
             path = Path(f["Location"]).resolve()
             scores[path] = (int(f["Code"]), float(f["Complexity"]))
@@ -342,7 +353,7 @@ def write_svg(rects: list, root: Path, W: float, H: float,
               metric_label: str) -> None:
     label_threshold = (W * H) / 200
     parts: list[str] = [
-        f'<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
+        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
         f'<svg xmlns="http://www.w3.org/2000/svg" '
         f'viewBox="0 0 {W:.0f} {H:.0f}" '
         f'width="{W:.0f}" height="{H:.0f}" '
@@ -547,7 +558,8 @@ def main() -> int:
         description=(
             "Render a Codecov-style hotspot treemap of any folder. "
             "Hue = cyclomatic complexity, saturation = recent git churn "
-            "(last 6 months). Vivid red = complex AND active = highest risk."
+            "(auto-windowed: 12mo -> 24mo -> 5y -> all-time). "
+            "Vivid red = complex AND active = highest risk."
         ))
     ap.add_argument("path", type=Path, help="Directory to analyse")
     ap.add_argument(

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import math
 import shutil
 import subprocess
 import sys
@@ -465,6 +466,82 @@ def render(files: list[tuple[Path, int, float, str]],
                   f"[{src:6}]  {rel}")
 
 
+def write_stats(files: list[tuple[Path, int, float, str]],
+                aux_data: dict[Path, int] | None,
+                aux_label: str | None,
+                root: Path, out_path: Path) -> None:
+    """Write a JSON stats sidecar summarising the treemap data.
+
+    Consumed by the /assess skill: percentiles drive Layer 2 scoring,
+    top hotspot lists become the named files in the actions table.
+    Composite hotspot score = ccn * (1 + log1p(churn)), so a vivid
+    red block (complex AND active) outranks a frozen complex file.
+    """
+    locs = [f[1] for f in files]
+    ccns = [f[2] for f in files]
+    churns = ([float(aux_data.get(f[0], 0)) for f in files]
+              if aux_data is not None else [])
+
+    def pct(values: list[float], q: float) -> float:
+        return float(np.percentile(values, q)) if values else 0.0
+
+    def rel(p: Path) -> str:
+        try:
+            return str(p.relative_to(root))
+        except ValueError:
+            return str(p)
+
+    enriched = []
+    for path, loc, ccn, src in files:
+        churn = float(aux_data.get(path, 0)) if aux_data else 0.0
+        enriched.append({
+            "path": rel(path),
+            "loc": int(loc),
+            "ccn": float(ccn),
+            "churn": int(churn) if aux_data else None,
+            "source": src,
+            "_score": ccn * (1.0 + math.log1p(churn)),
+        })
+
+    def strip(rows: list[dict]) -> list[dict]:
+        return [{k: v for k, v in r.items() if k != "_score"} for r in rows]
+
+    by_score = sorted(enriched, key=lambda f: -f["_score"])
+    by_ccn = sorted(enriched, key=lambda f: -f["ccn"])
+    by_loc = sorted(enriched, key=lambda f: -f["loc"])
+
+    stats: dict = {
+        "files_scored": len(files),
+        "scoring_coverage": {
+            "lizard": sum(1 for f in files if f[3] == "lizard"),
+            "scc": sum(1 for f in files if f[3] == "scc"),
+        },
+        "churn_window": aux_label,
+        "loc": {
+            "p50": pct(locs, 50),
+            "p95": pct(locs, 95),
+            "max": float(max(locs)) if locs else 0.0,
+            "total": sum(locs),
+        },
+        "ccn": {
+            "p50": pct(ccns, 50),
+            "p95": pct(ccns, 95),
+            "max": float(max(ccns)) if ccns else 0.0,
+        },
+        "churn": ({
+            "p50": pct(churns, 50),
+            "p95": pct(churns, 95),
+            "max": float(max(churns)) if churns else 0.0,
+        } if aux_data is not None else None),
+        "top_hotspots": strip(by_score[:10]),
+        "top_complex": strip(by_ccn[:10]),
+        "top_large": strip(by_loc[:10]),
+    }
+
+    out_path.write_text(json.dumps(stats, indent=2))
+    print(f"wrote {out_path}")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description=(
@@ -480,6 +557,12 @@ def main() -> int:
     )
     ap.add_argument("--labels", action="store_true",
                     help="Annotate large blocks with filename, LOC and metric")
+    ap.add_argument(
+        "--stats", type=Path,
+        help=("Write a JSON stats sidecar (file count, LOC/CCN percentiles, "
+              "top hotspot/complex/large files). Used by /assess to score "
+              "Layer 2 and surface specific improvement actions."),
+    )
     args = ap.parse_args()
 
     root = args.path.resolve()
@@ -496,6 +579,8 @@ def main() -> int:
     render(files, root, out, f"Hotspot: {root.name}",
            show_labels=args.labels, by=effective_by,
            aux_data=aux_data, aux_label=aux_label)
+    if args.stats:
+        write_stats(files, aux_data, aux_label, root, args.stats)
     return 0
 
 

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Huddle - structured multi-perspective analysis with professional lens team members who cycle through Six Thinking Hats phases"
-argument-hint: "<topic or problem to analyze>"
+name: huddle
+description: "Structured multi-perspective analysis using Six Thinking Hats with professional lens team members. TRIGGER when the user types /huddle, asks to run a huddle, wants a panel/board/team to analyze a decision, asks for multi-perspective analysis, debate, or red-team/blue-team review, or wants to weigh a hard call from several angles. Scales from solo (1 agent) to board-level (8+) using Fibonacci sizing."
 ---
 
 # Huddle - Six Thinking Hats Analysis


### PR DESCRIPTION
## Summary

- Introduces `skills/` directory layout. Moves `/assess` and `/huddle` from `commands/*.md` to `skills/<name>/SKILL.md` with skill-format frontmatter (`name` + TRIGGER-style `description`).
- Bundles `complexity-treemap.py` inside `skills/assess/scripts/`. Treemap logic copied from [sky-uk/gdp-gretna-core-planning#294](https://github.com/sky-uk/gdp-gretna-core-planning/pull/294). Size = LOC, hue = cyclomatic complexity, saturation = recent git churn. Self-contained SVG with hover tooltips, PEP 723 inline deps resolved by `uv`.
- `/assess` now produces two artefacts in `.assess/` inside the target repo: `complexity-heatmap.svg` and `assess-report.md` (embeds the SVG via relative path so GitHub renders it inline in PRs). After writing, the skill asks the user whether to open a PR in the target repo or leave files local for review.

## Changes Made

- `skills/assess/SKILL.md` — converted from `commands/assess.md`. New Steps 1, 2, 5 wrap the existing layered assessment. Report template now leads with a "Hotspot snapshot" section that embeds the SVG.
- `skills/assess/scripts/complexity-treemap.py` — 504-line treemap generator, identical to the version validated in gdp-gretna PR #294 (verified end-to-end on `shak-ng` 4349 files and smaller repos). Only the usage docstring was updated to reference the new home.
- `skills/huddle/SKILL.md` — frontmatter conversion only; body unchanged.
- `commands/assess.md`, `commands/huddle.md` — removed (history preserved via `git mv`).
- `.gitignore` — allowlist extended to include `/skills/`.
- `README.md` — repository structure block updated; added a short "Skills vs commands" note.

## Technical Details

**Skill format** uses YAML frontmatter with `name:` and `description:` (TRIGGER-style trigger phrases). Skills can carry bundled assets in their directory; commands cannot. That's the reason `/assess` was promoted — it now ships executable code alongside its instructions.

**Treemap script** runs via `uv run skills/assess/scripts/complexity-treemap.py <path> -o <out.svg>`. Optional `brew install scc` extends complexity scoring beyond the 13 languages lizard handles natively. If the script fails for any reason, the assessment still runs and the report records "could not be generated — <reason>".

**Report co-location** — SVG and MD live in the same directory (`.assess/`) and the MD embeds the SVG via relative path. GitHub renders the SVG inline in PR conversation, PR files-changed view, and the file's own page.

## Testing

- Verified `git mv` rename detection preserves history for both files (rename similarity 76% and 96%).
- Verified `.gitignore` allowlist now passes `skills/` through (`git check-ignore` no longer matches).
- Treemap script itself is unchanged from gdp-gretna PR #294 where it was end-to-end tested on three representative codebases.

## Risk Assessment

Low. Pure refactor + additive new script. The treemap script declares its own PEP 723 deps so no top-level package state changes. Skills replace the slash commands cleanly — the `/assess` and `/huddle` triggers continue to work because Claude Code's skill auto-discovery picks them up by `description`.

## Deployment Notes

After merge, `~/.claude/skills/assess/` and `~/.claude/skills/huddle/` will be present on next sync. First `/assess` run triggers `uv` to resolve the script's PEP 723 deps (~30s incl. matplotlib download); subsequent runs are instant from cache.

## Test plan

- [ ] Pull this branch onto another machine, confirm `/assess` and `/huddle` are picked up by Claude Code's skill discovery.
- [ ] Run `/assess` against a small repo, verify `.assess/complexity-heatmap.svg` and `.assess/assess-report.md` are written and the SVG renders inline in the MD.
- [ ] Run `/assess` against a non-git directory, verify graceful fallback (saturation signal dropped, files render fully vivid).
- [ ] Confirm "ask before PR" prompt fires after files are written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an assessment skill that produces visual hotspot treemaps, optional summary stats, and an integrated PR workflow to propose findings.
  * Enhanced a huddle-style skill with richer triggers, descriptions, and sizing guidance.

* **Documentation**
  * Updated README to document a new skills directory, explain "skills vs commands", and refresh command listings.

* **Chores**
  * Adjusted ignore rules so the skills directory is tracked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/claude-config/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->