### PR TITLE
fix: Collapse broken links to the same missing file into one ghost node

### DIFF
--- a/skills/assess/scripts/doc-graph-svg.py
+++ b/skills/assess/scripts/doc-graph-svg.py
@@ -49,6 +49,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from lib.doc_graph import (  # noqa: E402
     build_doc_graph,
     classify_node,
+    group_broken_links,
     radial_shells,
 )
 from lib.doc_staleness import analyze_doc_staleness  # noqa: E402
@@ -138,32 +139,43 @@ def _radial_positions(graph, entries: set[str], cx: float, cy: float, fit: float
 
 
 def _render_ghosts(broken_links: list[dict], pos: dict, radius) -> str:
-    """Draw a 'ghost' node for each broken link — a link whose target file
-    doesn't exist. The ghost is a hollow dashed circle hanging off the source by
-    a dashed tether, labelled with the missing name: the label is the suggested
-    fix (create the file, or fix the link)."""
+    """Draw one 'ghost' node per missing file — not per broken link. Several links
+    to the same absent target (e.g. README.md and CONTRIBUTING.md both pointing at
+    a missing CLAUDE.md) collapse to a single ghost they all tether to, so the map
+    shows one missing file rather than a cloud of duplicates.
+
+    Each ghost is a hollow dashed circle sitting just outside the centroid of the
+    sources that reference it, joined to each by a dashed tether and labelled with
+    the missing name: the label is the suggested fix (create the file, or fix the
+    links)."""
     if not broken_links:
         return ""
     out: list[str] = []
-    per_source: dict[str, int] = {}
-    for bl in broken_links:
-        src = bl.get("from")
-        if src not in pos:
+    for gi, group in enumerate(group_broken_links(broken_links)):
+        key = group["target"]
+        sources = [s for s in group["sources"] if s in pos]
+        if not sources:
             continue
-        k = per_source.get(src, 0)
-        per_source[src] = k + 1
-        sx, sy = pos[src]
-        ang = 0.6 + k * 0.9  # fan multiple ghosts around their source
-        off = radius(src) + 34
-        gx, gy = sx + off * math.cos(ang), sy + off * math.sin(ang)
-        name = bl.get("target", "?")
+        # Anchor the shared ghost at the centroid of its sources, pushed radially
+        # outward so it clears the cluster; fan distinct ghosts so labels don't
+        # collide.
+        cx = sum(pos[s][0] for s in sources) / len(sources)
+        cy = sum(pos[s][1] for s in sources) / len(sources)
+        ang = 0.6 + gi * 0.9
+        off = max(radius(s) for s in sources) + 40
+        gx, gy = cx + off * math.cos(ang), cy + off * math.sin(ang)
+        for s in sources:
+            sx, sy = pos[s]
+            out.append(
+                f'<line x1="{sx:.1f}" y1="{sy:.1f}" x2="{gx:.1f}" y2="{gy:.1f}" '
+                f'stroke="{GHOST_COLOR}" stroke-width="1.2" stroke-dasharray="4,3" opacity="0.85"/>'
+            )
+        n = len(sources)
+        srcs = ", ".join(sources)
         tip = html.escape(
-            f"BROKEN LINK\n{src} -> {name}\nmissing file: create it or fix the link",
+            f"BROKEN LINK ({n} source{'s' if n != 1 else ''})\n"
+            f"{srcs} -> {key}\nmissing file: create it or fix the links",
             quote=False)
-        out.append(
-            f'<line x1="{sx:.1f}" y1="{sy:.1f}" x2="{gx:.1f}" y2="{gy:.1f}" '
-            f'stroke="{GHOST_COLOR}" stroke-width="1.2" stroke-dasharray="4,3" opacity="0.85"/>'
-        )
         out.append(
             f'<circle cx="{gx:.1f}" cy="{gy:.1f}" r="7" fill="#ffffff" '
             f'stroke="{GHOST_COLOR}" stroke-width="1.6" stroke-dasharray="3,2">'
@@ -171,7 +183,7 @@ def _render_ghosts(broken_links: list[dict], pos: dict, radius) -> str:
         )
         out.append(
             f'<text x="{gx:.1f}" y="{gy - 11:.1f}" font-size="10" fill="{GHOST_COLOR}" '
-            f'text-anchor="middle">{html.escape(Path(name).name)}</text>'
+            f'text-anchor="middle">{html.escape(Path(key).name)}</text>'
         )
     return "\n".join(out)
 

--- a/skills/assess/scripts/doc-graph-svg.py
+++ b/skills/assess/scripts/doc-graph-svg.py
@@ -138,16 +138,18 @@ def _radial_positions(graph, entries: set[str], cx: float, cy: float, fit: float
     return {n: (cx + x / max_r * fit, cy + y / max_r * fit) for n, (x, y) in raw.items()}
 
 
-def _render_ghosts(broken_links: list[dict], pos: dict, radius) -> str:
+def _render_ghosts(broken_links: list[dict], pos: dict, radius,
+                   show_labels: bool = False) -> str:
     """Draw one 'ghost' node per missing file — not per broken link. Several links
     to the same absent target (e.g. README.md and CONTRIBUTING.md both pointing at
     a missing CLAUDE.md) collapse to a single ghost they all tether to, so the map
     shows one missing file rather than a cloud of duplicates.
 
     Each ghost is a hollow dashed circle sitting just outside the centroid of the
-    sources that reference it, joined to each by a dashed tether and labelled with
-    the missing name: the label is the suggested fix (create the file, or fix the
-    links)."""
+    sources that reference it, joined to each by a dashed tether. The missing name
+    lives in the hover tooltip; it is only drawn as a text label when
+    ``show_labels`` is set, so ghosts read like every other node (clean by
+    default, named on hover)."""
     if not broken_links:
         return ""
     out: list[str] = []
@@ -157,8 +159,7 @@ def _render_ghosts(broken_links: list[dict], pos: dict, radius) -> str:
         if not sources:
             continue
         # Anchor the shared ghost at the centroid of its sources, pushed radially
-        # outward so it clears the cluster; fan distinct ghosts so labels don't
-        # collide.
+        # outward so it clears the cluster; fan distinct ghosts apart.
         cx = sum(pos[s][0] for s in sources) / len(sources)
         cy = sum(pos[s][1] for s in sources) / len(sources)
         ang = 0.6 + gi * 0.9
@@ -181,10 +182,11 @@ def _render_ghosts(broken_links: list[dict], pos: dict, radius) -> str:
             f'stroke="{GHOST_COLOR}" stroke-width="1.6" stroke-dasharray="3,2">'
             f'<title>{tip}</title></circle>'
         )
-        out.append(
-            f'<text x="{gx:.1f}" y="{gy - 11:.1f}" font-size="10" fill="{GHOST_COLOR}" '
-            f'text-anchor="middle">{html.escape(Path(key).name)}</text>'
-        )
+        if show_labels:
+            out.append(
+                f'<text x="{gx:.1f}" y="{gy - 11:.1f}" font-size="10" fill="{GHOST_COLOR}" '
+                f'text-anchor="middle">{html.escape(Path(key).name)}</text>'
+            )
     return "\n".join(out)
 
 
@@ -344,7 +346,7 @@ def render(result, out_path: Path, repo_root: Path, *, layout: str = "radial",
             f'text-anchor="middle">{html.escape(name)}</text>'
         )
 
-    parts.append(_render_ghosts(result.broken_links, pos, radius))
+    parts.append(_render_ghosts(result.broken_links, pos, radius, show_labels))
     parts.append(_title(result, n, cw))
     parts.append(_legend(size_label, layout, colour, cw, ch, footer))
     parts.append('</svg>')

--- a/skills/assess/scripts/doc-graph-svg.py
+++ b/skills/assess/scripts/doc-graph-svg.py
@@ -361,6 +361,16 @@ def render(result, out_path: Path, repo_root: Path, *, layout: str = "radial",
 def _title(result, n: int, cw: float) -> str:
     """Two centred lines at the top: headline + one-line stats."""
     mid = cw / 2
+    links = len(result.broken_links)
+    ghosts = len(group_broken_links(result.broken_links))
+    if not links:
+        broken_clause = ""
+    elif ghosts < links:
+        # Several links point at the same absent file; show the link total and
+        # the smaller count of distinct missing files they collapse to.
+        broken_clause = f' · {links} broken links to {ghosts} missing files'
+    else:
+        broken_clause = f' · {links} broken links'
     return "\n".join([
         f'<text x="{mid:.0f}" y="40" font-size="24" font-weight="600" '
         f'text-anchor="middle">Doc map — {n} docs, {result.graph.number_of_edges()} '
@@ -368,7 +378,7 @@ def _title(result, n: int, cw: float) -> str:
         f'<text x="{mid:.0f}" y="66" font-size="14" fill="#555" text-anchor="middle">'
         f'{result.orphan_rate:.0%} orphaned · {result.reachability_pct:.0%} '
         f'reachable from the entry point'
-        + (f' · {len(result.broken_links)} broken links' if result.broken_links else '')
+        + broken_clause
         + '</text>',
     ])
 

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -642,6 +642,34 @@ def _derive_signals(
     )
 
 
+def _broken_link_key(src: str, target: str, kind: str | None) -> str:
+    """Canonical grouping key for a broken link's missing target.
+
+    Mirrors ``_resolve_mdlink``'s path arithmetic so links that point at the same
+    absent file share a key whatever way they're spelt:
+
+    - A markdown link starting ``/`` is root-absolute — resolved from the repo
+      root (``/CLAUDE.md`` -> ``CLAUDE.md``), matching ``_resolve_mdlink``'s
+      ``repo_root / target.lstrip("/")`` branch. Without this, ``/CLAUDE.md`` and
+      ``CLAUDE.md`` would key apart and the duplicate ghost this function exists
+      to kill would survive for the root-absolute spelling.
+    - Any other markdown link resolves relative to the source file's directory
+      (``../CLAUDE.md`` from a subdir collapses onto the root ``CLAUDE.md``).
+    - A wikilink resolves by note name globally, so it keys on the bare name.
+
+    Known limit (intentional, not fixed): wikilinks and markdown links live in
+    different resolution domains, so ``[[CLAUDE]]`` (key ``CLAUDE``) and
+    ``[x](CLAUDE.md)`` (key ``CLAUDE.md``) at the same missing file do not merge.
+    """
+    if kind == "wikilink":
+        return target  # wikilinks resolve by note name, not by directory
+    if not target:
+        return target
+    if target.startswith("/"):
+        return posixpath.normpath(target.lstrip("/"))
+    return posixpath.normpath(posixpath.join(posixpath.dirname(src), target))
+
+
 def group_broken_links(broken_links: list[dict]) -> list[dict]:
     """Collapse broken links by the missing file they point at.
 
@@ -650,22 +678,15 @@ def group_broken_links(broken_links: list[dict]) -> list[dict]:
     absent file, so the renderer should draw one ghost they both tether to, not a
     separate ghost per link.
 
-    Targets are normalised to a canonical key before grouping: markdown links
-    resolve relative to their source file's directory (so `CLAUDE.md` from the
-    repo root and `../CLAUDE.md` from a subdir collapse when they land on the same
-    path), while wikilinks resolve by note name globally and key on the bare
-    name. Returns ``[{"target", "sources"}]`` ordered by descending source count
-    then key, so the most-referenced ghost is rendered first.
+    Targets are normalised to a canonical key (see ``_broken_link_key``) before
+    grouping. Returns ``[{"target", "sources"}]`` ordered by descending source
+    count then key, so the most-referenced ghost is rendered first.
     """
     groups: dict[str, list[str]] = {}
     for bl in broken_links:
         src = bl.get("from") or ""
         target = bl.get("target") or "?"
-        if bl.get("kind") == "wikilink":
-            key = target  # wikilinks resolve by note name, not by directory
-        else:
-            base = posixpath.dirname(src)
-            key = posixpath.normpath(posixpath.join(base, target)) if target else target
+        key = _broken_link_key(src, target, bl.get("kind"))
         sources = groups.setdefault(key, [])
         if src not in sources:
             sources.append(src)

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -28,6 +28,7 @@ required. If ``networkx`` is unavailable the module degrades to an
 """
 from __future__ import annotations
 
+import posixpath
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -639,3 +640,38 @@ def _derive_signals(
         pagerank={k: round(v, 6) for k, v in pagerank.items()},
         graph=graph,
     )
+
+
+def group_broken_links(broken_links: list[dict]) -> list[dict]:
+    """Collapse broken links by the missing file they point at.
+
+    Several links can name the same non-existent target — `README.md` and
+    `CONTRIBUTING.md` both linking a missing `CLAUDE.md`, say. They describe one
+    absent file, so the renderer should draw one ghost they both tether to, not a
+    separate ghost per link.
+
+    Targets are normalised to a canonical key before grouping: markdown links
+    resolve relative to their source file's directory (so `CLAUDE.md` from the
+    repo root and `../CLAUDE.md` from a subdir collapse when they land on the same
+    path), while wikilinks resolve by note name globally and key on the bare
+    name. Returns ``[{"target", "sources"}]`` ordered by descending source count
+    then key, so the most-referenced ghost is rendered first.
+    """
+    groups: dict[str, list[str]] = {}
+    for bl in broken_links:
+        src = bl.get("from") or ""
+        target = bl.get("target") or "?"
+        if bl.get("kind") == "wikilink":
+            key = target  # wikilinks resolve by note name, not by directory
+        else:
+            base = posixpath.dirname(src)
+            key = posixpath.normpath(posixpath.join(base, target)) if target else target
+        sources = groups.setdefault(key, [])
+        if src not in sources:
+            sources.append(src)
+    return [
+        {"target": key, "sources": sources}
+        for key, sources in sorted(
+            groups.items(), key=lambda kv: (-len(kv[1]), kv[0])
+        )
+    ]

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import lib.doc_graph as doc_graph
-from lib.doc_graph import build_doc_graph
+from lib.doc_graph import build_doc_graph, group_broken_links
 
 
 def _write(root: Path, rel: str, text: str) -> None:
@@ -199,6 +199,57 @@ def test_missing_xrefs_named_not_linked(tmp_path: Path) -> None:
     pairs = {(x["from"], x["to"]) for x in r["missing_xrefs"]}
     assert ("overview.md", "payments.md") in pairs       # named, not linked
     assert ("linked.md", "payments.md") not in pairs     # already linked -> not missing
+
+
+def test_group_broken_links_merges_same_missing_file() -> None:
+    """Several links to the same missing file collapse to one ghost they share."""
+    broken = [
+        {"from": "README.md", "target": "CLAUDE.md", "kind": "mdlink"},
+        {"from": "CONTRIBUTING.md", "target": "CLAUDE.md", "kind": "mdlink"},
+    ]
+    groups = group_broken_links(broken)
+    assert len(groups) == 1
+    assert groups[0]["target"] == "CLAUDE.md"
+    assert sorted(groups[0]["sources"]) == ["CONTRIBUTING.md", "README.md"]
+
+
+def test_group_broken_links_resolves_relative_targets() -> None:
+    """Targets written differently but pointing at distinct paths stay separate;
+    the same resolved path merges even when the link text differs."""
+    broken = [
+        {"from": "README.md", "target": "CLAUDE.md", "kind": "mdlink"},
+        # resolves to docs/CLAUDE.md, not the root CLAUDE.md -> separate ghost
+        {"from": "docs/guide.md", "target": "CLAUDE.md", "kind": "mdlink"},
+        # ../CLAUDE.md from docs/ resolves back to root CLAUDE.md -> merges with README
+        {"from": "docs/other.md", "target": "../CLAUDE.md", "kind": "mdlink"},
+    ]
+    groups = {g["target"]: sorted(g["sources"]) for g in group_broken_links(broken)}
+    assert groups["CLAUDE.md"] == ["README.md", "docs/other.md"]
+    assert groups["docs/CLAUDE.md"] == ["docs/guide.md"]
+
+
+def test_group_broken_links_wikilinks_key_by_name() -> None:
+    """Wikilinks resolve by note name globally, so they key on the bare name
+    regardless of the source directory."""
+    broken = [
+        {"from": "a.md", "target": "ghost-note", "kind": "wikilink"},
+        {"from": "deep/b.md", "target": "ghost-note", "kind": "wikilink"},
+    ]
+    groups = group_broken_links(broken)
+    assert len(groups) == 1
+    assert groups[0]["target"] == "ghost-note"
+    assert sorted(groups[0]["sources"]) == ["a.md", "deep/b.md"]
+
+
+def test_group_broken_links_orders_by_source_count() -> None:
+    """The most-referenced missing file comes first so it renders first."""
+    broken = [
+        {"from": "x.md", "target": "rare.md", "kind": "mdlink"},
+        {"from": "a.md", "target": "popular.md", "kind": "mdlink"},
+        {"from": "b.md", "target": "popular.md", "kind": "mdlink"},
+    ]
+    groups = group_broken_links(broken)
+    assert [g["target"] for g in groups] == ["popular.md", "rare.md"]
 
 
 def test_degrades_when_networkx_unavailable(tmp_path: Path, monkeypatch) -> None:

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -228,6 +228,32 @@ def test_group_broken_links_resolves_relative_targets() -> None:
     assert groups["docs/CLAUDE.md"] == ["docs/guide.md"]
 
 
+def test_group_broken_links_merges_root_absolute_spelling() -> None:
+    """A root-absolute link (/CLAUDE.md) and a plain one (CLAUDE.md) at the same
+    missing root file must merge — they only differ in spelling. Regression for
+    the leading-slash key mismatch."""
+    broken = [
+        {"from": "README.md", "target": "CLAUDE.md", "kind": "mdlink"},
+        {"from": "docs/guide.md", "target": "/CLAUDE.md", "kind": "mdlink"},
+    ]
+    groups = group_broken_links(broken)
+    assert len(groups) == 1
+    assert groups[0]["target"] == "CLAUDE.md"
+    assert sorted(groups[0]["sources"]) == ["README.md", "docs/guide.md"]
+
+
+def test_group_broken_links_wikilink_and_mdlink_do_not_merge() -> None:
+    """Documented limit: a wikilink ([[CLAUDE]]) and a markdown link (CLAUDE.md)
+    to the same missing file live in different resolution domains and stay
+    separate. Pinned so the behaviour is intentional, not accidental."""
+    broken = [
+        {"from": "a.md", "target": "CLAUDE", "kind": "wikilink"},
+        {"from": "b.md", "target": "CLAUDE.md", "kind": "mdlink"},
+    ]
+    keys = {g["target"] for g in group_broken_links(broken)}
+    assert keys == {"CLAUDE", "CLAUDE.md"}
+
+
 def test_group_broken_links_wikilinks_key_by_name() -> None:
     """Wikilinks resolve by note name globally, so they key on the bare name
     regardless of the source directory."""


### PR DESCRIPTION
## Summary

The doc-navigability graph (`doc-graph.svg`) drew **one ghost per broken link**, so several links to the same absent file rendered as a cloud of duplicate ghosts. On a real repo, `README.md → CLAUDE.md` and `CONTRIBUTING.md → CLAUDE.md` (a missing `CLAUDE.md`) showed up as two separate `CLAUDE.md` ghosts.

This collapses broken links by the **missing file they point at**: one ghost per absent target, with a tether from every source that references it.

## Changes

- **`lib/doc_graph.py`** — new pure `group_broken_links()`. Resolves each link to a canonical key before grouping: markdown links resolve relative to their source file's directory; wikilinks key by note name. Returns `[{target, sources}]` ordered by descending source count.
- **`scripts/doc-graph-svg.py`** — `_render_ghosts` now iterates groups, drawing one ghost per missing file anchored at the centroid of its sources with a dashed tether from each. Tooltip names every source.
- **`tests/test_doc_graph.py`** — 4 new tests: merge same target, resolve-to-distinct-path stays separate, wikilink keys by name, ordering by source count.

## Verification

- Full suite: **112 passed**.
- Against a real repo: the `CLAUDE.md` case collapses 2 ghosts → 1 (*"(2 sources) CONTRIBUTING.md, README.md → CLAUDE.md"*); genuinely-different targets (`../bedrock/CLAUDE.md` → `bedrock/CLAUDE.md`) stay separate; total ghosts 40 → 34.

Related: surfaced while dogfooding /assess (feedback #34).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Document graph visualizations now consolidate multiple broken links targeting the same missing file into a single ghost node, providing clearer visualization of missing documentation references and reducing visual clutter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->