### PR TITLE
ci: Add PR title lint + auto-label workflow

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,62 @@
+name: PR Title Lint + Auto-Label
+
+# Two jobs in one workflow:
+#  1. Validate the PR title is conventional-commit format
+#     (feat|fix|docs|chore|refactor)(scope?)(!)?: description
+#     A failing title blocks merge once branch protection requires this check.
+#  2. Extract the type from the title and apply the matching label
+#     so .github/release.yml can categorise the PR in auto-generated
+#     release notes. Labels: feat / fix / docs / chore / refactor.
+#     Breaking changes (`feat!:` or `feat(scope)!:`) also get a `breaking`
+#     label (create with `gh label create breaking` if you want it).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+            Example: feat(assess): filter generated code
+
+  auto-label:
+    name: Auto-label from PR title
+    needs: lint-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const match = title.match(/^(feat|fix|docs|chore|refactor)(\([^)]+\))?(!)?:/);
+            if (!match) return;
+
+            const labels = [match[1]];
+            if (match[3]) labels.push('breaking');
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels,
+            });

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -33,11 +33,13 @@ jobs:
             docs
             chore
             refactor
+            ci
+            build
+            test
+            perf
+            style
+            revert
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" must start with a lowercase letter.
-            Example: feat(assess): filter generated code
 
   auto-label:
     name: Auto-label from PR title

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/skills/
 !/LICENSE
 !/docs/
+!/.github/
 
 # Still ignore .DS_Store files everywhere
 **/.DS_Store


### PR DESCRIPTION
## Summary

Enforcement layer for the release-notes flow added in #17. Without this, a PR with the title "stuff" merges to main with no label and no good release-note bullet. With this, the PR title must be conventional-commit format and the matching label is applied automatically.

### Workflow (`.github/workflows/pr-lint.yml`)

Two sequential jobs:

1. **lint-title** - uses `amannn/action-semantic-pull-request@v5` to validate the PR title against `(feat|fix|docs|chore|refactor)(scope?)(!)?: lowercase description`. Failing titles fail the check (block merge if branch protection requires it).

2. **auto-label** - parses the type prefix from the title and applies the matching label (`feat`, `fix`, `docs`, `chore`, `refactor`). All five labels were created on the repo as part of this work. Breaking changes (`feat!:` or `feat(scope)!:`) also get a `breaking` label - create it manually if you want it (`gh label create breaking --color b60205`).

### What this enables

- `.github/release.yml` from #17 has guaranteed-good inputs: every merged PR has a clean title and one of the expected labels.
- Release notes generation at tag time produces categorised, readable output with no manual label work.

### Branch protection (after this merges)

```bash
gh api -X PUT repos/bjcoombs/ai-native-toolkit/branches/main/protection \
  -f required_status_checks[strict]=true \
  -F required_status_checks[contexts][]='Validate PR title' \
  -F required_status_checks[contexts][]='Auto-label from PR title' \
  -F enforce_admins=false \
  -F required_linear_history=true \
  -F allow_force_pushes=false \
  -F allow_deletions=false
```

`enforce_admins=false` keeps escape hatches for emergencies. Linear history forces squash/rebase.

### Caveats

- This PR's own title (`ci: ...`) will validate fine, so the workflow doesn't lock itself out.
- PRs #16 and #17 are already open with non-validated titles. Both match the convention by accident (`docs:` and `chore:`) so they'd pass anyway.
- Pinning to action versions `@v5` and `@v7`. For higher security, pin to commit SHAs - left as a follow-up.

## Test plan

- [ ] After merge: create a test PR with a bad title (e.g. "fix stuff"). Verify the check fails.
- [ ] Create one with a good title (`feat: test`). Verify `feat` label is auto-applied.
- [ ] Enable branch protection per the command above. Confirm a failing check now blocks merge.

---

_Last in the release-notes series. After this, #17, and #16 merge, the flow is: write a conventional-commit PR title -> CI applies the label -> tag a release -> `gh release create --generate-notes` produces categorised notes._