### PR TITLE
docs: rewrite /assess narrative + rename Layer 0 to Agent Instructions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin: skills, agents, and commands for AI-native development. Ru
 
 The headline pieces are two **skills**:
 
-- **`/assess`** - score any codebase's readiness for AI agent contributors against a 7-layer contract model, with a Codecov-style complexity hotspot SVG. Generates a report + treemap and opens a PR in the target repo.
+- **`/assess`** - score any codebase's readiness for AI agent contributors against a layered contract model (agent instructions, types, linters, architecture tests, CI, coverage, review bots, AI project management), with a Codecov-style complexity hotspot SVG. Generates a report + treemap and opens a PR in the target repo.
 - **`/huddle`** - structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing (solo -> debate -> huddle -> panel -> board).
 
 ## What `/assess` produces
@@ -13,9 +13,32 @@ The headline pieces are two **skills**:
 
 > Real output from `/ai-native-toolkit:assess` run against a ~150k-LOC private monorepo (file paths sanitized). Size encodes lines of code, hue encodes cyclomatic complexity (red = high), saturation encodes recent git churn (vivid = active). Vivid red blocks are the migration risk an agent (or human) is most likely to break next week. Hover any block for its LOC, CCN, and recent commit count.
 
-Alongside the SVG you get an `assess-report.md`: a 0-7 layered readiness score (breadcrumbs, type safety, linters, architecture tests, CI, coverage, review bots, AI project management), three concrete leverage actions naming specific files, and a stats sidecar (`complexity-stats.json`) with percentiles and ranked hotspot lists.
+### Why this matters for an AI-driven codebase
 
-**Build artifacts and generated code are filtered by default** so a single `main.dart.js` or thousands of lines of `.pb.go` don't dominate the treemap. The filter catches minified bundles (`*.min.js`, `*.bundle.js`, `main.dart.js`), sourcemaps, protobuf bindings (`*.pb.go`, `*.connect.go`, `*_pb.ts`), Go generators (`wire_gen.go`, `zz_generated_*.go`), .NET source generators (`*.designer.cs`, `*.g.cs`), Dart codegen (`*.freezed.dart`, `*.g.dart`), and files under build dirs (`dist/`, `build/`, `.next/`, `.nuxt/`, `node_modules/`, etc.). Pass `--include-artifacts` to disable. If a single file still holds >30% of total LOC after filtering, the script warns - usually that's a build artifact that needs `.gitignore`.
+Once a codebase outgrows any single LLM context window and AI agents become regular contributors, code quality stops being a function of *who knows what* and starts being a function of *what the system enforces*. Norms ("we prefer X") fail because new contributors - especially AI agents starting each session fresh - never read them. Contracts ("the build fails if you don't do X") work because they're enforced regardless of who's reading.
+
+`/assess` gives you two paired views to act on that. The SVG above shows **where the codebase is today** - which files will bite next week. The accompanying `assess-report.md` shows **what scaffolding is in place to stop it getting worse** - a score across the layers below, each marked Present / Partial / Missing with concrete evidence:
+
+| Layer | What it enforces |
+|-------|------------------|
+| 0: Agent Instructions | Compact rules in `CLAUDE.md` / `AGENTS.md` / `copilot-instructions` that steer agent behaviour ("NEVER use `time.Sleep` in tests", "CockroachDB not PostgreSQL") |
+| 1: Code Design | Compile-time correctness via types - dimensional types, generated API clients, exhaustive enums |
+| 2: Linters | Style + correctness with rules targeting AI failure modes (suppressions, complexity gates, leftover TODOs) |
+| 3: Architecture Tests | Structural rules as executable tests (`depguard`, ArchUnit-style boundary checks) |
+| 4: CI Pipeline | Every PR runs everything; failing pipeline blocks merge |
+| 5: Coverage Gates | Test discipline as a build contract |
+| 6: Review Bots | Design-level feedback (CodeRabbit, claude[bot]) catching what linters can't |
+| 7: AI Project Management | Retros, task tracking, the feedback loop that keeps the contracts above current |
+
+A codebase can be 7/7 and still on fire (great scaffolding, legacy debt) or 2/7 with a calm treemap (small codebase, no enforcement needed yet). The score tells you whether the system will catch the next class of pain before it lands; the SVG tells you where today's pain already is. The report's **Top 3 Actions** table names specific files, always - "improve code quality" is the failure mode `/assess` exists to prevent; "Add `cyclop` rule (threshold 15) to `.golangci.yml`. Current p95 ccn is 23; immediate offenders: `internal/import/parser.go` (ccn 67)" is what makes the report actionable.
+
+**The compounding payoff.** Contracts are front-loaded - types, lint rules, architecture tests, agent instructions all take time to write. The payoff compounds: every new service, feature, and contributor inherits the contracts that already exist. Skip them and you lose 15-45 minutes per AI session to convention drift, rework, and false signals - forever. Run `/assess` periodically to ratchet the score upward; each layer you add closes a recurring cost.
+
+A stats sidecar (`complexity-stats.json`) accompanies the report with percentiles and ranked file lists that feed the treemap and the report's hotspot callouts.
+
+### Build artifacts and generated code are filtered by default
+
+A single `main.dart.js` or thousands of lines of `.pb.go` shouldn't dominate the treemap. The filter catches minified bundles (`*.min.js`, `*.bundle.js`, `main.dart.js`), sourcemaps, protobuf bindings (`*.pb.go`, `*.connect.go`, `*_pb.ts`), Go generators (`wire_gen.go`, `zz_generated_*.go`), .NET source generators (`*.designer.cs`, `*.g.cs`), Dart codegen (`*.freezed.dart`, `*.g.dart`), and files under build dirs (`dist/`, `build/`, `.next/`, `.nuxt/`, `node_modules/`, etc.). Pass `--include-artifacts` to disable. If a single file still holds >30% of total LOC after filtering, the script warns - usually that's a build artifact that needs `.gitignore`.
 
 The skill runs locally - lizard, optional scc, and git log do the analysis in your Claude Code session. No data leaves the machine.
 

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -7,7 +7,7 @@ description: "Assess a codebase's readiness for AI agent contributors using the 
 
 Two artefacts in one pass against a target repo:
 
-1. **Layered contract assessment** — 0–7 score across breadcrumbs, types, linters, architecture tests, CI, coverage, review bots, AI project management.
+1. **Layered contract assessment** — 0–7 score across agent instructions, types, linters, architecture tests, CI, coverage, review bots, AI project management.
 2. **Complexity hotspot SVG** — Codecov-style treemap. Size = LOC. Hue = cyclomatic complexity. Saturation = recent git churn. Vivid red = complex AND active = highest risk.
 
 Both land as files inside the target repo. The skill always writes them locally; after writing, **ask the user** whether to open a PR in the target repo with both artefacts.
@@ -143,7 +143,7 @@ The `plugin_version` field in `run-context.json` tells you which plugin version 
 
 Run these checks in parallel where possible. For each layer, collect evidence and assess quality.
 
-### Layer 0: Breadcrumbs (Behavioral Contracts)
+### Layer 0: Agent Instructions (Behavioral Contracts)
 
 Read the agent instruction file grades from `run-context.json`:
 
@@ -193,7 +193,7 @@ fd -t f 'doc\.go$' "$REPO_ROOT" 2>/dev/null | wc -l  # Go
 Docs: README [yes/no], architecture guide [yes/no], ADRs [N found], API specs [N found], package docs [N found]
 ```
 
-Missing docs don't reduce the layer score (breadcrumbs are the primary signal), but flag gaps in the report. An agent with good breadcrumbs but no README or architecture docs can follow rules but can't orient itself in unfamiliar parts of the codebase.
+Missing docs don't reduce the layer score (agent instructions are the primary signal), but flag gaps in the report. An agent with good agent instructions but no README or architecture docs can follow rules but can't orient itself in unfamiliar parts of the codebase.
 
 ### Layer 1: Code Design (Compile-Time Correctness)
 
@@ -461,7 +461,7 @@ rg -i 'retrospective|retro|feedback loop|learnings|post.?mortem' "$REPO_ROOT"/{C
 **Assess across three dimensions:**
 
 1. **Task orchestration** - Are AI tasks structured and tracked? (Task Master tags, SpecKit specs, GSD tasks, GitHub Projects with AI labels, etc.)
-2. **Feedback loop** - Do learnings feed back into contracts? (retro logs, breadcrumb updates traced to incidents, iterative CLAUDE.md refinement)
+2. **Feedback loop** - Do learnings feed back into contracts? (retro logs, agent instruction updates traced to incidents, iterative CLAUDE.md refinement)
 3. **Workflow maturity** - Is there evidence of repeated AI work cycles? (multiple completed tags/sprints, merged PR history from AI branches, wave-based orchestration)
 
 **Scoring:**
@@ -528,7 +528,7 @@ Size encodes lines of code, hue encodes cyclomatic complexity (red = high), satu
 
 | Layer | Status | Evidence | Gap |
 |-------|--------|----------|-----|
-| 0: Breadcrumbs | Present/Partial/Missing | <what was found> | <what's missing> |
+| 0: Agent Instructions | Present/Partial/Missing | <what was found> | <what's missing> |
 | 1: Code Design | Present/Partial/Missing | <what was found> | <what's missing> |
 | 2: Linters | Present/Partial/Missing | <what was found> | <what's missing> |
 | 3: Architecture Tests | Present/Partial/Missing | <what was found> | <what's missing> |
@@ -548,7 +548,7 @@ Size encodes lines of code, hue encodes cyclomatic complexity (red = high), satu
 
 ## Top 3 Actions
 
-Prioritize by leverage: breadcrumbs and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session and reference **specific files** from the hotspot snapshot wherever possible — generic advice is the failure mode this report exists to prevent.
+Prioritize by leverage: agent instructions and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session and reference **specific files** from the hotspot snapshot wherever possible — generic advice is the failure mode this report exists to prevent.
 
 | # | Action | Layer | Effort | Command / First Step | Hotspot files this addresses | Issue |
 |---|--------|-------|--------|---------------------|------------------------------|-------|


### PR DESCRIPTION
## Summary

Two changes that go together:

**1. README narrative for `/assess` was dry.** Led with the SVG hero + one-line description of the report, didn't tell anyone *why* this matters. Rewritten to land the underlying thesis:

- Codebases > context window + AI contributors = norms break, contracts hold.
- The report is a paired view: SVG shows where the codebase is today; the layered score shows whether the system will stop it getting worse.
- Top 3 Actions name specific files; "improve code quality" is the failure mode the report exists to prevent.
- Compounding payoff: contracts are front-loaded, savings are forever (15-45 min per AI session, recurring).

Also surfaces the layer table inline in the README so readers see what the 0-7 score is actually measuring without having to install the skill.

**2. Renamed "Breadcrumbs" -> "Agent Instructions"** in README and `skills/assess/SKILL.md`. "Breadcrumbs" is jargon - and the code is already on this naming (`agent_instructions_grader.py`); the docs just lagged. Matches what the ecosystem calls these files: `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, Cursor rules.

Historical `docs/superpowers/plans/*.md` still reference "breadcrumb" - left as period-correct context for those PRDs.

## Version bump

`1.6.1 -> 1.6.2` so the standalone-skills build workflow republishes `assess.zip` and `huddle.zip` with the new terminology on merge.

## Test plan

- [x] `cd scripts && uv run --with pytest pytest -q` - 38 tests pass
- [x] `bash scripts/build-standalone-skills.sh` - both ZIPs build, assess shrunk slightly to ~100 KB
- [x] Grep confirms no `breadcrumb` mentions remain in `README.md` or `skills/assess/SKILL.md`
- [x] Rebuilt assess.zip confirmed to contain "agent instructions" / "Layer 0: Agent Instructions" not "breadcrumbs"

Follows up the merge of #26 (or works concurrently - no overlap in touched README sections).
