### PR TITLE
fix(huddle): send team-mode messages per-recipient, not broadcast

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-7 layered contract model) and generates a Codecov-style complexity hotspot SVG. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/docs/superpowers/plans/2026-05-27-huddle-broadcast-per-recipient.md
+++ b/docs/superpowers/plans/2026-05-27-huddle-broadcast-per-recipient.md
@@ -1,0 +1,114 @@
+# Huddle Team-Mode Broadcast Incompatibility — PRD / Issue
+
+**Type:** Bug
+**Severity:** High for team-mode users — facilitation stalls mid-meeting. Zero impact on standalone ZIP and on size-1 solo mode.
+**Affected file:** `skills/huddle/SKILL.md` (team-mode sections only).
+**Surfaced:** during an end-to-end size-2 team-mode run on 2026-05-27, immediately after the PR #30 CLI-team-mode fix. Worked around live by sending per-recipient; the skill text was not changed.
+**Status:** Implemented on branch `fix/huddle-broadcast-per-recipient` (branched from `main` at the PR #30 tip). Plugin bumped 1.7.1 → 1.7.2.
+
+---
+
+## Problem Statement
+
+The current Agent Teams runtime rejects fan-out broadcasts. A `SendMessage` with `to: "*"` returns:
+
+```
+broadcast (to: "*") is no longer supported — send a message per recipient
+```
+
+The huddle skill still instructs both the chair (Blue Hat) and the team members to broadcast with `to: "*"`. In team mode this means:
+
+- **Chair → team** phase announcements (Step 4a) and phase transitions (Step 4c) fail to send.
+- **Member → team** sharing of findings (Step 3 member-prompt template) fails to send.
+
+The net effect: in a real team-mode huddle, phases never get announced and members can't share findings, so the meeting cannot progress without manual per-recipient intervention. Static inspection does not reveal this — only an end-to-end team-mode run does.
+
+## Technical Context
+
+The skill was authored against an earlier Agent Teams API that supported `to: "*"` fan-out. The API changed to require one `SendMessage` per named recipient. The skill's team-mode instructions were not updated.
+
+All four occurrences are inside `chat-skip` blocks, so they ship **only** in the CLI plugin (team mode) and are stripped from the standalone ZIP. Confirmed sites (line numbers indicative as of installed 1.7.1 — match on context):
+
+| Line | Section | Current text |
+|------|---------|--------------|
+| ~184 | Step 3 — member prompt, IMMEDIATE FIRST TASK | "share your key findings with the team via `SendMessage(to="*")`" |
+| ~195 | Step 3 — member prompt, How Subsequent Phases Work | "**Share findings** via `SendMessage(to="*")`" |
+| ~232 | Step 4a — chair phase announcement | `SendMessage(to: "*", …)` |
+| ~259 | Step 4c — chair phase transition | `SendMessage(to: "*", …)` |
+
+Because all sites are `chat-skip`-wrapped, **no `standalone_skill_config.py` change is required** and the standalone ZIP build is unaffected.
+
+## Root Cause
+
+Reliance on a removed broadcast primitive (`to: "*"`). Sends must now be addressed to a specific teammate name. Replacing a broadcast requires the sender to know the recipient names — straightforward for the chair (it spawned everyone), but members need the roster supplied to them.
+
+## Design Decision (the substantive part)
+
+Two distinct senders need fixing differently:
+
+**Chair → members (Steps 4a, 4c):** the chair knows every member's name. Replace each broadcast with a loop that sends the identical message to each member individually.
+
+**Members → peers (Step 3):** a member must share findings with the team without broadcast. Options:
+
+- **(a) Chair supplies the roster.** The chair includes the full list of member names in each spawn prompt (Step 3) and in phase announcements; members send findings to each named peer individually. *Recommended.*
+- **(b) Members self-discover.** Members `Read('~/.claude/teams/{team}/config.json')` to enumerate `members[].name`, then send per-peer. Keep as a fallback note for members that weren't given a roster.
+- **(c) Members send only to the chair, who relays.** Rejected — violates the skill's "Be a Chair, Not a Switchboard" principle.
+
+**Recommendation: (a), with (b) as a documented fallback.** Fibonacci sizing keeps N small (≤5 typical), so per-peer fan-out is a handful of messages per share, not a scaling problem. Preserve peer-to-peer discussion — members still talk directly to each other, just addressed per-recipient instead of via broadcast.
+
+## Solution Requirements
+
+1. No `SendMessage(to: "*")` (or `to="*"`) anywhere in the skill.
+2. Chair sends phase announcements and transitions to each member by name (Steps 4a, 4c) — show the per-recipient loop explicitly in the example.
+3. Members share findings to each named peer individually; the chair must supply the roster in spawn prompts (Step 3) and in phase announcements. Document the team-config self-discovery fallback.
+4. Preserve the "don't relay / chair is not a switchboard" facilitation principle — members continue to talk peer-to-peer.
+5. Update the "Control Pacing" message-budget guidance so the math accounts for per-peer fan-out (a single "share" is now N−1 sends).
+6. Standalone ZIP behaviour and build output must remain unchanged (sites are already `chat-skip`-only; verify after edits).
+
+## Proposed Fix
+
+- [x] **Step 4a / 4c (chair):** replace the `to: "*"` broadcast examples with a per-recipient send — e.g. "send this announcement to each member individually (one `SendMessage` per name): `SendMessage(to: "<member-name>", …)`."
+- [x] **Step 3 (member template):** change the two `SendMessage(to="*")` instructions to "send to each of your named peers individually." Add the roster into the spawn-prompt template (a `## Your Teammates` line listing names) and note the `~/.claude/teams/{team}/config.json` fallback.
+- [x] **Facilitation Principles / Control Pacing:** add a sentence that a "share" now fans out to N−1 per-recipient sends, and keep the existing 2–3 substantive messages per member per phase ceiling.
+- [x] **Lessons Learned:** add a one-liner — "Broadcast (one message to all teammates at once) is unsupported; address each teammate by name."
+- [x] **Static guard:** extend `tests/test_cli_source.py` to assert `skills/huddle/SKILL.md` contains no `to: "*"` / `to="*"`. Cheap, and prevents regression (live team mode can't be unit-tested, so this static check is the guardrail).
+- [x] **Version bump:** PATCH bump in `.claude-plugin/plugin.json` (1.7.1 → 1.7.2).
+- [x] **Validate:** `cd scripts && uv run --with pytest pytest -v` (new assert green); rebuild the ZIP and confirm no diff in standalone output.
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `skills/huddle/SKILL.md` | Steps 3, 4a, 4c per-recipient; roster in spawn prompt; pacing + lessons notes |
+| Modify | `scripts/tests/test_cli_source.py` | Add assert: no `to: "*"` in the CLI source |
+| Modify | `.claude-plugin/plugin.json` | PATCH version bump |
+
+## Success Criteria
+
+- A live team-mode huddle (size ≥ 2) completes all phases with no broadcast-rejection errors; chair announcements and member shares are all delivered per-recipient.
+- Peer-to-peer discussion is preserved (no chair relaying).
+- New static assert fails against the current source and passes after the fix.
+- Standalone ZIP build output is byte-unchanged; full suite green.
+- PATCH version bumped.
+
+## Risk Assessment
+
+Low. Markdown-only change confined to the team-mode (`chat-skip`) path; solo and standalone surfaces untouched. Main residual concern is per-peer fan-out verbosity at larger team sizes — mitigated by Fibonacci sizing and the tightened message budget. Roster drift (a member added mid-run) is rare and chair-controlled; the config self-discovery fallback covers it.
+
+## Companion Item
+
+A sibling cosmetic fix from the same review — the `continue to Step 2` dangling line leaking into the standalone ZIP — is captured separately in `2026-05-27-huddle-cli-team-mode-regression-prd.md` follow-ups. This broadcast fix is the higher-impact of the two.
+
+---
+
+## Implementation Notes (added at implementation time, 2026-05-27)
+
+Two places where the PRD as written was internally inconsistent, and how each was resolved:
+
+1. **`to: "*"` literal in the Lessons one-liner vs. Requirement 1.** Requirement 1 ("no `to: "*"` anywhere") and the proposed Lessons one-liner (which quoted the literal `to: "*"`) conflict. Resolved in favour of the absolute rule: the literal is banned even in "don't do this" prose, so the static guard is a dead-simple substring check with no usage-vs-mention exceptions to get wrong. Explanatory mentions were reworded ("all-recipients broadcast" / "one message to all teammates at once").
+
+2. **"Byte-unchanged" standalone ZIP vs. the version bump.** The standalone build injects the plugin version into the skill `description` (the update-awareness feature from PR #29), so a PATCH bump necessarily changes one line of standalone output (`Standalone build v1.7.1` → `v1.7.2`). Verified by building huddle from `main` and from this branch and diffing: the **only** difference is that version string. The substantive skill body is byte-identical, confirming the broadcast fixes are entirely within `chat-skip` blocks.
+
+Additionally, the new Control Pacing and Lessons Learned sentences reference `SendMessage` (a Claude Code–only tool) and were therefore wrapped in `chat-skip` markers per the repo's marker convention — keeping them out of the standalone build, which has no team mode.
+
+**Branch note:** the original PRD suggested landing on the existing `huddle-cleanup-followups` branch. That branch was already merged (PR #4) and stale (predated the PR #30 team-mode fix this bug builds on), so a fresh `fix/huddle-broadcast-per-recipient` branch was cut from current `main` instead — consistent with the PRD's primary instruction ("worktree branched from `main`").

--- a/scripts/tests/test_cli_source.py
+++ b/scripts/tests/test_cli_source.py
@@ -31,6 +31,15 @@ STANDALONE_ONLY_PHRASES = [
     "Claude Code only",
 ]
 
+# The Agent Teams runtime removed fan-out broadcast: a SendMessage with to="*"
+# is rejected ("broadcast (to: "*") is no longer supported — send a message per
+# recipient"). Any raw SKILL.md instructing a broadcast ships to the CLI and
+# stalls a live team-mode run — phases never get announced and findings never
+# get shared. Sends must be addressed to a named recipient, so the literal is
+# banned outright (even in "don't do this" prose), keeping this a dead-simple
+# substring guard with no usage-vs-mention exceptions to get wrong.
+BROADCAST_LITERALS = ['to: "*"', 'to="*"']
+
 
 def _raw_skill_md(skill_name: str) -> str:
     cfg = SKILLS[skill_name]
@@ -64,6 +73,21 @@ def test_standalone_replacements_not_in_raw_source(skill_name):
         f"{skill_name}/SKILL.md contains the standalone replacement text for "
         f"{leaked} verbatim. The line after a chat-replace marker is the CLI "
         f"default and must differ from the config replacement."
+    )
+
+
+@pytest.mark.parametrize("skill_name", sorted(SKILLS))
+def test_no_broadcast_literal_in_raw_source(skill_name):
+    """No SKILL.md may instruct a fan-out broadcast. to="*" was removed from the
+    Agent Teams runtime; a broadcast send is rejected and a live team-mode huddle
+    stalls. Both chair and members must address each teammate by name."""
+    raw = _raw_skill_md(skill_name)
+    leaked = [literal for literal in BROADCAST_LITERALS if literal in raw]
+    assert not leaked, (
+        f"{skill_name}/SKILL.md contains broadcast literal(s) {leaked}. The Agent "
+        f"Teams runtime rejects to=\"*\"; send one SendMessage per named recipient. "
+        f"Remove the literal even from explanatory prose (reword to e.g. "
+        f"'all-recipients broadcast')."
     )
 
 

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -151,7 +151,9 @@ TeamCreate(
 
 Spawn ALL members in parallel (single message with multiple Agent tool calls). Each member is a general-purpose agent with their professional identity and **explicit first-phase instructions**.
 
-**CRITICAL**: Include the first hat phase instructions directly in the spawn prompt. Do NOT send a separate broadcast to start the first phase - members should begin investigating immediately after reading the source material. This eliminates the idle-then-nudge cycle that wastes time.
+**CRITICAL**: Include the first hat phase instructions directly in the spawn prompt. Do NOT send a separate message to start the first phase - members should begin investigating immediately after reading the source material. This eliminates the idle-then-nudge cycle that wastes time.
+
+**Supply the roster.** There is no broadcast — members share findings by sending one `SendMessage` per teammate. So each spawn prompt must list that member's peers by name (the `## Your Teammates` line in the template below). You're spawning everyone, so you know all the names; give each member the others.
 
 For each member, use the Agent tool:
 
@@ -175,13 +177,17 @@ You are a [PROFESSIONAL ROLE] participating in a Six Thinking Hats team meeting 
 
 You are a [ROLE] with deep expertise in [DOMAIN]. This identity persists across ALL phases of the meeting. You see everything through the lens of your professional experience.
 
+## Your Teammates
+
+[ROSTER — the chair lists every other member's name slug here, e.g. "security-eng, product-mgr, sre".] You share findings by sending one `SendMessage` per teammate name; there is no broadcast. If this roster is missing, read `~/.claude/teams/{team}/config.json` and use `members[].name` (excluding yourself) as your peer list.
+
 ## IMMEDIATE FIRST TASK
 
 Read [SOURCE FILES]. Then immediately begin the [FIRST HAT COLOR] Hat phase:
 
 1. Spawn the [hat-color]-hat agent: Agent(subagent_type="[hat-color]-hat", prompt="As a [ROLE] investigating [TOPIC], focus on [SPECIFIC LENS-SHAPED QUESTIONS]. Read [SOURCE FILES] and investigate: [2-3 CONCRETE QUESTIONS FROM YOUR LENS].")
 
-2. When the agent returns, share your key findings with the team via SendMessage(to="*"). Lead with what's most important from your professional perspective.
+2. When the agent returns, share your key findings with each teammate individually — one `SendMessage(to: "<teammate-name>", …)` per name on your roster (broadcast is unsupported). Lead with what's most important from your professional perspective.
 
 3. Read what other team members share. Respond directly to specific members via SendMessage when you see something they missed, want to build on their observation, disagree based on your expertise, or have a question.
 
@@ -192,7 +198,7 @@ Read [SOURCE FILES]. Then immediately begin the [FIRST HAT COLOR] Hat phase:
 Blue Hat (the team lead) will announce each new phase. When announced:
 
 1. **Spawn the hat agent** with a prompt shaped by YOUR professional lens
-2. **Share findings** via SendMessage(to="*")
+2. **Share findings** with each teammate individually — one `SendMessage` per name on your roster (no broadcast)
 3. **Discuss with peers** — 2-3 substantive messages max per phase
 4. **Follow Blue's direction** — when Blue says move on, move on
 
@@ -225,11 +231,12 @@ For each hat in your chosen sequence, facilitate a phase:
 
 **4a. Announce the phase**
 
-Note: The first phase is embedded in the member spawn prompts (Step 3). For subsequent phases, send a broadcast:
+Note: The first phase is embedded in the member spawn prompts (Step 3). For subsequent phases, send the identical announcement to each member individually — one `SendMessage` per member name (there is no all-recipients broadcast). You spawned the team, so you already know every name:
 
 ```
+for each <member-name> in your team:
 SendMessage(
-  to: "*",
+  to: "<member-name>",
   message: "[HAT COLOR] Hat phase. [Framing question for this phase].
 
   Spawn the [hat-color]-hat agent with a prompt shaped by your professional expertise. Share your findings, then discuss with your peers.
@@ -252,11 +259,12 @@ As messages come in from team members:
 
 **4c. Move to next phase**
 
-Move on when you have findings from at least N-1 members (e.g., 2 of 3). Do not wait indefinitely for every member. Announce the transition with a summary:
+Move on when you have findings from at least N-1 members (e.g., 2 of 3). Do not wait indefinitely for every member. Announce the transition to each member individually — one `SendMessage` per member name (there is no all-recipients broadcast):
 
 ```
+for each <member-name> in your team:
 SendMessage(
-  to: "*",
+  to: "<member-name>",
   message: "[1-2 sentence summary of key takeaway from this phase]. Moving to [NEXT HAT] phase.
 
   [Specific framing questions informed by what was just surfaced]",
@@ -340,6 +348,9 @@ After delivering the verdict:
 
 ### Control Pacing
 - Max ~2-3 substantive messages per member per phase
+<!-- chat-skip:start -->
+- In team mode each "share" fans out to N-1 per-recipient sends (no broadcast), so the wire traffic is the message count times N-1 — keep the per-member ceiling tight and rely on Fibonacci sizing to keep N small
+<!-- chat-skip:end -->
 - Extend if the dialogue is producing genuine insight
 - Cut short if responses are repetitive or circular
 - **Move on after N-1 members have contributed** - don't block on stragglers
@@ -361,6 +372,9 @@ After delivering the verdict:
 - **Move on without stragglers.** One nudge per straggler. If they don't respond, proceed with N-1 findings.
 - **Concrete phase prompts.** "The dunning race condition is the biggest risk - how do we fix it?" produces action. "What are the risks?" produces confusion.
 - **Red Hat after White is a natural pairing.** Facts first, then gut check - grounds intuition in evidence.
+<!-- chat-skip:start -->
+- **Broadcast — one message to all teammates at once — is unsupported; address each teammate by name.** In team mode both the chair and members send one `SendMessage` per recipient, so every member needs the roster of peer names in its spawn prompt.
+<!-- chat-skip:end -->
 
 ## Usage
 `/huddle [topic or problem to analyze]`


### PR DESCRIPTION
## Summary

The Agent Teams runtime removed fan-out broadcast — a `SendMessage` addressed to all recipients is now rejected with *"broadcast is no longer supported — send a message per recipient"*. The `/huddle` skill still instructed both the chair (Blue Hat) and team members to broadcast, so in a live team-mode run **phase announcements never sent and members could not share findings**: the meeting stalled and required manual per-recipient intervention. Surfaced during an end-to-end size-2 team-mode run, immediately after the PR #30 team-mode restoration.

All four broadcast sites are inside `chat-skip` blocks, so only the CLI team-mode path was affected. The standalone ZIP and size-1 solo mode were never impacted.

## Changes Made

- **Chair (Steps 4a, 4c)** — phase announcements and transitions now send one `SendMessage` per member name, shown as an explicit per-recipient loop. The chair spawned the team, so it already knows every name.
- **Member template (Step 3)** — members share findings to each named peer individually. Added a `## Your Teammates` roster line that the chair populates in each spawn prompt, plus a `~/.claude/teams/{team}/config.json` self-discovery fallback for members that weren't given one.
- **Control Pacing / Lessons Learned** — added a note that a "share" now fans out to N−1 per-recipient sends, keeping the 2–3 substantive-messages-per-member-per-phase ceiling. Both notes are `chat-skip`-wrapped since `SendMessage` is a CLI-only concept.
- **Static guard** — extended `scripts/tests/test_cli_source.py` to assert no broadcast literal (`to: "*"` / `to="*"`) survives into any raw `SKILL.md`. Live team mode can't be unit-tested, so this static check is the regression guardrail.
- **Version** — PATCH bump `1.7.1` → `1.7.2`.

## Technical Details

The "don't relay / chair is not a switchboard" principle is preserved — members still talk peer-to-peer, just addressed per-recipient instead of via broadcast. The broadcast literal is banned even in explanatory prose (reworded to "all-recipients broadcast"), which keeps the guard a dead-simple substring check with no usage-vs-mention exceptions.

## Testing

- `scripts/` suite: **59 passed** (includes the new guard).
- `skills/assess/` suite: **59 passed**.
- New guard verified to **fail against the pre-fix source** (4 literal hits) and **pass after** the fix.

## Risk Assessment

Low. Markdown-only change confined to the team-mode (`chat-skip`) path; solo and standalone surfaces untouched. Residual concern — per-peer fan-out verbosity at larger team sizes — is mitigated by Fibonacci sizing and the tightened message budget. Roster drift (a member added mid-run) is rare and chair-controlled; the config self-discovery fallback covers it.

## Standalone build

Rebuilt the standalone huddle ZIP from this branch and diffed against `main`. The **only** difference is the surfaced version string (`Standalone build v1.7.1` → `v1.7.2`) — which is the intended effect of the bump via the update-awareness feature (PR #29). The skill body is byte-identical, confirming the fixes are entirely within `chat-skip` blocks.

## Plan

`docs/superpowers/plans/2026-05-27-huddle-broadcast-per-recipient.md` (includes implementation notes on two PRD inconsistencies resolved during the work).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Huddle team-mode communication to use per-recipient sends instead of broadcasts, ensuring chair phase announcements and member share operations complete successfully during team-mode huddles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->