### PR TITLE
chore: Add GitHub release-notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,43 @@
+# Categories shown in GitHub-generated release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# A PR appears in the first category whose `labels` it matches. The `*`
+# catch-all at the end picks up anything unlabelled. Labels listed here
+# must exist on the repo (the four below are GitHub defaults plus
+# 'chore' which is conventional-commit style; create that one with:
+#   gh label create chore --description "Maintenance, refactors, CI"
+# ).
+#
+# To cut a release once PRs are merged:
+#   1. Bump .claude-plugin/plugin.json version in a small PR (CLAUDE.md
+#      rule: same-PR bump for features; this is the case where it
+#      hasn't been done).
+#   2. After merge, tag and push:
+#        git tag v$(jq -r .version .claude-plugin/plugin.json)
+#        git push origin --tags
+#   3. Create the release with auto-notes:
+#        gh release create vX.Y.Z --generate-notes
+#
+# The notes will group merged PRs by label per the config below.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - skip-changelog
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feat
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/skills/
 !/LICENSE
 !/docs/
+!/.github/
 
 # Still ignore .DS_Store files everywhere
 **/.DS_Store


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` so future tagged releases auto-generate categorised notes via `gh release create --generate-notes`.

Lighter than Changesets (which `claude-task-master` uses) because this repo is solo + single-package + non-npm. The config is zero-overhead at PR time (only need a label) and zero-overhead at release time (one `gh` command).

### How it works

1. Each PR gets a label before merging (`enhancement` / `bug` / `documentation` / `feat` / `fix` / `docs` / `chore`).
2. When cutting a release:
   ```bash
   git tag v$(jq -r .version .claude-plugin/plugin.json)
   git push origin --tags
   gh release create vX.Y.Z --generate-notes
   ```
3. GitHub generates release notes grouped by the categories defined in this config (Features / Fixes / Documentation / Other).

### Categories

| Category | Labels |
|---|---|
| Features | `enhancement`, `feat` |
| Fixes | `bug`, `fix` |
| Documentation | `documentation`, `docs` |
| Other Changes | `*` (catch-all) |

`enhancement`, `bug`, `documentation` are GitHub default labels on this repo. `feat` / `fix` / `docs` / `chore` are conventional-commit-style aliases - GitHub doesn't auto-create these. To add (recommended):

```bash
gh label create feat   --description "New feature or enhancement"   --color a2eeef
gh label create fix    --description "Bug fix"                      --color d73a4a
gh label create docs   --description "Documentation only"           --color 0075ca
gh label create chore  --description "Maintenance, refactors, CI"   --color cfd3d7
```

### Why no plugin version bump

`.github/release.yml` doesn't change `/assess` or `/huddle` behaviour. It changes the release process, which takes effect at the next tagged release. The next feature/fix PR is when the next version bump will land.

### Not in scope (follow-up if useful)

- A `.github/workflows/label.yml` workflow that auto-labels PRs based on the conventional-commit prefix in the title (e.g. `feat:` -> `feat` label). Removes the manual labelling step.
- Backfilling labels on already-merged PRs (#10 through #15) so the first auto-generated release notes are complete. Can be done with `gh pr edit <num> --add-label <label>` against closed PRs.

## Test plan

- [ ] After merge: create the four missing labels (feat/fix/docs/chore).
- [ ] On next release: tag, push, run `gh release create vX.Y.Z --generate-notes`. Verify the release page groups PRs into the four categories.