### PR TITLE
fix: Restore CLI team mode in huddle skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ dist/standalone-skills/
 # Still ignore .DS_Store files everywhere
 **/.DS_Store
 
+# Python tooling artefacts under the allowlisted dirs above (scripts/, etc.)
+**/__pycache__/
+**/*.pyc
+**/.pytest_cache/
+**/.venv/
+**/uv.lock
+
 # Ignore nested CLAUDE.md files (e.g. user's personal config when they
 # clone this into ~/.claude/). The root /CLAUDE.md is re-allowlisted
 # below - it's the in-repo agent contract.

--- a/docs/superpowers/plans/2026-05-27-huddle-cli-team-mode-regression.md
+++ b/docs/superpowers/plans/2026-05-27-huddle-cli-team-mode-regression.md
@@ -1,0 +1,98 @@
+# Huddle CLI Team Mode Regression — PRD / Issue
+
+> **For agentic workers:** Implement on a worktree branched from `main` (e.g. `fix-huddle-cli-team-mode`). Suggested home for the committed copy of this doc: `docs/superpowers/plans/2026-05-27-huddle-cli-team-mode-regression.md`. Steps use checkbox (`- [ ]`) syntax for tracking. This is a **PATCH** bug fix (no user-facing feature change) — bump `.claude-plugin/plugin.json` `.version` in the same PR.
+
+**Type:** Bug (regression)
+**Severity:** High — the headline `/huddle` capability (team mode) is silently unreachable in the CLI, which is its primary surface.
+**Introduced by:** `docs/superpowers/plans/2026-05-23-standalone-skill-pipeline.md` (the marker-based dual-distribution refactor).
+**Affected skill:** `skills/huddle/SKILL.md`.
+
+---
+
+## Problem Statement
+
+In the Claude Code CLI, with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set and confirmed live, invoking `/huddle` on a size-2+ topic does **not** enter team mode (`TeamCreate` / `SendMessage` persistent agents). It silently degrades to phased sub-agent mode. Team mode is the skill's headline capability on its primary surface, so the regression is high-impact but invisible — no error is raised; the skill simply announces phased mode and proceeds.
+
+The flag is not the problem. The skill's own `SKILL.md` instructs the model that it is in a standalone build where team mode is unreachable, and the model correctly obeys its skill file.
+
+## Technical Context
+
+The standalone-skill pipeline treats the plugin `SKILL.md` as the authoritative source and derives the standalone ZIP from it via two transform operations (`scripts/transform_skill.py`):
+
+1. `strip_chat_skip()` — deletes everything between `<!-- chat-skip:start -->` / `<!-- chat-skip:end -->`.
+2. `apply_chat_replace()` — for each `<!-- chat-replace:KEY -->`, deletes the marker **and the line immediately after it**, substituting `replacements[KEY]` from `scripts/standalone_skill_config.py`.
+
+Critical property: **the transform only runs for the ZIP. The CLI plugin ships the raw, untransformed `SKILL.md`.** Therefore any standalone-specific wording written as plain body prose — i.e. text that is neither inside a `chat-skip` block nor positioned as a `chat-replace` default line — survives verbatim into the CLI build.
+
+The pipeline has no "standalone-only / strip-from-CLI" primitive. Standalone-divergent text must live in `standalone_skill_config.py` (`replacements`), never as visible body prose in `SKILL.md`.
+
+## Root Cause
+
+Three pieces of standalone-only wording were authored as content the **untransformed CLI copy** reads as live instruction. They override the (correctly `chat-skip`-fenced) team-mode logic above them. Line numbers are indicative as of 2026-05-27 and may drift — match on the quoted text.
+
+| # | Location | Text the CLI reads verbatim | Why it breaks CLI |
+|---|----------|------------------------------|-------------------|
+| 1 | ~line 30, unguarded paragraph after a `chat-skip:end` | "Two execution modes are reachable in **this standalone build**… Team mode (persistent agents with cross-talk) is only available in the Claude Code CLI and is **not reachable from here**." | Not inside any guard → present in the CLI copy. Directly tells the model team mode is off. |
+| 2 | ~line 39, unguarded table row after a `chat-skip:end` | "\| **Team mode** \| Size 2+, **Claude Code only** \| … **not available in standalone context** \| — \|" | Unguarded duplicate of the correctly-fenced team-mode row (~line 37, inside `chat-skip`) → contradictory mode table. |
+| 3 | ~lines 53–54, the `chat-replace:capability-detection` **default line** | "**Tell the user which mode you're in** before you start. One line: \"Running in **phased sub-agent mode** (3 lenses, 5 phases — Agent Teams flag **not detected**).\"" | The line-after-marker is the CLI default (the standalone wording is injected from config for the ZIP). It was authored with standalone wording, so the CLI hardcodes "announce phased mode." |
+
+Leak #3 is the decisive one: `standalone_skill_config.py` already holds the correct standalone replacement for `capability-detection`; the SKILL.md default line should have been the **CLI** instruction (detect the Agent Teams capability and announce team mode when present) but is instead a near-copy of the standalone text.
+
+The correctly-fenced team-mode logic (the three-mode rule, the `Size 2+ AND flag enabled → Team Mode` branch row, and Steps 2–4/6) is all still present inside `chat-skip` blocks — it is simply overridden in the model's reading by these louder, declarative standalone sentences.
+
+### Why it used to work
+
+The previous local-only `huddle` skill was CLI-only, with no standalone variant text. Merging both distributions into one marker-driven source moved standalone prose into the shared body. The transform strips/swaps it correctly for the ZIP, but the CLI reads the raw file with the standalone sentences intact.
+
+## Process Gap
+
+`scripts/tests/test_integration.py` validates forbidden strings in the **ZIP** output. Nothing validates the **CLI source** (`skills/<name>/SKILL.md` as shipped, untransformed) for leaked standalone wording. This entire bug class — standalone prose authored as body text — is currently untested. A guard that greps the raw source for standalone-only phrases would have caught this and will prevent recurrence.
+
+## Solution Requirements
+
+1. The CLI `skills/huddle/SKILL.md` (untransformed) must contain only CLI-correct capability text: it must describe detecting the Agent Teams capability and, when present at team size ≥ 2, entering team mode.
+2. The standalone ZIP must remain unchanged in behaviour (still announces phased sub-agent mode for size 2+) — the existing `replacements["capability-detection"]` already provides this; do not regress it.
+3. All standalone-divergent wording must live in `scripts/standalone_skill_config.py`, not in `SKILL.md` body prose.
+4. A test must assert the raw CLI source is free of standalone-only assertions, so this bug class cannot silently return.
+
+## Proposed Fix
+
+Convert each of the three leaks so the CLI copy is correct and the standalone wording is supplied by config:
+
+- [ ] **Leak #3 (capability-detection default line):** rewrite the line after `<!-- chat-replace:capability-detection -->` to CLI-correct instruction, e.g.:
+  > "Tell the user which mode you're in before starting. Check whether the Agent Teams capability is available (`TeamCreate` / `SendMessage`). If it is and team size ≥ 2, announce team mode (one line, e.g. \"Running in team mode — 3 professional lenses, 5 phases\"). Otherwise announce phased sub-agent mode."
+
+  Leave `replacements["capability-detection"]` in `standalone_skill_config.py` untouched (it correctly injects the standalone wording for the ZIP).
+
+- [ ] **Leak #1 (unguarded "standalone build" paragraph):** remove the standalone assertion from the body. Either (a) rely on the existing `chat-skip` three-mode block for CLI and convert this paragraph into a `chat-replace` whose default line is a neutral CLI summary with the standalone sentence moved to `replacements`; or (b) wrap it appropriately so it cannot appear in the CLI copy. The CLI must not read "this standalone build" or "not reachable from here."
+
+- [ ] **Leak #2 (unguarded "Claude Code only" table row):** drop the duplicate row (the `chat-skip`-fenced team-mode row already covers CLI) or convert it to `chat-replace` with a CLI-correct default and the standalone row text moved to `replacements`. The CLI mode table must list team mode as reachable when the flag is enabled.
+
+- [ ] **Sweep:** re-read the full `skills/huddle/SKILL.md` for any other body prose asserting standalone/phased-only behaviour that is not `chat-skip`-fenced or a `chat-replace` default. Apply the same treatment.
+
+- [ ] **Guard test:** add a test (alongside `scripts/tests/test_integration.py`) asserting the **raw, untransformed** `skills/huddle/SKILL.md` does not contain standalone-only phrases — candidate forbidden list: `"standalone build"`, `"not reachable from here"`, `"flag not detected"`, `"Claude Code only"`, `"not available in standalone"`. Assert positively too: the raw source must contain the team-mode branch (e.g. the `TeamCreate` / `Size 2+ … Team Mode` path). Consider generalising to all skills, not just huddle.
+
+- [ ] **Rebuild + validate:** `cd scripts && uv run --with pytest pytest -v`, then `bash scripts/build-standalone-skills.sh huddle` and confirm the ZIP still strips correctly (no orphan markers, standalone capability text intact).
+
+- [ ] **Version bump:** PATCH bump in `.claude-plugin/plugin.json` in the same PR (per repo CLAUDE.md versioning rules), so `/plugin update` surfaces the fix.
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `skills/huddle/SKILL.md` | Fix the three leaks; ensure CLI copy is team-mode-correct |
+| Modify | `scripts/standalone_skill_config.py` | Hold any standalone wording relocated out of the body (if leaks #1/#2 converted to `chat-replace`) |
+| Create | `scripts/tests/test_cli_source.py` (or extend `test_integration.py`) | Guard: raw CLI source free of standalone-only phrases; team-mode path present |
+| Modify | `.claude-plugin/plugin.json` | PATCH version bump |
+
+## Success Criteria
+
+- In the CLI with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, `/huddle <size-2+ topic>` announces and enters team mode (`TeamCreate` is called).
+- Without the flag, `/huddle` still degrades cleanly to phased sub-agent mode in the CLI.
+- The standalone ZIP build is unchanged: size-2+ still announces phased sub-agent mode; no orphan markers; capability text intact.
+- New guard test fails against the current (buggy) source and passes after the fix.
+- `cd scripts && uv run --with pytest pytest -v` green; PATCH version bumped.
+
+## Risk Assessment
+
+Low. Markdown-only change to one skill file plus a test and a version bump; no executable runtime affected. Main risk is asymmetric drift between CLI and ZIP wording — the new guard test plus the existing ZIP forbidden-string test together pin both surfaces. Verify by reading the rebuilt ZIP's `SKILL.md` and by a live `/huddle` in a flag-enabled CLI session.

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -104,6 +104,17 @@ SKILLS: dict[str, dict] = {
                 "phases — standalone build, team mode not available).\""
             ),
             "branch-phased-row": "| Size 2+ | **Phased Sub-Agent Mode** (below) |",
+            "execution-mode-rule": (
+                "Two execution modes are reachable in this standalone build. "
+                "Pick one deterministically: team size = 1 → solo flat-parallel; "
+                "team size ≥ 2 → phased sub-agent mode. Team mode (persistent "
+                "agents with cross-talk) is only available in the Claude Code CLI "
+                "and is not reachable from here."
+            ),
+            "team-mode-row": (
+                "| **Team mode** | Size 2+, Claude Code only | Persistent agents "
+                "with cross-talk — not available in standalone context | — |"
+            ),
         },
         # Bundle the hat methodology files inside the ZIP so standalone-mode
         # sub-agents can read them via relative paths. Without this they'd

--- a/scripts/tests/test_cli_source.py
+++ b/scripts/tests/test_cli_source.py
@@ -1,0 +1,77 @@
+"""
+Guard tests for the RAW (untransformed) plugin SKILL.md sources.
+
+The standalone ZIP pipeline transforms each SKILL.md for chat / Cowork, but the
+Claude Code CLI ships the raw source unchanged. Any standalone-only wording
+written as plain body prose — i.e. text that is neither inside a chat-skip
+block nor positioned as a chat-replace default line — therefore survives
+verbatim into the CLI build, where the model reads and obeys it.
+
+This bit /huddle: standalone "team mode is not reachable" assertions leaked into
+the CLI source and silently disabled CLI team mode (the skill's headline
+capability) even with the Agent Teams flag live. test_integration.py only
+checks the ZIP output; nothing checked the raw source. These tests close that
+gap so the bug class cannot return.
+"""
+from pathlib import Path
+
+import pytest
+
+from standalone_skill_config import SKILLS
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Phrases that are only true in the standalone (chat / Cowork) build. If any
+# appears in a raw SKILL.md it ships to the CLI, where it is false and overrides
+# the live capability-detection logic.
+STANDALONE_ONLY_PHRASES = [
+    "standalone build",
+    "not reachable from here",
+    "not available in standalone",
+    "Claude Code only",
+]
+
+
+def _raw_skill_md(skill_name: str) -> str:
+    cfg = SKILLS[skill_name]
+    return (REPO_ROOT / cfg["source_dir"] / "SKILL.md").read_text("utf-8")
+
+
+@pytest.mark.parametrize("skill_name", sorted(SKILLS))
+def test_no_standalone_only_phrases_in_raw_source(skill_name):
+    raw = _raw_skill_md(skill_name)
+    leaked = [phrase for phrase in STANDALONE_ONLY_PHRASES if phrase in raw]
+    assert not leaked, (
+        f"{skill_name}/SKILL.md ships raw to the CLI and contains standalone-only "
+        f"wording {leaked}. Move it into standalone_skill_config.py replacements "
+        f"behind a chat-replace marker; the CLI default line must be CLI-correct."
+    )
+
+
+@pytest.mark.parametrize("skill_name", sorted(SKILLS))
+def test_standalone_replacements_not_in_raw_source(skill_name):
+    """Each replacement value is the STANDALONE wording. If it also appears in
+    the raw source, the CLI default line was authored as standalone text instead
+    of the CLI variant — exactly the leak that broke huddle team mode."""
+    cfg = SKILLS[skill_name]
+    raw = _raw_skill_md(skill_name)
+    leaked = [
+        key
+        for key, value in cfg.get("replacements", {}).items()
+        if value.strip() and value in raw
+    ]
+    assert not leaked, (
+        f"{skill_name}/SKILL.md contains the standalone replacement text for "
+        f"{leaked} verbatim. The line after a chat-replace marker is the CLI "
+        f"default and must differ from the config replacement."
+    )
+
+
+def test_huddle_raw_source_keeps_cli_team_mode_path():
+    """The CLI source must positively describe the team-mode path, so a future
+    edit cannot quietly strip it while still passing the negative checks."""
+    raw = _raw_skill_md("huddle")
+    assert "TeamCreate" in raw, "CLI team-mode infrastructure missing from raw huddle source"
+    assert "flag enabled" in raw, (
+        "CLI team-mode branch (Size 2+, flag enabled → team mode) missing from raw huddle source"
+    )

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -18,25 +18,15 @@ Scales from a solo gut check to a board-level deliberation using Fibonacci team 
 
 ## Capability Requirements
 
-<!-- chat-skip:start -->
-Three execution modes exist. Pick one **deterministically** by this rule, in order:
-
-1. If team size = 1 → **Solo flat-parallel**.
-2. If team size ≥ 2 AND you can confirm the team-mode capability is available in your environment → **Team mode**.
-3. Otherwise (team size ≥ 2 and you cannot confirm team mode) → **Phased sub-agent mode**.
-
-If you're unsure whether team mode is available, default to phased — do not guess it's on. Phased mode degrades gracefully; attempting team mode without the capability fails loudly.
-<!-- chat-skip:end -->
-Two execution modes are reachable in this standalone build. Pick one deterministically: team size = 1 → solo flat-parallel; team size ≥ 2 → phased sub-agent mode. Team mode (persistent agents with cross-talk) is only available in the Claude Code CLI and is not reachable from here.
+<!-- chat-replace:execution-mode-rule -->
+Three execution modes exist. Pick one **deterministically**: team size = 1 → **solo flat-parallel**; team size ≥ 2 AND you can confirm the team-mode capability (`TeamCreate` / `SendMessage`) is available → **team mode**; otherwise → **phased sub-agent mode**. If you cannot confirm team mode, default to phased — it degrades gracefully, whereas attempting team mode without the capability fails loudly.
 
 | Mode | When chosen | Mechanism | Cost (relative) |
 |------|-------------|-----------|----------------|
 | **Solo flat-parallel** | Size 1 | Hat agents fire in parallel via standard Agent tool; Blue Hat synthesises | 1× |
 | **Phased sub-agent** | Size 2+, no flag | Iterate phases sequentially; spawn N sub-agents per phase (one per lens), each with fresh context, briefed via a running synopsis Blue Hat maintains | 2–4× |
-<!-- chat-skip:start -->
+<!-- chat-replace:team-mode-row -->
 | **Team mode** | Size 2+, flag enabled | Persistent `TeamCreate` agents cross-talk via `SendMessage` across phases | 5–15× |
-<!-- chat-skip:end -->
-| **Team mode** | Size 2+, Claude Code only | Persistent agents with cross-talk — not available in standalone context | — |
 
 <!-- chat-skip:start -->
 **Agent Teams flag** enables `TeamCreate`, `SendMessage`, and related tools. Enable in your environment:
@@ -51,7 +41,7 @@ Without the flag, `/huddle` still runs multi-perspective deliberations via phase
 <!-- chat-skip:end -->
 
 <!-- chat-replace:capability-detection -->
-**Tell the user which mode you're in** before you start. One line: "Running in phased sub-agent mode (3 lenses, 5 phases — Agent Teams flag not detected)."
+**Tell the user which mode you're in** before you start. If the Agent Teams capability (`TeamCreate` / `SendMessage`) is available and team size ≥ 2, announce team mode — one line, e.g. "Running in team mode (3 professional lenses, 5 phases — persistent agents)." Otherwise announce phased sub-agent mode, e.g. "Running in phased sub-agent mode (3 lenses, 5 phases)."
 
 ## No Arguments Behavior
 


### PR DESCRIPTION
## Summary

In the Claude Code CLI, `/huddle` on a size-2+ topic silently degraded to phased sub-agent mode even with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set and confirmed live. Team mode (`TeamCreate` / persistent agents) is the skill's headline capability on its primary surface, so the regression was high-impact but invisible — no error, the skill just announced phased mode and proceeded.

The flag was never the problem. The standalone-skill pipeline transforms `SKILL.md` only for the ZIP; the **CLI ships the raw, untransformed source**. Three pieces of standalone-only wording were authored as plain body prose — neither `chat-skip`-fenced nor positioned as a `chat-replace` default line — so they survived verbatim into the CLI build and overrode the (correctly fenced) team-mode logic.

Introduced by the marker-based dual-distribution refactor (`docs/superpowers/plans/2026-05-23-standalone-skill-pipeline.md`).

## Changes Made

| Leak | CLI read (verbatim) | Fix |
|------|---------------------|-----|
| Execution-modes paragraph | "Two execution modes are reachable in **this standalone build** … team mode … **not reachable from here**" | `chat-replace:execution-mode-rule` — CLI default states the three-mode rule (team mode reachable when capability confirmed); standalone text moved to config |
| Cost-table team row | "\| Team mode \| Size 2+, **Claude Code only** … **not available in standalone context** \|" | `chat-replace:team-mode-row` — CLI default marks team mode reachable with the flag; standalone row moved to config |
| `capability-detection` default | hardcoded "Running in **phased sub-agent mode** … flag **not detected**" | rewritten to detect the Agent Teams capability and announce team mode at size ≥ 2, else phased. Config replacement already held the correct standalone wording and is untouched |

Plus: a guard test, a PATCH version bump (`1.7.0 → 1.7.1`), and a `.gitignore` rule for Python tooling artefacts.

## Technical Details

The pipeline has no "strip-from-CLI" primitive — standalone-divergent text must live in `scripts/standalone_skill_config.py` `replacements`, never as body prose. Each leak is now a single `chat-replace`: the line after the marker is the CLI-correct default, and the standalone wording is supplied from config for the ZIP. The two new replacements (`execution-mode-rule`, `team-mode-row`) reproduce the previous standalone text exactly.

## Testing

- `cd scripts && uv run --with pytest pytest` — **57 passed** (5 new in `test_cli_source.py`).
- New guard `test_no_standalone_only_phrases_in_raw_source` **fails on the pre-fix source** (4 forbidden-phrase hits in the old `huddle/SKILL.md`) and **passes after the fix** (0).
- `test_standalone_replacements_not_in_raw_source` asserts no config replacement value is duplicated into the raw source (the exact leak shape).
- Rebuilt the standalone ZIP and diffed against baseline: the SKILL.md **body is byte-identical**; the only change is the auto-appended version suffix (`v1.7.0 → v1.7.1`).

## Risk Assessment

Low. Markdown-only change to one skill file plus a test, a version bump, and a `.gitignore` rule; no executable runtime affected. The new raw-source guard and the existing ZIP forbidden-string test together pin both surfaces against asymmetric drift. Recommend a live `/huddle <size-2+ topic>` in a flag-enabled CLI session to confirm `TeamCreate` is reached.

## Deployment Notes

PATCH bump surfaces the fix via `/plugin update`. The standalone-ZIP build workflow will rebuild `standalone-skills-latest` on merge (version changed); ZIP behaviour is unchanged. Locally-installed marketplace copies need `/plugin update` to pick up the fix.

Implements `docs/superpowers/plans/2026-05-27-huddle-cli-team-mode-regression.md` (added in this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/huddle` regression where team mode silently degraded to phased sub-agent mode in the CLI. The skill now correctly detects team-mode capability and announces the execution mode being used.

* **Tests**
  * Added tests to prevent CLI source contamination from standalone-only language.

* **Documentation**
  * Updated huddle skill execution rules and mode selection logic.

* **Chores**
  * Bumped version to 1.7.1; updated gitignore for Python artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->