### PR TITLE
fix(plugin): Use string for repository field, not object

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,8 +7,5 @@
     "name": "Ben Coombs"
   },
   "homepage": "https://github.com/bjcoombs/ai-native-toolkit",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bjcoombs/ai-native-toolkit.git"
-  }
+  "repository": "https://github.com/bjcoombs/ai-native-toolkit.git"
 }


### PR DESCRIPTION
Caught at plugin install time:

> Validation errors: repository: Invalid input: expected string, received object

Claude Code's plugin manifest validator expects `repository` as a plain URL string, not the npm/Node `{type, url}` object form. Schema source-of-truth is Claude Code's validator, not `package.json` convention.

One-line fix. Merging immediately so install works on next attempt.