### PR TITLE
feat(assess): Filter generated code (protobuf, wire, codegen)

### DIFF
--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -100,7 +100,12 @@ The script prints a one-line summary (file count, lizard vs scc coverage, churn 
 
 **Dependencies:** the script uses PEP 723 inline metadata (`lizard`, `squarify`, `matplotlib`, `numpy`). `uv` resolves them on first run.
 
-**Build artifacts are filtered by default.** The script excludes `main.dart.js`, `*.min.js`, `*.bundle.js`, `*.chunk.js`, `*.map`, sourcemaps, service workers, and files under `node_modules/`, `dist/`, `build/`, `.next/`, `.nuxt/`, `.output/`, `coverage/`, etc. (full list in `complexity-treemap.py`'s `EXCLUDE_DIRS` and `EXCLUDE_FILE_PATTERNS`). If you specifically want to score these, pass `--include-artifacts`.
+**Build artifacts and generated code are filtered by default.** The script excludes two classes of files:
+
+- **Build artifacts**: `main.dart.js`, `*.min.js`, `*.bundle.js`, `*.chunk.js`, `*.map`, sourcemaps, service workers, and files under `node_modules/`, `dist/`, `build/`, `.next/`, `.nuxt/`, `.output/`, `coverage/`, etc.
+- **Generated code**: protobuf bindings (`*.pb.go`, `*_grpc.pb.go`, `*.pb.gw.go`, `*.connect.go`, `*_pb.ts`, `*_pb.d.ts`, `*_pb2.py`, `*.pb.cc`, `*.pb.h`), Go generators (`*.gen.go`, `wire_gen.go`, `zz_generated_*.go`, `bindata.go`), .NET source generators (`*.designer.cs`, `*.g.cs`), Dart/Flutter codegen (`*.freezed.dart`, `*.g.dart`, `*.gr.dart`).
+
+Full list in `complexity-treemap.py`'s `EXCLUDE_DIRS` and `EXCLUDE_FILE_PATTERNS`. If you specifically want to score these (e.g., to visualise how much of the repo is generated), pass `--include-artifacts`.
 
 **Dominance warning.** If a single file still holds >30% of total scoreable LOC after filtering (the threshold compiled bundles typically cross), the script prints a warning to stderr identifying the file. When you see this:
 

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -41,11 +41,14 @@ Output is a single self-contained SVG with hover tooltips on every block
 annotate large blocks with text.
 
 Build artifacts (main.dart.js, *.min.js, *.bundle.js, *.map, files under
-node_modules/dist/build/.next/.nuxt/etc.) are filtered by default so one
-compiled bundle doesn't dominate the treemap. If a single file still
-holds >30% of total LOC after filtering, a warning prints to stderr
-suggesting it might be a build artifact that needs .gitignore. Pass
---include-artifacts to disable the filter.
+node_modules/dist/build/.next/.nuxt/etc.) and generated code (*.pb.go,
+*.connect.go, *_pb.ts, wire_gen.go, zz_generated_*.go, *.freezed.dart,
+*.designer.cs, etc.) are filtered by default so compiled bundles and
+protoc-emitted bindings don't dominate the "most complex" lists with
+code nobody wrote by hand. If a single remaining file still holds >30%
+of total LOC, a warning prints to stderr suggesting it might be a build
+artifact that needs .gitignore. Pass --include-artifacts to disable the
+filter entirely.
 
 Usage:
     uv run skills/assess/scripts/complexity-treemap.py <path> [-o out.svg] [--labels] [--include-artifacts]
@@ -82,11 +85,16 @@ EXCLUDE_DIRS = {".git", "node_modules", "dist", "build", "target", "vendor",
                 "flutter_assets"}
 
 # Filenames that match these glob patterns are treated as build artifacts
-# and excluded from scoring. Triggers when a single compiled bundle is
-# eating 78% of the codebase LOC and skewing every percentile (see
-# https://github.com/bjcoombs/ai-native-toolkit/issues for the case that
-# prompted this). Pass --include-artifacts to disable.
+# or generated code and excluded from scoring. Two motivations:
+#   - Compiled bundles (main.dart.js etc.) eat 78% of LOC and skew
+#     every percentile (see PR #12).
+#   - Generated bindings (.pb.go, *_pb.ts etc.) dominate "most complex"
+#     lists with machine-emitted switch statements and getters that
+#     nobody wrote by hand (see meridian PR #2212 - 8/10 most-complex
+#     files were protobuf bindings).
+# Pass --include-artifacts to disable.
 EXCLUDE_FILE_PATTERNS = [
+    # --- build artifacts ---
     # Minified / bundled JS-CSS
     "*.min.js", "*.min.mjs", "*.min.css",
     "*.bundle.js", "*.bundle.mjs", "*.bundle.css",
@@ -98,6 +106,26 @@ EXCLUDE_FILE_PATTERNS = [
     "main.dart.js", "flutter_service_worker.js", "flutter.js",
     # PWA / service worker stubs
     "service-worker.js", "sw.js", "workbox-*.js",
+
+    # --- generated code ---
+    # Go protobuf / gRPC / grpc-gateway / Connect
+    "*.pb.go", "*_grpc.pb.go", "*.pb.gw.go", "*.connect.go",
+    # JS/TS protobuf / Connect (buf, ts-proto, protoc-gen-grpc-web)
+    "*_pb.ts", "*_pb.d.ts", "*_pb.js",
+    "*_connect.ts", "*_connect.d.ts", "*_connect.js",
+    # Python protobuf
+    "*_pb2.py", "*_pb2_grpc.py",
+    # C++ protobuf
+    "*.pb.cc", "*.pb.h",
+    # Go generators (wire, controller-gen, mockgen, bindata)
+    "*.gen.go", "*.generated.go",
+    "wire_gen.go",
+    "zz_generated_*.go",
+    "bindata.go", "bindata_assetfs.go",
+    # .NET designer / source generators
+    "*.designer.cs", "*.g.cs", "*.g.i.cs",
+    # Dart/Flutter codegen (freezed, json_serializable, riverpod, get_it)
+    "*.freezed.dart", "*.g.dart", "*.gr.dart", "*.config.dart",
 ]
 
 


### PR DESCRIPTION
## Summary

Reviewing meridianhub/meridian#2212 (a `/assess` run on a Go monorepo): **8 of the top 10 most-complex files were `.pb.go` protobuf bindings**. `current_account.pb.go` alone weighed in at 5,084 LOC, ccn 864 - all protoc-emitted switch statements and getters that nobody wrote by hand.

Same root cause as PR #12 (build artifacts): machine-generated code masquerading as a human-authored hotspot. Same fix shape: add to `EXCLUDE_FILE_PATTERNS`.

### Patterns added

| Generator family | Patterns |
|---|---|
| Go protobuf / gRPC / grpc-gateway / Connect | `*.pb.go`, `*_grpc.pb.go`, `*.pb.gw.go`, `*.connect.go` |
| JS/TS protobuf / Connect (buf, ts-proto) | `*_pb.ts`, `*_pb.d.ts`, `*_pb.js`, `*_connect.ts`, `*_connect.d.ts`, `*_connect.js` |
| Python protobuf | `*_pb2.py`, `*_pb2_grpc.py` |
| C++ protobuf | `*.pb.cc`, `*.pb.h` |
| Go generators (wire, controller-gen, mockgen, bindata) | `*.gen.go`, `*.generated.go`, `wire_gen.go`, `zz_generated_*.go`, `bindata.go`, `bindata_assetfs.go` |
| .NET designer / source generators | `*.designer.cs`, `*.g.cs`, `*.g.i.cs` |
| Dart/Flutter codegen (freezed, json_serializable, riverpod, get_it) | `*.freezed.dart`, `*.g.dart`, `*.gr.dart`, `*.config.dart` |

### Scope choice: filename-only

Content-sniff for `DO NOT EDIT` / `@generated` markers is deferred. Filename patterns catch all canonical generators in the wild; content-sniff costs a syscall per file. Can revisit if custom generators leak through (and it would be easy to add an opt-in flag later).

## Test plan

- [x] 14/14 unit cases pass: `current_account.pb.go`, `*_grpc.pb.go`, `*.connect.go`, `*_pb.ts`, `*_connect.ts`, `wire_gen.go`, `zz_generated_*.go`, `*.freezed.dart`, `*.g.dart`, `*.designer.cs`, `*_pb2.py`, plus negative cases (`Button.tsx`, `handler/user.go`)
- [x] Smoke run on this repo passes (no regressions; only file scored is the treemap script itself)
- [ ] After merge + version bump: re-run `/assess` against a Go monorepo with protobuf; verify `.pb.go` files no longer appear in `top_complex` / `top_large` / `top_hotspots`

---

_Fifth in the series of PRs surfaced by dogfooding `/assess`. Counterpart to #12 (build artifacts)._