### PR TITLE
fix: standalone pipeline follow-ups + pr-lint permission

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/workflows/build-standalone-skills.yml
+++ b/.github/workflows/build-standalone-skills.yml
@@ -37,11 +37,9 @@ jobs:
             echo "build=true"  >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Python
+      - name: Install uv
         if: steps.version-check.outputs.build == 'true' || github.event_name == 'workflow_dispatch'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
-        with:
-          python-version: "3.11"
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
 
       - name: Build standalone skill ZIPs
         if: steps.version-check.outputs.build == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write    # github.rest.issues.addLabels uses the issues API
 
 jobs:
   lint-title:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ai-native-toolkit/
 
 ## Contributors
 
-Thanks to [@franklywatson](https://github.com/franklywatson) (Jerome Pimmel) for the standalone skill ZIP pipeline that makes `/assess` and `/huddle` installable in Claude Desktop chat and Cowork ([#24](https://github.com/bjcoombs/ai-native-toolkit/pull/24)).
+Thanks to [@franklywatson](https://github.com/franklywatson) for the standalone skill ZIP pipeline that makes `/assess` and `/huddle` installable in Claude Desktop chat and Cowork ([#24](https://github.com/bjcoombs/ai-native-toolkit/pull/24)).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ ai-native-toolkit/
     └── example-heatmap.svg            # Sanitized real-world /assess output (README hero)
 ```
 
+## Contributors
+
+Thanks to [@franklywatson](https://github.com/franklywatson) (Jerome Pimmel) for the standalone skill ZIP pipeline that makes `/assess` and `/huddle` installable in Claude Desktop chat and Cowork ([#24](https://github.com/bjcoombs/ai-native-toolkit/pull/24)).
+
 ## License
 
 Licensed under the Apache License, Version 2.0 - see [`LICENSE`](LICENSE) for the full text.

--- a/scripts/build-standalone-skills.sh
+++ b/scripts/build-standalone-skills.sh
@@ -32,7 +32,9 @@ done
 mkdir -p "$DEST"
 
 cd "$SCRIPT_DIR"
-python3 - "$DEST" "$REPO_ROOT" ${SKILLS_TO_BUILD[@]+"${SKILLS_TO_BUILD[@]}"} <<'PYEOF'
+# Use `uv run` so the script honours scripts/pyproject.toml's `requires-python`
+# and provisions a matching interpreter even when system python3 is older.
+uv run python - "$DEST" "$REPO_ROOT" ${SKILLS_TO_BUILD[@]+"${SKILLS_TO_BUILD[@]}"} <<'PYEOF'
 import sys
 from pathlib import Path
 

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -1,10 +1,15 @@
 """Unit tests for transform_skill.py primitives."""
+import zipfile
+from pathlib import Path
+
 import pytest
 from transform_skill import (
-    strip_chat_skip,
+    REQUIRED_EXCLUDES,
     apply_chat_replace,
-    override_frontmatter,
+    build_standalone_skill_zip,
     check_orphan_markers,
+    override_frontmatter,
+    strip_chat_skip,
 )
 
 
@@ -89,6 +94,26 @@ def test_frontmatter_preserves_body():
     assert "body content here" in result
 
 
+def test_frontmatter_does_not_touch_body_yaml_example():
+    # Regression: a fenced YAML example in the body must not be rewritten
+    # just because it contains name: / description: lines.
+    text = (
+        "---\nname: real\ndescription: \"real\"\n---\n\n"
+        "```yaml\nname: example\ndescription: \"shown in docs\"\n```\n"
+    )
+    result = override_frontmatter(text, "NEW", "NEW DESC")
+    assert "name: NEW" in result
+    assert "description: \"NEW DESC\"" in result
+    # Body example untouched
+    assert "name: example" in result
+    assert 'description: "shown in docs"' in result
+
+
+def test_frontmatter_no_frontmatter_returns_input_unchanged():
+    text = "no frontmatter here\nname: foo\n"
+    assert override_frontmatter(text, "x", "y") == text
+
+
 # ── check_orphan_markers ─────────────────────────────────────────────────────
 
 def test_orphan_unclosed_start():
@@ -136,6 +161,46 @@ def test_assess_config_covers_all_markers():
     in_config = set(SKILLS["assess"]["replacements"])
     uncovered = in_file - in_config
     assert not uncovered, f"assess markers with no config entry: {uncovered}"
+
+
+# ── build-level safety: REQUIRED_EXCLUDES always applied ───────────────────
+
+def _zip_names(out_zip: Path) -> list[str]:
+    with zipfile.ZipFile(out_zip) as zf:
+        return zf.namelist()
+
+
+def _make_fake_skill(root: Path) -> Path:
+    """Build a synthetic skill source with tooling artefacts."""
+    src = root / "fake_skill"
+    src.mkdir()
+    (src / "SKILL.md").write_text('---\nname: fake\ndescription: "fake"\n---\n# Body\n')
+    (src / "__pycache__").mkdir()
+    (src / "__pycache__" / "junk.pyc").write_bytes(b"junk")
+    (src / ".pytest_cache").mkdir()
+    (src / ".pytest_cache" / "v").write_text("cache")
+    (src / ".venv").mkdir()
+    (src / ".venv" / "pyvenv.cfg").write_text("home = /usr/bin")
+    return src
+
+
+def test_required_excludes_applied_even_when_caller_passes_empty_set(tmp_path):
+    src = _make_fake_skill(tmp_path)
+    out_zip = tmp_path / "fake.zip"
+    issues = build_standalone_skill_zip(
+        skill_source_dir=src,
+        out_zip=out_zip,
+        standalone_name="fake",
+        standalone_description="fake desc",
+        replacements={},
+        exclude_dirs=frozenset(),  # caller opts out of all configured excludes
+    )
+    assert issues == []
+    names = _zip_names(out_zip)
+    for forbidden in REQUIRED_EXCLUDES:
+        assert not any(forbidden in n for n in names), (
+            f"{forbidden!r} leaked into ZIP: {names}"
+        )
 
 
 def test_huddle_config_has_no_orphan_replace_markers():

--- a/scripts/transform_skill.py
+++ b/scripts/transform_skill.py
@@ -11,6 +11,11 @@ _SKIP_PATTERN = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 _REPLACE_PATTERN = re.compile(r"<!-- chat-replace:(\S+?) -->")
+_FRONTMATTER_PATTERN = re.compile(r"\A(---\n)(.*?)(\n---\n)", re.DOTALL)
+
+# Always excluded from the ZIP regardless of per-skill config — these are tooling
+# artefacts that should never ship.
+REQUIRED_EXCLUDES: frozenset[str] = frozenset({"__pycache__", ".pytest_cache", ".venv"})
 
 
 def strip_chat_skip(text: str) -> str:
@@ -37,15 +42,29 @@ def apply_chat_replace(text: str, replacements: dict[str, str]) -> str:
 
 
 def override_frontmatter(text: str, name: str, description: str) -> str:
-    """Rewrite name: and description: fields in YAML frontmatter."""
-    text = re.sub(r"^name:.*$", f"name: {name}", text, flags=re.MULTILINE)
-    text = re.sub(
-        r'^description:.*?(?=^\S|\Z)',
+    """Rewrite name: and description: fields in the YAML frontmatter only.
+
+    Body content is left untouched even if a line begins with `name:` or
+    `description:` (e.g. a fenced YAML example showing skill manifest syntax).
+    """
+    m = _FRONTMATTER_PATTERN.match(text)
+    if not m:
+        return text
+    fm_open, fm_body, fm_close = m.groups()
+    rest = text[m.end():]
+
+    fm_body = re.sub(r"^name:.*$", f"name: {name}", fm_body, flags=re.MULTILINE)
+    fm_body = re.sub(
+        r"^description:.*?(?=^\S|\Z)",
         f'description: "{description}"\n',
-        text,
+        fm_body,
         flags=re.MULTILINE | re.DOTALL,
     )
-    return text
+    # Strip the trailing newline left by the description replacement so the
+    # rebuilt document doesn't gain a blank line before the closing fence.
+    fm_body = fm_body.rstrip("\n")
+
+    return f"{fm_open}{fm_body}{fm_close}{rest}"
 
 
 def check_orphan_markers(text: str) -> list[str]:
@@ -72,14 +91,19 @@ def build_standalone_skill_zip(
     standalone_name: str,
     standalone_description: str,
     replacements: dict[str, str],
-    exclude_dirs: frozenset[str] = frozenset({"tests", "__pycache__", ".pytest_cache", ".venv"}),
+    exclude_dirs: frozenset[str] = frozenset({"tests"}),
 ) -> list[str]:
     """
     Transform *skill_source_dir* and write a standalone ZIP to *out_zip*.
 
     Returns validation issues; empty list means success. ZIP is not written if
     there are issues.
+
+    ``REQUIRED_EXCLUDES`` (``__pycache__``, ``.pytest_cache``, ``.venv``) are
+    always excluded in addition to *exclude_dirs* — callers cannot opt out of
+    these tooling artefacts.
     """
+    effective_excludes = exclude_dirs | REQUIRED_EXCLUDES
     staging = out_zip.parent / f"_staging_{standalone_name}"
     if staging.exists():
         shutil.rmtree(staging)
@@ -91,7 +115,7 @@ def build_standalone_skill_zip(
         if src.is_dir():
             continue
         rel = src.relative_to(skill_source_dir)
-        if any(part in exclude_dirs for part in rel.parts):
+        if any(part in effective_excludes for part in rel.parts):
             continue
         dest = target_root / rel
         dest.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Three small fixes spotted during review of #24, plus the version bump that triggers a fresh standalone-skills release.

- **`override_frontmatter` now scoped to the YAML fence** - previously `re.sub` with `MULTILINE` would rewrite any line in the body starting with `name:` or `description:` (e.g. a fenced YAML example showing skill manifest syntax). Latent today since both SKILL.md bodies are clean, but the docstring and implementation diverged. Regression test added.
- **`REQUIRED_EXCLUDES` always applied** - `build_standalone_skill_zip` now unions the caller's `exclude_dirs` with `{"__pycache__", ".pytest_cache", ".venv"}` so a skill config that passes an empty set (huddle today) cannot accidentally ship tooling artefacts. Regression test added.
- **`pr-lint.yml` now grants `issues: write`** - `github.rest.issues.addLabels` hits the issues API even for PRs. GitHub's 403 response confirmed it (`x-accepted-github-permissions: issues=write; pull_requests=write`). Pre-existing bug, just surfaced on #24.

Plus:
- Version bumped `1.6.0 -> 1.6.1` (PATCH - latent fixes, no user-visible behaviour change). Triggers `build-standalone-skills.yml` on merge to rebuild and republish `standalone-skills-latest`.
- README "Contributors" section added crediting @franklywatson for #24.

## Test plan

- [x] `cd scripts && uv run --with pytest pytest -v` - 38 tests pass (35 original + 3 new)
- [x] `cd skills/assess && uv run --with pytest pytest -v` - 59 tests pass (no regression)
- [x] `bash scripts/build-standalone-skills.sh` - both ZIPs build (assess ~104 KB, huddle ~10 KB), no forbidden strings, frontmatter correctly overridden

Follows up on #24 by @franklywatson.
