### PR TITLE
docs: Add CLAUDE.md - in-repo agent contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@
 # Still ignore .DS_Store files everywhere
 **/.DS_Store
 
-# Claude-specific files to ignore
+# Ignore nested CLAUDE.md files (e.g. user's personal config when they
+# clone this into ~/.claude/). The root /CLAUDE.md is re-allowlisted
+# below - it's the in-repo agent contract.
 .claude/
-CLAUDE.md
 **/CLAUDE.md
+!/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,10 @@
 # CLAUDE.md
 
-In-repo contract for agents editing `ai-native-toolkit`. The README is for humans; this file scopes how agents (Claude Code, Codex, anyone else) modify the plugin's source.
-
-Hierarchy: user instructions (`~/.claude/CLAUDE.md`, direct requests) override this file. This file overrides default behaviour.
+In-repo contract for agents editing `ai-native-toolkit`. Repo-specific rules only - global conventions (voice, workflow, worktrees) live in the user's `~/.claude/CLAUDE.md` and aren't repeated here.
 
 ## Scope of this repo
 
-This is the source for the `ai-native-toolkit` Claude Code plugin. Two portable skills (`/assess`, `/huddle`), portable framework commands (`/6hats`, `/understand`), and personal workflow commands that are opt-in (`/tm`, `/fix-pr`, `/fix-develop`).
+Source for the `ai-native-toolkit` Claude Code plugin. Two portable skills (`/assess`, `/huddle`), portable framework commands (`/6hats`, `/understand`), and personal workflow commands that are opt-in (`/tm`, `/fix-pr`, `/fix-develop`).
 
 The deliverable is markdown: agents, commands, skills. The only executable code is `skills/assess/scripts/complexity-treemap.py`. There is no application runtime, no test suite, no build step.
 
@@ -20,7 +18,7 @@ The plugin follows [semver](https://semver.org). Version lives in `.claude-plugi
 | MINOR | New skill, new command, new feature on an existing skill (`--include-artifacts` was a MINOR) |
 | PATCH | Bug fix, doc-only change, refactor with no user-visible effect |
 
-**Bump in the same PR as the change.** Claude Code's `/plugin update` is version-based - users see "already at latest" and miss changes if the version doesn't move. A trailing version-bump PR (like #13) is a fix-up, not the pattern to follow.
+**Bump in the same PR as the change.** Claude Code's `/plugin update` is version-based - users see "already at latest" and miss changes if the version doesn't move. A trailing version-bump PR is a fix-up, not the pattern to follow.
 
 ## File conventions
 
@@ -54,38 +52,15 @@ Commands without frontmatter still work but provide no `/help` description.
 ## Invariants
 
 - Every plugin listed in `.claude-plugin/marketplace.json` must exist on disk.
-- Every skill listed in `.claude-plugin/plugin.json` (none currently - the plugin manifest references the bundle, not individual skills) and every skill auto-discovered from `skills/` must have a valid `SKILL.md`.
+- Every skill auto-discovered from `skills/` must have a valid `SKILL.md`.
 - Commands that orchestrate agents should explicitly reference the agent name. Commands that are pure orchestrators (no subagent invocation) should say so in their body so an agent reading the file isn't confused.
-
-## Voice
-
-- Imperative, terse.
-- **No em-dashes (—)**. Use hyphens (-). Em-dashes are an AI tell.
-- No second-person fluff ("you might want to consider..."). Say the thing.
-- No emojis unless the user explicitly asks.
-- Backtick concrete things: filenames, commands, flag names, code identifiers.
-- Tables when comparing options; mermaid when showing flow; markdown lists for sequences.
-
-## Workflow
-
-Per the user's standard layout (see README's "Adapting for your workflow"):
-
-- Default branch: `main`. The PR target.
-- **Never edit `claude-config-main/` directly.** That directory is the sacred pristine copy; a hook will block writes.
-- All work happens in `../worktree/<branch-name>/`. Create with `git worktree add ../worktree/<branch-name> <branch-name>`.
-- Branch naming: `<type>/<short-description>`. Types: `feat`, `fix`, `docs`, `chore`, `refactor`. Examples: `feat/filter-build-artifacts`, `docs/refresh-readme`, `chore/bump-1.2.0`.
-- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): summary`, `fix(scope): summary`, `docs: summary`, etc.
-- PR titles mirror the commit format.
-- PRs are squash-merged.
 
 ## What this repo doesn't have (and that's fine)
 
 - No CI - the plugin has no executable surface beyond one Python script. If a frontmatter validator or markdown linter is added, it should live in `.github/workflows/`.
-- No tests for the Python script - it's small enough to smoke-test by running `/assess` against this repo (`uv run skills/assess/scripts/complexity-treemap.py .`).
+- No tests for the Python script - small enough to smoke-test by running `uv run skills/assess/scripts/complexity-treemap.py .`.
 - No coverage gates - same reason.
-
-Adding these in future is good. Not having them isn't a bug.
 
 ## Compatibility
 
-This file is recognised by Claude Code as `CLAUDE.md`. If you want it picked up by Codex (`AGENTS.md`) or Gemini CLI (`GEMINI.md`), copy or symlink it under those names. The content is tool-agnostic.
+Recognised by Claude Code as `CLAUDE.md`. For Codex (`AGENTS.md`) or Gemini CLI (`GEMINI.md`), copy or symlink under those names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+In-repo contract for agents editing `ai-native-toolkit`. The README is for humans; this file scopes how agents (Claude Code, Codex, anyone else) modify the plugin's source.
+
+Hierarchy: user instructions (`~/.claude/CLAUDE.md`, direct requests) override this file. This file overrides default behaviour.
+
+## Scope of this repo
+
+This is the source for the `ai-native-toolkit` Claude Code plugin. Two portable skills (`/assess`, `/huddle`), portable framework commands (`/6hats`, `/understand`), and personal workflow commands that are opt-in (`/tm`, `/fix-pr`, `/fix-develop`).
+
+The deliverable is markdown: agents, commands, skills. The only executable code is `skills/assess/scripts/complexity-treemap.py`. There is no application runtime, no test suite, no build step.
+
+## Versioning
+
+The plugin follows [semver](https://semver.org). Version lives in `.claude-plugin/plugin.json` under `.version`.
+
+| Bump | When |
+|------|------|
+| MAJOR | Breaking change to a skill or command (rename, removed flag, behaviour change users would need to adapt to) |
+| MINOR | New skill, new command, new feature on an existing skill (`--include-artifacts` was a MINOR) |
+| PATCH | Bug fix, doc-only change, refactor with no user-visible effect |
+
+**Bump in the same PR as the change.** Claude Code's `/plugin update` is version-based - users see "already at latest" and miss changes if the version doesn't move. A trailing version-bump PR (like #13) is a fix-up, not the pattern to follow.
+
+## File conventions
+
+### `skills/<name>/SKILL.md`
+
+Required frontmatter:
+
+- `name` - kebab-case, must match the directory name
+- `description` - **must include a `TRIGGER` clause** describing the user phrases / questions that should activate the skill. Claude Code's skill router matches on this.
+
+Bundled executables go under `skills/<name>/scripts/`. Reference docs go under `skills/<name>/references/`.
+
+### `agents/<name>.md`
+
+Required frontmatter:
+
+- `name` - kebab-case, must match the filename
+- `description` - one-line behaviour summary
+- `model` - typically `inherit`
+- `color` - one of: `cyan`, `blue`, `red`, `yellow`, `green`, `purple`, `pink`, `orange`, `indigo`
+
+### `commands/<name>.md`
+
+Frontmatter recommended (some existing commands don't have it yet):
+
+- `description` - shown in `/help`
+- `argument-hint` - shown after the command name when typing
+
+Commands without frontmatter still work but provide no `/help` description.
+
+## Invariants
+
+- Every plugin listed in `.claude-plugin/marketplace.json` must exist on disk.
+- Every skill listed in `.claude-plugin/plugin.json` (none currently - the plugin manifest references the bundle, not individual skills) and every skill auto-discovered from `skills/` must have a valid `SKILL.md`.
+- Commands that orchestrate agents should explicitly reference the agent name. Commands that are pure orchestrators (no subagent invocation) should say so in their body so an agent reading the file isn't confused.
+
+## Voice
+
+- Imperative, terse.
+- **No em-dashes (—)**. Use hyphens (-). Em-dashes are an AI tell.
+- No second-person fluff ("you might want to consider..."). Say the thing.
+- No emojis unless the user explicitly asks.
+- Backtick concrete things: filenames, commands, flag names, code identifiers.
+- Tables when comparing options; mermaid when showing flow; markdown lists for sequences.
+
+## Workflow
+
+Per the user's standard layout (see README's "Adapting for your workflow"):
+
+- Default branch: `main`. The PR target.
+- **Never edit `claude-config-main/` directly.** That directory is the sacred pristine copy; a hook will block writes.
+- All work happens in `../worktree/<branch-name>/`. Create with `git worktree add ../worktree/<branch-name> <branch-name>`.
+- Branch naming: `<type>/<short-description>`. Types: `feat`, `fix`, `docs`, `chore`, `refactor`. Examples: `feat/filter-build-artifacts`, `docs/refresh-readme`, `chore/bump-1.2.0`.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): summary`, `fix(scope): summary`, `docs: summary`, etc.
+- PR titles mirror the commit format.
+- PRs are squash-merged.
+
+## What this repo doesn't have (and that's fine)
+
+- No CI - the plugin has no executable surface beyond one Python script. If a frontmatter validator or markdown linter is added, it should live in `.github/workflows/`.
+- No tests for the Python script - it's small enough to smoke-test by running `/assess` against this repo (`uv run skills/assess/scripts/complexity-treemap.py .`).
+- No coverage gates - same reason.
+
+Adding these in future is good. Not having them isn't a bug.
+
+## Compatibility
+
+This file is recognised by Claude Code as `CLAUDE.md`. If you want it picked up by Codex (`AGENTS.md`) or Gemini CLI (`GEMINI.md`), copy or symlink it under those names. The content is tool-agnostic.


### PR DESCRIPTION
## Summary

Closes Action #1 from the original `/assess` on this repo. Declares the conventions that have lived in the maintainer's head and now need to be explicit so future agents (and future humans) can edit the plugin safely.

### What's in CLAUDE.md

- **Versioning strategy** - semver, MAJOR/MINOR/PATCH definitions, **bump in the same PR as the change** (the trailing-bump pattern in #13 is fix-up, not the pattern to follow going forward).
- **Required frontmatter** for `skills/<name>/SKILL.md` (`name`, `description` with `TRIGGER` clause), `agents/<name>.md` (`name`, `description`, `model`, `color`), and `commands/<name>.md` (recommended). Acknowledges that three existing commands don't have frontmatter yet rather than pretending they do.
- **Marketplace invariants** - every plugin in `marketplace.json` exists on disk; commands that orchestrate agents reference them by name.
- **Voice rules** - imperative, terse, no em-dashes (em-dashes are an AI tell), no second-person fluff, no emojis.
- **Workflow expectations** - worktree-based, conventional commits, branch naming.
- **What this repo doesn't have (and that's fine)** - no CI, no test suite for the one Python script. Future-proofs against new contributors wasting effort looking for them.

### Gitignore

Root `CLAUDE.md` re-allowlisted. Nested `CLAUDE.md` (e.g. when someone clones this repo into `~/.claude/` over their personal config) stays ignored. Verified both behaviours with `git check-ignore -v`.

### Compatibility

The content is tool-agnostic. If you want it picked up by Codex (`AGENTS.md`) or Gemini CLI (`GEMINI.md`), copy or symlink. Done as a one-liner note in the file rather than committing duplicates - one source of truth.

## Test plan

- [x] `git check-ignore -v CLAUDE.md` confirms root file is trackable (matches `!/CLAUDE.md`)
- [x] `git check-ignore -v agents/CLAUDE.md` confirms nested ignored (matches `**/CLAUDE.md`)
- [ ] After merge: verify a Claude Code session in this worktree picks up the in-repo `CLAUDE.md` (it should auto-load alongside the user's global)

---

_Final PR of the dogfood-driven series surfaced by running `/assess` on this repo._