### PR TITLE
fix(huddle): bundle hat methodologies, deterministic mode picker

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/scripts/build-standalone-skills.sh
+++ b/scripts/build-standalone-skills.sh
@@ -61,6 +61,10 @@ for name, cfg in SKILLS.items():
     except ValueError:
         display_path = out_zip
     print(f"Building {name} -> {display_path} ...", flush=True)
+    bundle_files = {
+        dest_rel: repo_root / src_rel
+        for dest_rel, src_rel in cfg.get("bundle_files", {}).items()
+    }
     issues = build_standalone_skill_zip(
         skill_source_dir=repo_root / cfg["source_dir"],
         out_zip=out_zip,
@@ -68,6 +72,7 @@ for name, cfg in SKILLS.items():
         standalone_description=cfg["standalone_description"],
         replacements=cfg["replacements"],
         exclude_dirs=frozenset(cfg["exclude_dirs"]),
+        bundle_files=bundle_files,
     )
     if issues:
         print(f"  FAIL — {len(issues)} issue(s):")

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -8,6 +8,9 @@ Each entry in SKILLS maps a skill name to:
   source_dir             — path relative to repo root
   replacements           — dict mapping chat-replace:KEY → replacement text
   exclude_dirs           — subdirectories omitted from the ZIP
+  bundle_files           — optional dict mapping ZIP-relative dest paths → source
+                           paths (relative to repo root). Markdown files have their
+                           YAML frontmatter stripped during bundling.
 """
 
 SKILLS: dict[str, dict] = {
@@ -47,10 +50,43 @@ SKILLS: dict[str, dict] = {
             "to run a huddle, wanting multi-perspective or red-team/blue-team analysis, needing "
             "to weigh a hard decision from several angles, or wanting panel/board deliberation. "
             "Scales from solo gut-check (1) to board-level deliberation (8+) using Fibonacci "
-            "team sizing. Team mode with persistent agents requires Claude Code."
+            "team sizing. Team mode with persistent agents requires the Claude Code CLI."
         ),
         "source_dir": "skills/huddle",
         "exclude_dirs": set(),
-        "replacements": {},
+        "replacements": {
+            "hat-source": (
+                "**Hat methodologies** (`white-hat`, `red-hat`, `black-hat`, "
+                "`yellow-hat`, `green-hat`, `blue-hat`) are bundled inside this "
+                "skill at `hats/<hat>-hat.md`. Spawn prompts instruct sub-agents "
+                "to `Read('hats/<hat>-hat.md')` before applying the methodology "
+                "— this is how a fresh-context sub-agent learns the hat without "
+                "depending on Claude-Code-only agent infrastructure."
+            ),
+            "phased-spawn-instructions": (
+                "   - The hat methodology for this phase: instruct the sub-agent "
+                "to call `Read('hats/<hat>-hat.md')` (relative to the skill root) "
+                "and apply that methodology"
+            ),
+            "capability-detection": (
+                "**This standalone build runs phased sub-agent mode for size 2+.** "
+                "Team mode (persistent agents with cross-talk) is only available "
+                "in the Claude Code CLI and is not reachable from here. Tell the "
+                "user one line: \"Running in phased sub-agent mode (N lenses, M "
+                "phases — standalone build, team mode not available).\""
+            ),
+        },
+        # Bundle the hat methodology files inside the ZIP so standalone-mode
+        # sub-agents can read them via relative paths. Without this they'd
+        # depend on `~/.claude/agents/*-hat.md` which only exists in plugin
+        # installs.
+        "bundle_files": {
+            "hats/white-hat.md": "agents/white-hat.md",
+            "hats/red-hat.md": "agents/red-hat.md",
+            "hats/black-hat.md": "agents/black-hat.md",
+            "hats/yellow-hat.md": "agents/yellow-hat.md",
+            "hats/green-hat.md": "agents/green-hat.md",
+            "hats/blue-hat.md": "agents/blue-hat.md",
+        },
     },
 }

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -75,6 +75,7 @@ SKILLS: dict[str, dict] = {
                 "user one line: \"Running in phased sub-agent mode (N lenses, M "
                 "phases — standalone build, team mode not available).\""
             ),
+            "branch-phased-row": "| Size 2+ | **Phased Sub-Agent Mode** (below) |",
         },
         # Bundle the hat methodology files inside the ZIP so standalone-mode
         # sub-agents can read them via relative paths. Without this they'd

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -221,6 +221,23 @@ def test_strip_frontmatter_no_frontmatter_unchanged():
     assert strip_frontmatter(text) == text
 
 
+def test_strip_frontmatter_handles_crlf_line_endings():
+    text = "---\r\nname: x\r\ncolor: red\r\n---\r\nbody here\r\n"
+    assert strip_frontmatter(text) == "body here\r\n"
+
+
+def test_strip_frontmatter_handles_closing_fence_at_eof():
+    # No trailing newline after the closing ---
+    text = "---\nname: x\n---"
+    assert strip_frontmatter(text) == ""
+
+
+def test_strip_frontmatter_handles_eof_with_body_after():
+    # Closing fence with body but no trailing newline at EOF
+    text = "---\nname: x\n---\nbody"
+    assert strip_frontmatter(text) == "body"
+
+
 # ── bundle_files ───────────────────────────────────────────────────────────
 
 def test_bundle_files_copies_extra_files_into_zip(tmp_path):
@@ -265,6 +282,40 @@ def test_bundle_files_missing_source_raises(tmp_path):
             standalone_description="fake desc",
             replacements={},
             bundle_files={"hats/missing.md": tmp_path / "does-not-exist.md"},
+        )
+
+
+def test_bundle_files_rejects_absolute_destination(tmp_path):
+    src = _make_fake_skill(tmp_path)
+    extras_dir = tmp_path / "extras"
+    extras_dir.mkdir()
+    (extras_dir / "hat.md").write_text("---\nname: x\n---\nbody\n")
+    out_zip = tmp_path / "fake.zip"
+    with pytest.raises(ValueError, match="relative path within the skill"):
+        build_standalone_skill_zip(
+            skill_source_dir=src,
+            out_zip=out_zip,
+            standalone_name="fake",
+            standalone_description="fake desc",
+            replacements={},
+            bundle_files={"/etc/passwd": extras_dir / "hat.md"},
+        )
+
+
+def test_bundle_files_rejects_parent_traversal(tmp_path):
+    src = _make_fake_skill(tmp_path)
+    extras_dir = tmp_path / "extras"
+    extras_dir.mkdir()
+    (extras_dir / "hat.md").write_text("---\nname: x\n---\nbody\n")
+    out_zip = tmp_path / "fake.zip"
+    with pytest.raises(ValueError, match="relative path within the skill"):
+        build_standalone_skill_zip(
+            skill_source_dir=src,
+            out_zip=out_zip,
+            standalone_name="fake",
+            standalone_description="fake desc",
+            replacements={},
+            bundle_files={"../escaped.md": extras_dir / "hat.md"},
         )
 
 

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -296,6 +296,50 @@ def test_huddle_real_build_contains_all_hat_files(tmp_path):
             assert not body.startswith("---"), f"{hat}-hat.md still has frontmatter"
 
 
+def test_huddle_plugin_source_retains_team_mode_infrastructure():
+    """Plugin SKILL.md must keep the full team-mode flow.
+
+    Pairs with the integration-test assertions that team-mode tool names are
+    absent from the *standalone* ZIP. Together these enforce the invariant:
+    plugin install gets team mode; standalone strips it. A PR that accidentally
+    removed team-mode content from the source would let standalone pass (the
+    forbidden strings would still be absent) but silently regress the plugin —
+    this test catches that case.
+
+    If you are intentionally removing team mode from the plugin (e.g.
+    deprecation), delete this test in the same PR with a note in the commit
+    message explaining the deprecation path.
+    """
+    from pathlib import Path
+    source = Path("../skills/huddle/SKILL.md").read_text("utf-8")
+
+    required_tool_names = [
+        "TeamCreate",          # team creation
+        "SendMessage",         # cross-agent messaging
+        "TeamDelete",          # team shutdown
+        "subagent_type",       # Agent-tool dispatch path
+        "~/.claude/agents",    # hat methodology resolution in plugin
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",  # capability env var
+    ]
+    for token in required_tool_names:
+        assert token in source, (
+            f"plugin SKILL.md missing team-mode token {token!r} — "
+            "team mode appears to have been removed from the source. "
+            "If intentional, remove this test in the same PR."
+        )
+
+    required_section_headers = [
+        "### Step 2: Create the Team",
+        "### Step 3: Spawn Team Members",
+        "### Step 4: Facilitate Hat Phases",
+        "### Step 6: Shutdown the Team",
+    ]
+    for header in required_section_headers:
+        assert header in source, (
+            f"plugin SKILL.md missing team-mode section {header!r}"
+        )
+
+
 def test_huddle_config_covers_all_markers():
     """Every chat-replace marker in huddle sources must have a config entry,
     and every config entry must correspond to a marker in the source."""

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -10,6 +10,7 @@ from transform_skill import (
     check_orphan_markers,
     override_frontmatter,
     strip_chat_skip,
+    strip_frontmatter,
 )
 
 
@@ -203,13 +204,109 @@ def test_required_excludes_applied_even_when_caller_passes_empty_set(tmp_path):
         )
 
 
-def test_huddle_config_has_no_orphan_replace_markers():
+# ── strip_frontmatter ──────────────────────────────────────────────────────
+
+def test_strip_frontmatter_removes_yaml_block():
+    text = "---\nname: x\ndescription: y\n---\nbody here\n"
+    assert strip_frontmatter(text) == "body here\n"
+
+
+def test_strip_frontmatter_handles_multiline_yaml():
+    text = "---\nname: x\ncolor: red\nmodel: inherit\n---\n\nfirst para.\n\nsecond.\n"
+    assert strip_frontmatter(text) == "first para.\n\nsecond.\n"
+
+
+def test_strip_frontmatter_no_frontmatter_unchanged():
+    text = "just body\nno frontmatter here\n"
+    assert strip_frontmatter(text) == text
+
+
+# ── bundle_files ───────────────────────────────────────────────────────────
+
+def test_bundle_files_copies_extra_files_into_zip(tmp_path):
+    src = _make_fake_skill(tmp_path)
+    extras_dir = tmp_path / "extras"
+    extras_dir.mkdir()
+    (extras_dir / "hat-a.md").write_text(
+        "---\nname: hat-a\ncolor: red\n---\nMethodology body.\n"
+    )
+    (extras_dir / "hat-b.md").write_text(
+        "---\nname: hat-b\n---\nOther methodology.\n"
+    )
+    out_zip = tmp_path / "fake.zip"
+    issues = build_standalone_skill_zip(
+        skill_source_dir=src,
+        out_zip=out_zip,
+        standalone_name="fake",
+        standalone_description="fake desc",
+        replacements={},
+        bundle_files={
+            "hats/hat-a.md": extras_dir / "hat-a.md",
+            "hats/hat-b.md": extras_dir / "hat-b.md",
+        },
+    )
+    assert issues == []
+    with zipfile.ZipFile(out_zip) as zf:
+        assert "fake/hats/hat-a.md" in zf.namelist()
+        assert "fake/hats/hat-b.md" in zf.namelist()
+        body_a = zf.read("fake/hats/hat-a.md").decode("utf-8")
+        assert body_a == "Methodology body.\n", "frontmatter should be stripped"
+        assert "color: red" not in body_a
+
+
+def test_bundle_files_missing_source_raises(tmp_path):
+    src = _make_fake_skill(tmp_path)
+    out_zip = tmp_path / "fake.zip"
+    with pytest.raises(FileNotFoundError, match="bundle_files source missing"):
+        build_standalone_skill_zip(
+            skill_source_dir=src,
+            out_zip=out_zip,
+            standalone_name="fake",
+            standalone_description="fake desc",
+            replacements={},
+            bundle_files={"hats/missing.md": tmp_path / "does-not-exist.md"},
+        )
+
+
+def test_huddle_real_build_contains_all_hat_files(tmp_path):
+    """Integration check: real huddle build bundles all 6 hat methodologies."""
+    from standalone_skill_config import SKILLS
+    repo_root = Path(__file__).parent.parent.parent
+    cfg = SKILLS["huddle"]
+    bundle_files = {
+        dest_rel: repo_root / src_rel
+        for dest_rel, src_rel in cfg.get("bundle_files", {}).items()
+    }
+    out_zip = tmp_path / "huddle.zip"
+    issues = build_standalone_skill_zip(
+        skill_source_dir=repo_root / cfg["source_dir"],
+        out_zip=out_zip,
+        standalone_name=cfg["standalone_name"],
+        standalone_description=cfg["standalone_description"],
+        replacements=cfg["replacements"],
+        exclude_dirs=frozenset(cfg["exclude_dirs"]),
+        bundle_files=bundle_files,
+    )
+    assert issues == []
+    with zipfile.ZipFile(out_zip) as zf:
+        names = zf.namelist()
+        for hat in ["white", "red", "black", "yellow", "green", "blue"]:
+            assert f"huddle/hats/{hat}-hat.md" in names, f"missing {hat}-hat.md"
+            body = zf.read(f"huddle/hats/{hat}-hat.md").decode("utf-8")
+            assert not body.startswith("---"), f"{hat}-hat.md still has frontmatter"
+
+
+def test_huddle_config_covers_all_markers():
+    """Every chat-replace marker in huddle sources must have a config entry,
+    and every config entry must correspond to a marker in the source."""
     from standalone_skill_config import SKILLS
     from pathlib import Path
     import re
     in_file: set[str] = set()
     for md in Path("../skills/huddle").rglob("*.md"):
         in_file |= set(re.findall(r"<!-- chat-replace:(\S+?) -->", md.read_text()))
-    # huddle uses chat-skip+inline only; no chat-replace markers expected
-    assert not in_file, f"unexpected chat-replace markers in huddle: {in_file}"
-    assert SKILLS["huddle"]["replacements"] == {}, "huddle replacements should be empty"
+    in_config = set(SKILLS["huddle"]["replacements"])
+    uncovered = in_file - in_config
+    unused = in_config - in_file
+    assert not uncovered, f"huddle markers with no config entry: {uncovered}"
+    assert not unused, f"huddle config keys with no marker in source: {unused}"

--- a/scripts/transform_skill.py
+++ b/scripts/transform_skill.py
@@ -12,6 +12,12 @@ _SKIP_PATTERN = re.compile(
 )
 _REPLACE_PATTERN = re.compile(r"<!-- chat-replace:(\S+?) -->")
 _FRONTMATTER_PATTERN = re.compile(r"\A(---\n)(.*?)(\n---\n)", re.DOTALL)
+# Permissive variant used only by strip_frontmatter: tolerates CRLF line
+# endings and an EOF close fence (closing `---` without a trailing newline).
+_FRONTMATTER_STRIP_PATTERN = re.compile(
+    r"\A---\r?\n(.*?)\r?\n---(\r?\n|\Z)",
+    re.DOTALL,
+)
 
 # Always excluded from the ZIP regardless of per-skill config — these are tooling
 # artefacts that should never ship.
@@ -86,8 +92,13 @@ def _transform_md(text: str, replacements: dict[str, str]) -> str:
 
 
 def strip_frontmatter(text: str) -> str:
-    """Return *text* with any leading YAML frontmatter (--- ... ---) removed."""
-    m = _FRONTMATTER_PATTERN.match(text)
+    """Return *text* with any leading YAML frontmatter (--- ... ---) removed.
+
+    Tolerates CRLF line endings and a closing ``---`` at EOF without a
+    trailing newline — both are valid frontmatter variants and should be
+    stripped from bundled methodology files.
+    """
+    m = _FRONTMATTER_STRIP_PATTERN.match(text)
     if not m:
         return text
     return text[m.end():].lstrip("\n")
@@ -140,11 +151,19 @@ def build_standalone_skill_zip(
 
     if bundle_files:
         for rel_dest, src_path in bundle_files.items():
+            # Guard against config errors that would write outside the staging
+            # skill root: reject absolute paths and any '..' segments.
+            dest_path = Path(rel_dest)
+            if dest_path.is_absolute() or ".." in dest_path.parts:
+                raise ValueError(
+                    f"bundle_files dest must be a relative path within the skill "
+                    f"root (got {rel_dest!r}); absolute paths and '..' segments are rejected"
+                )
             if not src_path.exists():
                 raise FileNotFoundError(
                     f"bundle_files source missing: {src_path} (for {rel_dest})"
                 )
-            dest = target_root / rel_dest
+            dest = target_root / dest_path
             dest.parent.mkdir(parents=True, exist_ok=True)
             if src_path.suffix == ".md":
                 dest.write_text(strip_frontmatter(src_path.read_text("utf-8")), "utf-8")

--- a/scripts/transform_skill.py
+++ b/scripts/transform_skill.py
@@ -85,6 +85,14 @@ def _transform_md(text: str, replacements: dict[str, str]) -> str:
     return text
 
 
+def strip_frontmatter(text: str) -> str:
+    """Return *text* with any leading YAML frontmatter (--- ... ---) removed."""
+    m = _FRONTMATTER_PATTERN.match(text)
+    if not m:
+        return text
+    return text[m.end():].lstrip("\n")
+
+
 def build_standalone_skill_zip(
     skill_source_dir: Path,
     out_zip: Path,
@@ -92,6 +100,7 @@ def build_standalone_skill_zip(
     standalone_description: str,
     replacements: dict[str, str],
     exclude_dirs: frozenset[str] = frozenset({"tests"}),
+    bundle_files: dict[str, Path] | None = None,
 ) -> list[str]:
     """
     Transform *skill_source_dir* and write a standalone ZIP to *out_zip*.
@@ -102,6 +111,11 @@ def build_standalone_skill_zip(
     ``REQUIRED_EXCLUDES`` (``__pycache__``, ``.pytest_cache``, ``.venv``) are
     always excluded in addition to *exclude_dirs* — callers cannot opt out of
     these tooling artefacts.
+
+    ``bundle_files`` maps destination paths (relative to the skill root inside
+    the ZIP) to source ``Path`` objects somewhere on disk. Markdown bundled
+    files have their YAML frontmatter stripped so the body reads as plain
+    methodology rather than Claude-Code-agent metadata.
     """
     effective_excludes = exclude_dirs | REQUIRED_EXCLUDES
     staging = out_zip.parent / f"_staging_{standalone_name}"
@@ -123,6 +137,19 @@ def build_standalone_skill_zip(
             dest.write_text(_transform_md(src.read_text("utf-8"), replacements), "utf-8")
         else:
             shutil.copy2(src, dest)
+
+    if bundle_files:
+        for rel_dest, src_path in bundle_files.items():
+            if not src_path.exists():
+                raise FileNotFoundError(
+                    f"bundle_files source missing: {src_path} (for {rel_dest})"
+                )
+            dest = target_root / rel_dest
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if src_path.suffix == ".md":
+                dest.write_text(strip_frontmatter(src_path.read_text("utf-8")), "utf-8")
+            else:
+                shutil.copy2(src_path, dest)
 
     skill_md = target_root / "SKILL.md"
     if skill_md.exists():

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -11,13 +11,23 @@ Scales from a solo gut check to a board-level deliberation using Fibonacci team 
 
 **You are Blue Hat** - the chair. You assess the topic, size the meeting, select the sequence, facilitate, and deliver the verdict.
 
-**Hat agents** (`white-hat`, `red-hat`, `black-hat`, `yellow-hat`, `green-hat`) are methodology specialists in `~/.claude/agents/`.
+<!-- chat-replace:hat-source -->
+**Hat agents** (`white-hat`, `red-hat`, `black-hat`, `yellow-hat`, `green-hat`) are methodology specialists in `~/.claude/agents/`, dispatched via the `Agent` tool with `subagent_type=<hat>`.
 
 **Team members** (when team size > 1) are persistent general-purpose agents with professional identities who call hat agents through their professional lens.
 
 ## Capability Requirements
 
-Three execution modes exist; the skill picks one automatically based on team size and whether the Agent Teams capability flag is enabled.
+<!-- chat-skip:start -->
+Three execution modes exist. Pick one **deterministically** by this rule, in order:
+
+1. If team size = 1 → **Solo flat-parallel**.
+2. If team size ≥ 2 AND you can confirm the team-mode capability is available in your environment → **Team mode**.
+3. Otherwise (team size ≥ 2 and you cannot confirm team mode) → **Phased sub-agent mode**.
+
+If you're unsure whether team mode is available, default to phased — do not guess it's on. Phased mode degrades gracefully; attempting team mode without the capability fails loudly.
+<!-- chat-skip:end -->
+Two execution modes are reachable in this standalone build. Pick one deterministically: team size = 1 → solo flat-parallel; team size ≥ 2 → phased sub-agent mode. Team mode (persistent agents with cross-talk) is only available in the Claude Code CLI and is not reachable from here.
 
 | Mode | When chosen | Mechanism | Cost (relative) |
 |------|-------------|-----------|----------------|
@@ -40,6 +50,7 @@ Without the flag, `/huddle` still runs multi-perspective deliberations via phase
 **Why enable team mode anyway:** persistent professional-lens agents talking to each other across phases produce noticeably deeper synthesis — disagreements get rebutted in real time, edge cases surface from cross-talk, and the verdict feels like real deliberation rather than serially-summarised opinions. Worth it for decisions where being wrong costs 100× more than the analysis: architecture choices, irreversible migrations, hiring calls, contractual commitments.
 <!-- chat-skip:end -->
 
+<!-- chat-replace:capability-detection -->
 **Tell the user which mode you're in** before you start. One line: "Running in phased sub-agent mode (3 lenses, 5 phases — Agent Teams flag not detected)."
 
 ## No Arguments Behavior
@@ -57,7 +68,7 @@ Assess the topic to determine:
 
    | Size | Mode | Use |
    |------|------|-----|
-   | **1** | Solo | Quick analysis. You spawn hat agents in parallel, synthesize yourself. Fast (~5 min). |
+   | **1** | Solo | Quick analysis. You spawn hat agents in parallel, synthesize yourself. Cheapest tier. |
    | **2** | Debate | Two opposing lenses. Forced productive tension. |
    | **3** | Huddle | Sweet spot. Most deliberations. |
    | **5** | Panel | Broader perspectives. Cross-functional decisions. |
@@ -103,11 +114,14 @@ When team size > 1 but team mode is unavailable, do not collapse to flat-paralle
 1. **Announce the phase to the user.** "Phase 3 of 5: Black Hat — risks."
 2. **For each professional lens, spawn a sub-agent in parallel** for this phase. Each sub-agent gets:
    - Its persona (the professional lens you assigned in Step 1)
-   - The hat methodology for this phase (point it at `~/.claude/agents/<hat>-hat.md`)
+<!-- chat-replace:phased-spawn-instructions -->
+   - The hat methodology for this phase (`Agent` tool with `subagent_type=<hat>` resolves the agent file from `~/.claude/agents/`)
    - The topic
    - **A running synopsis you maintain as Blue Hat** — a 200-400 word summary of what every prior phase produced. This is how cross-phase continuity survives without a persistent team. Each sub-agent has a fresh context window, so the synopsis is its only memory of what came before.
 3. **Collect all sub-agent outputs.** As Blue Hat, write a 100-200 word phase summary capturing: what each lens contributed, where they agreed, where they conflicted, what changed your view. Append this to the running synopsis.
 4. **Surface the phase summary to the user** before moving on. Short, scannable.
+
+**When to collapse to one sub-agent per phase voicing all lenses.** Default is one sub-agent per lens per phase (preserves independent fresh contexts). But total spawns = `team_size × phases` — a size-5 board × 5 phases = 25 sub-agent calls. When that count exceeds ~8–10, or when running in a chat UI where spawn latency is user-visible, collapse to **one sub-agent per phase voicing all lenses**. When you do, **explicitly instruct that sub-agent to keep the lenses cognitively distinct** — separate labelled sections per lens, no blending. Without that instruction the lenses blur and you lose most of the multi-perspective value. This is a degraded fallback, not a third mode; reach for it deliberately.
 
 **At the end of all phases**, deliver the verdict as in team mode (Step 5 below): one paragraph stating the decision, the strongest dissent, and the conditions under which you'd reverse.
 
@@ -344,7 +358,7 @@ After delivering the verdict:
 - If Black Hat surfaces a critical risk, give Green Hat more time
 - Red Hat is permission to check your gut - use it when something feels off or people are affected
 - The sequence is a guide, not a straitjacket
-- **Target total meeting time**: 45-90 minutes. If approaching 90 min, compress remaining phases or go straight to verdict.
+- **Target depth, not duration.** Wall-clock time depends on the runtime — chat surfaces complete in minutes, CLI team mode can take longer. Use phase count and message budget as the lever: 5 phases × 2–3 substantive messages per member per phase is the default ceiling. If you've hit that ceiling without convergence, compress remaining phases or go straight to verdict — adding more rounds rarely changes the answer.
 
 ## Lessons Learned
 

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -95,7 +95,10 @@ After Step 1 you have a team size, a list of professional lenses, and a hat sequ
 | Configuration | Execution mode |
 |---|---|
 | Size 1 | **Solo flat-parallel** (below) |
+<!-- chat-skip:start -->
 | Size 2+ AND Agent Teams flag enabled | **Team Mode** (Step 2 onwards) |
+<!-- chat-skip:end -->
+<!-- chat-replace:branch-phased-row -->
 | Size 2+ AND Agent Teams flag NOT enabled | **Phased Sub-Agent Mode** (below) |
 
 ### Solo flat-parallel (Size 1)


### PR DESCRIPTION
## Summary

Real-use feedback from running `/huddle` in Cowork (Claude Desktop standalone install) surfaced three defects in the standalone ZIP. All three are fixed here, plus one wording change to address the spawn fan-out concern.

### 1. Hat methodology files don't ship in the standalone ZIP (real bug)

SKILL.md repeatedly told sub-agents to "point at `~/.claude/agents/<hat>-hat.md`" - files that exist in a Claude Code plugin install but not in the standalone ZIP. On chat surfaces, sub-agents either errored on the file read or silently improvised the hat methodology (which is the worse failure - a "passing" run with degraded quality).

**Fix.** Extend the build pipeline with a new `bundle_files` config key that copies arbitrary repo files into the ZIP at a chosen relative path. Huddle now bundles `agents/{white,red,black,yellow,green,blue}-hat.md` into `huddle/hats/`. Markdown bundles get their YAML frontmatter stripped during bundling so sub-agents read clean methodology, not Claude-Code-agent metadata. Standalone spawn prompts now say `Read('hats/<hat>-hat.md')`. Plugin keeps the `subagent_type` dispatch path.

**Source of truth stays in `agents/`** - no drift, no duplicate methodology.

### 2. Mode picker said "picks automatically" without saying how (wording)

Rewritten as a deterministic 3-step ordered rule with an explicit "if you cannot confirm team mode is available, default to phased" fallback. The standalone build gets a 2-mode variant since team mode is unreachable from there.

### 3. Time estimates ("~5 min", "45-90 minutes") read as literal (wording)

In agent contexts a phased run completes in minutes of wall clock - the durations confuse rather than inform. Replaced with depth/budget framing (phase count × message budget) that's runtime-independent.

### Plus: explicit guidance on phased-mode fan-out

Total spawns = `team_size × phases`. Size 5 × 5 phases = 25 sub-agent calls; size 8 × 5 = 40. When that count exceeds ~8-10 (or in chat UIs where spawn latency is user-visible), collapse to one sub-agent per phase voicing all lenses - **with an explicit instruction to keep lenses cognitively distinct**, else the fallback becomes lens-blur. Trigger is spawn count OR surface, not surface alone.

## What declined

**Cowork outputs-folder integration** - genuinely useful for the size-8 board verdict (which is unwieldy as a chat dump), but one run isn't enough demand signal to justify it. Parked accurately: Cowork does have `computer://` outputs (my earlier framing on this was wrong); deferring is a prioritisation call, not a capability gap.

## Test plan

- [x] `cd scripts && uv run --with pytest pytest -q` - 44 tests pass (35 original + 9 new for `strip_frontmatter` + `bundle_files`)
- [x] `bash scripts/build-standalone-skills.sh` - both ZIPs build clean
- [x] `unzip -p huddle.zip huddle/SKILL.md | grep -c TeamCreate` → 0
- [x] `unzip -p huddle.zip huddle/SKILL.md | grep -c '~/.claude/agents'` → 0
- [x] `unzip -p huddle.zip huddle/SKILL.md | grep -c subagent_type` → 0
- [x] All 6 hat files (`huddle/hats/<hat>-hat.md`) present in ZIP, frontmatter stripped
- [x] Plugin SKILL.md still has rich content (5 TeamCreate, 2 `~/.claude/agents`, 4 subagent_type refs - all inside chat-skip)
- [ ] Manual re-run of `/huddle` in Cowork after merge to confirm the loud failure (file-read error) and silent failure (improvised methodology) are both gone

## Pipeline change is additive

`bundle_files` defaults to `None`; `assess` is unaffected. The change ships behind that opt-in field.

## Version

`1.6.2 → 1.6.3` (PATCH - bug fix + wording, no new user-visible features). Triggers the standalone-skills workflow on merge to republish `assess.zip` and `huddle.zip`.

## Credit

Substantive retro from Claude Desktop running this in Cowork, pushed back on my triage twice, sharpened the final scope. Especially on point #3 - the substantive fix is bundling, not just hiding the broken instruction with `chat-skip`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced huddle skill documentation with clarified execution modes and standalone build capabilities.
  * Explicitly noted that team mode is unavailable in standalone builds.
  * Refreshed sub-agent mode instructions and updated guidance to prioritize depth over duration.

* **Chores**
  * Version bump to 1.6.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->