### PR TITLE
chore: Bump version to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"


### PR DESCRIPTION
## Summary

Bump plugin version 1.0.0 -> 1.1.0 so `/plugin update ai-native-toolkit` picks up the changes shipped in #10, #11, #12. Claude Code's plugin updater is version-based; without a bump it reports "already at latest" despite new commits on `main`.

Three commits since 1.0.0 - minor bump per semver (two new features, one docs, no breaking changes):

- #10 feat(assess): Offer to install scc before scan
- #11 docs: Rewrite README - lead with toolkit, not personal config
- #12 feat(assess): Filter build artifacts and warn on dominant files

## Test plan

- [ ] After merge: from a Claude Code session, run `/plugin marketplace update ai-native-toolkit` then `/plugin update ai-native-toolkit`. Confirm it reports "updated to 1.1.0" (or equivalent).
- [ ] Verify the installed cache path becomes `~/.claude/plugins/cache/ai-native-toolkit/ai-native-toolkit/1.1.0/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->