### PR TITLE
chore: Bump to 1.3.0, refresh CLAUDE.md for new CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,13 @@ Commands without frontmatter still work but provide no `/help` description.
 - Every skill auto-discovered from `skills/` must have a valid `SKILL.md`.
 - Commands that orchestrate agents should explicitly reference the agent name. Commands that are pure orchestrators (no subagent invocation) should say so in their body so an agent reading the file isn't confused.
 
+## CI
+
+- `.github/workflows/pr-lint.yml` validates PR titles match conventional-commit format and auto-applies the matching label (`feat` / `fix` / `docs` / `chore` / `refactor`). Other conventional types (`ci`, `build`, `test`, `perf`, `style`, `revert`) pass validation but aren't auto-labelled.
+- `.github/release.yml` configures categorised release notes when running `gh release create --generate-notes`. See the file for the label-to-category mapping.
+
 ## What this repo doesn't have (and that's fine)
 
-- No CI - the plugin has no executable surface beyond one Python script. If a frontmatter validator or markdown linter is added, it should live in `.github/workflows/`.
 - No tests for the Python script - small enough to smoke-test by running `uv run skills/assess/scripts/complexity-treemap.py .`.
 - No coverage gates - same reason.
 


### PR DESCRIPTION
## Summary

Final wrap-up of the dogfood-driven burst (#16-#19).

### Version bump 1.2.1 -> 1.3.0

#19 added a feature (offer to create tracking issues for Top 3 Actions) but deferred its version bump to avoid `plugin.json` conflicts across the four parallel PRs. This PR catches up. Per CLAUDE.md's versioning rule, MINOR is the right bump (additive feature, no breaking change).

### CLAUDE.md refresh

The "What this repo doesn't have" section claimed "No CI" - but the same burst added two CI files. Replaced that bullet with a new "## CI" section documenting what now exists:

- `.github/workflows/pr-lint.yml` - PR title validation + auto-label
- `.github/release.yml` - categorised release notes config

Tests + coverage absent for the one Python script - those stay in the "doesn't have" list.

### Note on the trailing-bump pattern

CLAUDE.md explicitly says trailing version-bump PRs are a fix-up, not the pattern. This one is the exception: the burst had four in-flight PRs touching shared files and stacking version bumps would have caused merge conflicts. Future single-PR feature work should bump in-place.

## Test plan

- [ ] After merge: from a Claude Code session run `/plugin update ai-native-toolkit`. Verify new version `1.3.0`.
- [ ] Tag and create release to validate the new release-notes flow:
  ```bash
  git tag v1.3.0
  git push origin --tags
  gh release create v1.3.0 --generate-notes
  ```
  Release page should group #16-#19 (and this PR) under Features / Documentation / Other Changes.