### PR TITLE
docs: standalone upgrade flow + version surfacing for update awareness

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Skills appear namespaced: `/ai-native-toolkit:assess`, `/ai-native-toolkit:huddl
 | You use... | Install via | Updates |
 |---|---|---|
 | Claude Code | `/plugin install` (see [Install](#install) above) | Automatic on `/plugin update`. Use this when available - it's the maintained path. |
-| claude.ai web or Claude Desktop only | Manual ZIP upload (below) | Manual: re-download the ZIP and re-upload when a new release ships. Watch the repo's [Releases](https://github.com/bjcoombs/ai-native-toolkit/releases) page if you want notifications. |
+| claude.ai web or Claude Desktop only | Manual ZIP upload (below) | Manual: re-download from the rolling release and use the Skills UI's **Replace** option. See [Upgrading the standalone install](#upgrading-the-standalone-install) and [Staying notified of new versions](#staying-notified-of-new-versions) below. |
 
 The ZIPs are rebuilt automatically from the same source on every plugin version bump, so feature parity is maintained - only the update mechanism differs.
 
@@ -84,6 +84,27 @@ The ZIPs are rebuilt automatically from the same source on every plugin version 
 6. Confirm the skill appears under **Personal skills** with toggle on and **Trigger: Slash command + auto**.
 
 Claude Desktop has the same Skills uploader under Settings; the flow is analogous.
+
+### Upgrading the standalone install
+
+The Skills UI has a built-in **Replace** option - use it instead of uninstalling and re-uploading (Replace preserves any in-progress chats that reference the skill).
+
+1. Download the new `assess.zip` / `huddle.zip` from [standalone-skills-latest](https://github.com/bjcoombs/ai-native-toolkit/releases/tag/standalone-skills-latest).
+2. In Customize → Skills, click the skill you want to upgrade.
+3. Open the three-dot menu (⋮) in the top right of the detail pane.
+4. Click **Replace** and select the new `.zip`.
+5. The toggle and trigger settings persist; only the skill contents change.
+
+**Checking which version you have installed.** The skill's Description field in the Skills UI ends with `Standalone build vX.Y.Z` - that's the version that shipped in the ZIP you uploaded. Compare against the [latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest) to know if there's a newer one.
+
+### Staying notified of new versions
+
+Neither Claude Desktop nor claude.ai polls for skill updates - the platform has no notification mechanism for uploaded skills. Two opt-in ways to hear about new releases:
+
+- **GitHub Watch.** On the [repo page](https://github.com/bjcoombs/ai-native-toolkit), click **Watch → Custom → Releases**. You'll get an email (and a GitHub notification) whenever a new tag ships.
+- **Atom/RSS feed.** Subscribe to https://github.com/bjcoombs/ai-native-toolkit/releases.atom in any RSS reader (Reeder, Feedly, NetNewsWire, etc.).
+
+Plugin-install users get this for free via `/plugin update ai-native-toolkit` - no subscription needed.
 
 ### Verify the auto-trigger works
 

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -4,7 +4,10 @@ Per-skill configuration for the standalone skill ZIP build pipeline.
 Each entry in SKILLS maps a skill name to:
   standalone_name        — name field written into the ZIP's SKILL.md frontmatter
   standalone_description — description field (trigger-phrased for description-based
-                           auto-matching; no plugin namespacing)
+                           auto-matching; no plugin namespacing). The current
+                           plugin version + release URL are appended automatically
+                           at build time so users see which version they installed
+                           in the Skills UI and know where to check for updates.
   source_dir             — path relative to repo root
   replacements           — dict mapping chat-replace:KEY → replacement text
   exclude_dirs           — subdirectories omitted from the ZIP
@@ -12,6 +15,29 @@ Each entry in SKILLS maps a skill name to:
                            paths (relative to repo root). Markdown files have their
                            YAML frontmatter stripped during bundling.
 """
+
+import json
+from pathlib import Path
+
+
+def _plugin_version() -> str:
+    """Read the canonical version from .claude-plugin/plugin.json.
+
+    Standalone descriptions append this so users see the installed version
+    in the Skills UI and can compare against the latest release. Single
+    source of truth — drift impossible.
+    """
+    plugin_json = Path(__file__).parent.parent / ".claude-plugin" / "plugin.json"
+    return json.loads(plugin_json.read_text("utf-8"))["version"]
+
+
+VERSION = _plugin_version()
+RELEASES_URL = "https://github.com/bjcoombs/ai-native-toolkit/releases"
+VERSION_SUFFIX = (
+    f" Standalone build v{VERSION} — check {RELEASES_URL} for updates and "
+    "use the Skills UI's Replace option to upgrade in place."
+)
+
 
 SKILLS: dict[str, dict] = {
     "assess": {
@@ -22,6 +48,7 @@ SKILLS: dict[str, dict] = {
             "codebase assessment, complexity heatmap, migration risk triage, or 'how ready is "
             "this code for agents?'. Full script automation (SVG, deterministic core) requires "
             "terminal access; the layered assessment works in any context."
+            + VERSION_SUFFIX
         ),
         "source_dir": "skills/assess",
         "exclude_dirs": {"tests", "__pycache__", ".pytest_cache", ".venv"},
@@ -51,6 +78,7 @@ SKILLS: dict[str, dict] = {
             "to weigh a hard decision from several angles, or wanting panel/board deliberation. "
             "Scales from solo gut-check (1) to board-level deliberation (8+) using Fibonacci "
             "team sizing. Team mode with persistent agents requires the Claude Code CLI."
+            + VERSION_SUFFIX
         ),
         "source_dir": "skills/huddle",
         "exclude_dirs": set(),

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -347,6 +347,39 @@ def test_huddle_real_build_contains_all_hat_files(tmp_path):
             assert not body.startswith("---"), f"{hat}-hat.md still has frontmatter"
 
 
+def test_all_standalone_descriptions_include_version_and_release_url():
+    """Every standalone_description must include the version and release URL.
+
+    Surfaces the installed version in the Skills UI so users can self-check
+    against the latest release, and points them at the right page to look.
+    Drift between config and plugin.json is impossible because both flow
+    from _plugin_version(), but a future contributor could still write a
+    description without `+ VERSION_SUFFIX` — this test catches that.
+    """
+    from standalone_skill_config import SKILLS, VERSION, RELEASES_URL
+    for name, cfg in SKILLS.items():
+        desc = cfg["standalone_description"]
+        assert f"v{VERSION}" in desc, (
+            f"SKILLS['{name}'] description missing version — "
+            f"append `+ VERSION_SUFFIX` after the trigger text"
+        )
+        assert RELEASES_URL in desc, (
+            f"SKILLS['{name}'] description missing releases URL"
+        )
+
+
+def test_plugin_version_matches_plugin_json():
+    """_plugin_version() must agree with .claude-plugin/plugin.json."""
+    import json
+    from pathlib import Path
+    from standalone_skill_config import VERSION
+    plugin_json = Path(__file__).parent.parent.parent / ".claude-plugin" / "plugin.json"
+    expected = json.loads(plugin_json.read_text("utf-8"))["version"]
+    assert VERSION == expected, (
+        f"VERSION ({VERSION!r}) does not match plugin.json ({expected!r})"
+    )
+
+
 def test_huddle_plugin_source_retains_team_mode_infrastructure():
     """Plugin SKILL.md must keep the full team-mode flow.
 


### PR DESCRIPTION
## Summary

Driven by your screenshot of the Skills UI showing the **Replace** option, and the broader question: how does a standalone install know there's a new version?

### 1. Document the Replace flow

The Skills UI has a built-in Replace option (skill detail → ⋮ → Replace). It's better than uninstall + reinstall because it preserves in-progress chats. README's previous "re-download and re-upload" wording missed it. New subsection: **Upgrading the standalone install** walks through the exact UI path.

### 2. Make the installed version visible to users

`standalone_skill_config.py` now reads the version from `.claude-plugin/plugin.json` and appends `Standalone build vX.Y.Z - check https://github.com/bjcoombs/ai-native-toolkit/releases for updates and use the Skills UI's Replace option to upgrade in place.` to every standalone description. That sentence is visible in the Skills UI Description pane, so users can compare against the [latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest) at a glance.

**Drift is impossible by design.** `VERSION = _plugin_version()` reads `plugin.json` once at config-load time. Single source of truth. Two regression tests guard the assertion: every description must contain the version + URL; `VERSION` must match `plugin.json`.

### 3. Honest answer about notifications

Neither Claude Desktop nor claude.ai polls for skill updates - the platform has no notification mechanism for uploaded skills. New subsection: **Staying notified of new versions** lists the two opt-in channels available:
- GitHub Watch → Custom → Releases (email)
- Atom/RSS feed at `/releases.atom`

Plugin-install users get this for free via `/plugin update`.

## What I declined to do

- **Skill self-fetches latest release on invocation.** Possible but invasive - the skill would phone home every run, need network egress, and add latency. Bad UX. The visible-version approach gives users the same information passively.
- **Skill self-announces version when invoked.** Noisy. A skill that says "Running vX.Y.Z - check for updates" every run gets uninstalled fast.

## Version bump

`1.6.3 → 1.6.4` so the standalone ZIPs auto-rebuild with the version-surfacing descriptions on merge.

## Test plan

- [x] `cd scripts && uv run --with pytest pytest -q` - 52 tests pass (50 + 2 new)
- [x] `bash scripts/build-standalone-skills.sh` - both ZIPs build clean
- [x] `unzip -p assess.zip assess/SKILL.md | head -3` shows `Standalone build v1.6.4 - check https://github.com/...` at end of description
- [x] Same verified for huddle.zip
- [x] README renders cleanly, all 3 anchor links resolve

After merge: confirm in the Skills UI that the Description field shows the new "Standalone build v1.6.4" tail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Plugin version bumped to 1.6.4.

* **Documentation**
  * Updated upgrade instructions for standalone installations with manual ZIP update workflow.
  * Added guidance on checking installed version.
  * Added options for staying notified of new releases via GitHub Watch and RSS feeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->