### PR TITLE
docs: Refresh README + bump to 1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The headline pieces are two **skills**:
 
 Alongside the SVG you get an `assess-report.md`: a 0-7 layered readiness score (breadcrumbs, type safety, linters, architecture tests, CI, coverage, review bots, AI project management), three concrete leverage actions naming specific files, and a stats sidecar (`complexity-stats.json`) with percentiles and ranked hotspot lists.
 
+**Build artifacts and generated code are filtered by default** so a single `main.dart.js` or thousands of lines of `.pb.go` don't dominate the treemap. The filter catches minified bundles (`*.min.js`, `*.bundle.js`, `main.dart.js`), sourcemaps, protobuf bindings (`*.pb.go`, `*.connect.go`, `*_pb.ts`), Go generators (`wire_gen.go`, `zz_generated_*.go`), .NET source generators (`*.designer.cs`, `*.g.cs`), Dart codegen (`*.freezed.dart`, `*.g.dart`), and files under build dirs (`dist/`, `build/`, `.next/`, `.nuxt/`, `node_modules/`, etc.). Pass `--include-artifacts` to disable. If a single file still holds >30% of total LOC after filtering, the script warns - usually that's a build artifact that needs `.gitignore`.
+
 The skill runs locally - lizard, optional scc, and git log do the analysis in your Claude Code session. No data leaves the machine.
 
 > **Portability split.** The framework pieces (`/assess`, `/huddle`, `/6hats`, `/understand` and their agents) are portable and work in any Claude Code session. The workflow commands (`/tm`, `/fix-pr`, `/fix-develop`) bake in one author's daily setup: a `<repo>-main/` + `worktree/` layout, GitHub + `gh` CLI, Task Master, CodeRabbit/claude[bot] review threads, and the Agent Teams capability flag. See [Adapting](#adapting-for-your-workflow) before relying on them in a different setup.
@@ -62,7 +64,7 @@ Spawns a Fibonacci-sized team (default 3) that cycles through De Bono's six hats
 
 | Skill | Description |
 |-------|-------------|
-| `/assess` | Layered AI-readiness assessment (0-7 contract model) plus a Codecov-style complexity hotspot SVG. Ships [`complexity-treemap.py`](skills/assess/scripts/complexity-treemap.py) so the agent runs the treemap with no external setup. Generated PRs include a self-install footer so reviewers can adopt the plugin. |
+| `/assess` | Layered AI-readiness assessment (0-7 contract model) plus a Codecov-style complexity hotspot SVG. Ships [`complexity-treemap.py`](skills/assess/scripts/complexity-treemap.py) so the agent runs the treemap with no external setup. Filters build artifacts and generated code by default (opt-out with `--include-artifacts`); warns when one file dominates LOC. Offers to install optional `scc` for repos heavy in markdown/JSON/YAML. Generated PRs include a self-install footer so reviewers can adopt the plugin. |
 | `/huddle` | Multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing (solo -> debate -> huddle -> panel -> board). Three execution modes: solo flat-parallel, phased sub-agent (default fallback), and team mode (needs Agent Teams capability flag). |
 
 ### Commands (slash-only, no bundled assets)


### PR DESCRIPTION
## Summary

Surfaces the new `/assess` capabilities shipped in #12 (build-artifact filter) and #14 (generated-code filter) so users find them from the README rather than the SKILL.md.

### Changes

1. **New paragraph in "What `/assess` produces"**: lists the artifact and generated-code patterns filtered by default (`*.min.js`, `main.dart.js`, `*.pb.go`, `*.connect.go`, `wire_gen.go`, `*.designer.cs`, `*.freezed.dart`, build dirs, etc.) and mentions `--include-artifacts` + the >30% dominance warning.
2. **Skill table description for `/assess`**: gains "Filters build artifacts and generated code by default (opt-out with `--include-artifacts`); warns when one file dominates LOC. Offers to install optional `scc` for repos heavy in markdown/JSON/YAML."
3. **Version bump**: `1.1.0` -> `1.2.0` in `.claude-plugin/plugin.json`. Two feature PRs since 1.1.0 (#12 and #14) - minor bump per semver.

### Out of scope (followups)

- **Hero image regeneration.** Current `docs/example-heatmap.svg` predates the filters; proportions are skewed by protobuf bindings and build artifacts that would now be excluded. Regenerating from a fresh `/assess` run against meridian belongs in its own focused PR.
- **Versioning strategy declaration.** Per agreed sequence, the explicit "this repo uses semver" statement lands in the upcoming `CLAUDE.md` PR alongside other in-repo conventions.

## Test plan

- [ ] After merge: `/plugin update ai-native-toolkit` from a Claude Code session reports new version `1.2.0`.
- [ ] README renders cleanly on GitHub; the filtering paragraph reads naturally.