### PR TITLE
feat: Instruction-surface integrity in Layer 0 (closes #34)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -187,28 +187,33 @@ Layer 0 answers: *can the agent form a true picture before it acts?* It has two 
 
 #### 0a — Agent instruction files
 
-Read the agent instruction file grades from `run-context.json`:
+Read the agent instruction file grades and surface integrity from `run-context.json`:
 
 ```bash
-jq '.instruction_files, .instructions_grade' "$REPO_ROOT/.assess/run-context.json"
+jq '.instruction_files, .instructions_grade, .untracked_instruction_files, .broken_instruction_refs' "$REPO_ROOT/.assess/run-context.json"
 ```
 
-`.instruction_files` is a dict keyed by filename (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`). The same heuristic grader scores each present file. For each:
+`.instruction_files` is a dict keyed by filename (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`). Only **git-tracked** files are graded — a file present on disk but uncommitted is *not* credited (it isn't part of what the repo ships). The same heuristic grader scores each tracked file. For each:
 - `grade: "A" | "B+" | ...` - report verbatim per file
 - `subscores.positive_directives` - count of positive directives found
 - `subscores.tradeoff_phrases` - count of reasoning phrases
 - `subscores.path_references` - count of file path references
 - `freshness_days` - days since last edit
 
-`.instructions_grade` is the best grade across all present files - use this for the layer scoring.
+`.instructions_grade` is the best grade across all tracked files - the starting point for the layer scoring.
 
-**Scoring rule:** trust the deterministic grade.
-- `instructions_grade` is `null` → **Missing** (no instruction file found at any known location)
+**Scoring rule:** start from the deterministic grade, then apply the integrity overrides below.
+- `instructions_grade` is `null` → **Missing** (no committed instruction file at any known location)
 - A/A-/B+ → **Present**
 - B/C → **Partial**
 - D/F → **Partial** if at least one file exists but scores low - note the grade and recommend rewriting
 
-Important: a null grade and an F grade map to different remediation. Null means "create a CLAUDE.md / AGENTS.md (whichever the team uses)." F means "the file is there but needs rewriting." Don't conflate them in the report.
+**Integrity overrides (these can pull the half *below* the grade — a single good file does not rescue a broken instruction surface):**
+- **`broken_instruction_refs` is non-empty → cap the instruction half at Partial, or Missing if it's the *primary* instruction surface that's broken.** These are advertised-but-broken instruction references: a committed `.cursorrules`/`AGENTS.md`/`CLAUDE.md` that is a **dangling symlink** (`reason: symlink target missing`), or an entry doc that **links to a missing instruction file** (`reason: link to missing instruction file`). The truth-pressure model says a broken map scores at or below absent — a repo that *advertises* `.cursorrules` but the symlink dangles is worse than one that never claimed to have it. Name each broken ref and make "fix or remove the broken instruction reference" a Top-3 action. Do **not** let an unrelated file that happens to grade B+ keep the half at Present.
+- **`untracked_instruction_files` is non-empty → note it, don't score it.** An instruction file exists on disk but isn't committed, so nobody who clones gets it. Report "`<file>` present locally but untracked — commit it or it won't reach contributors (human or agent)"; never let it raise the grade.
+- **Surface within-band regression.** The Present/Partial/Missing bucket is coarse — "lost the primary instruction file and gained 40 dangling links" may not move the bucket. When `broken_instruction_refs` or a large `doc_graph.dangling_links` count appears, call out the regression explicitly in the report even if the band label is unchanged.
+
+Important: a null grade and an F grade map to different remediation. Null means "create a CLAUDE.md / AGENTS.md (whichever the team uses)." F means "the file is there but needs rewriting." A broken/dangling reference means "the file you point at is gone — fix the link or remove the claim." Don't conflate them.
 
 When multiple instruction files are present (e.g. CLAUDE.md and AGENTS.md as symlinks of the same content), list each in the report.
 

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -90,25 +90,45 @@ def _file_freshness_days(file_path: Path) -> int:
         return 0
 
 
-def _grade_instruction_files(repo_root: Path) -> tuple[dict[str, dict], str | None]:
+def _grade_instruction_files(
+    repo_root: Path,
+) -> tuple[dict[str, dict], str | None, list[str], list[dict]]:
     """Scan all known instruction file locations and grade each one found.
 
-    Returns: (files_dict, best_grade)
-        files_dict: keyed by filename, e.g. {"CLAUDE.md": {grade, score, ...}, "AGENTS.md": {...}}
-        best_grade: best letter grade across all present files; None if none found.
-            None is distinct from "F": None means no file exists ("create the file"),
-            "F" means a file exists but scored poorly ("fix the file").
+    Returns: (files_dict, best_grade, untracked, dangling_refs)
+        files_dict: keyed by filename, e.g. {"CLAUDE.md": {grade, score, ...}}.
+        best_grade: best letter grade across all *tracked, present* files; None
+            if none found. None is distinct from "F": None means no committed
+            file exists ("create the file"), "F" means one exists but scored
+            poorly ("fix the file").
+        untracked: instruction files that exist on disk but aren't part of the
+            repo (untracked / git-ignored / symlinked from outside). Surfaced as
+            a finding so a personal CLAUDE.md isn't silently credited *or*
+            silently ignored - the agent should note it isn't committed.
+        dangling_refs: instruction files that are dangling symlinks (committed
+            `.cursorrules -> missing-target`) - an advertised-but-broken
+            instruction surface.
     """
     repo_root = repo_root.resolve()
     tracked = tracked_files(repo_root)
     found: dict[str, dict] = {}
+    untracked: list[str] = []
+    dangling_refs: list[dict] = []
     for rel_path in INSTRUCTION_FILE_PATHS:
         candidate = repo_root / rel_path
+        # A dangling symlink (an instruction file pointing at a missing target)
+        # exists() == False but is_symlink() == True - an advertised, broken
+        # instruction reference, not "no file".
+        if candidate.is_symlink() and not candidate.exists():
+            dangling_refs.append({"path": rel_path, "reason": "symlink target missing"})
+            continue
         if not candidate.exists():
             continue
-        # Only grade genuine repo files - not a contributor's untracked personal
-        # CLAUDE.md, nor one symlinked in from outside the repo.
+        # Only grade genuine repo files. An on-disk-but-untracked instruction
+        # file (a contributor's personal CLAUDE.md, or one symlinked in from
+        # outside) is recorded as a finding rather than credited to the score.
         if not is_repo_file(candidate, repo_root, tracked):
+            untracked.append(rel_path)
             continue
         text = candidate.read_text(encoding="utf-8")
         freshness = _file_freshness_days(candidate)
@@ -122,10 +142,30 @@ def _grade_instruction_files(repo_root: Path) -> tuple[dict[str, dict], str | No
             "present": True,
         }
 
-    if not found:
-        return {}, None
-    best = max(found.values(), key=lambda v: GRADE_RANK.get(v["grade"], 0))
-    return found, best["grade"]
+    best = (max(found.values(), key=lambda v: GRADE_RANK.get(v["grade"], 0))["grade"]
+            if found else None)
+    return found, best, untracked, dangling_refs
+
+
+# Basenames (lowercased) of the known instruction files, for cross-referencing
+# broken doc links against the instruction surface.
+_INSTRUCTION_BASENAMES = {Path(p).name.lower() for p in INSTRUCTION_FILE_PATHS}
+
+
+def _broken_instruction_refs(doc_graph: dict, dangling_refs: list[dict]) -> list[dict]:
+    """Combine dangling-symlink instruction files with broken doc links whose
+    target is an instruction file (an entry doc linking a missing CLAUDE.md).
+    These are advertised-but-broken instruction references."""
+    refs = list(dangling_refs)
+    if doc_graph.get("available"):
+        for bl in doc_graph.get("broken_links", []):
+            target = bl.get("target", "")
+            if Path(target).name.lower() in _INSTRUCTION_BASENAMES:
+                refs.append({
+                    "from": bl.get("from"), "target": target,
+                    "reason": "link to missing instruction file",
+                })
+    return refs
 
 
 def _read_plugin_version() -> str:
@@ -214,7 +254,8 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     prior_exists = prior is not None
 
     diff = diff_stats(prior=prior, current=current)
-    instruction_files, instructions_grade = _grade_instruction_files(repo_root)
+    instruction_files, instructions_grade, untracked_instr, dangling_instr = \
+        _grade_instruction_files(repo_root)
 
     # Load (and later update) the persistent first-flagged date map
     first_flagged_map = _load_first_flagged(assess_dir)
@@ -331,6 +372,13 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     ctx["doc_graph"] = doc_graph
     ctx["doc_staleness"] = doc_staleness
     ctx["stale_hubs"] = _build_stale_hubs(doc_graph, doc_staleness)
+    # Instruction-surface integrity (Layer 0): files present on disk but not
+    # committed, and advertised-but-broken instruction references (dangling
+    # symlinks + entry docs linking a missing instruction file). A broken
+    # instruction reference must penalise L0 even when one unrelated file grades
+    # well - see the Layer 0 scoring rule in SKILL.md.
+    ctx["untracked_instruction_files"] = untracked_instr
+    ctx["broken_instruction_refs"] = _broken_instruction_refs(doc_graph, dangling_instr)
     # When the scan failed, preserve failure semantics: a failed scan must not be
     # read as "no observability" (rung 0) - that would mis-score Layer 1 Missing
     # when the truth is "not assessed". Carry the reason instead.

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -26,6 +26,61 @@ def _minimal_repo(tmp_path: Path) -> Path:
     return repo
 
 
+_EMPTY_STATS = json.dumps({
+    "files_scored": 0, "loc": {}, "ccn": {},
+    "top_hotspots": [], "top_complex": [], "top_large": [],
+})
+
+
+def _seed_assess(repo: Path) -> None:
+    (repo / ".assess").mkdir(exist_ok=True)
+    (repo / ".assess" / "complexity-stats.json").write_text(_EMPTY_STATS)
+
+
+def test_untracked_instruction_file_flagged_not_graded(git_repo, fixtures_dir: Path) -> None:
+    """Issue #34 Gap 1: an on-disk-but-untracked instruction file isn't credited
+    to the grade, and is surfaced as a finding."""
+    repo, commit = git_repo
+    good = (fixtures_dir / "good_instructions.md").read_text()
+    _seed_assess(repo)
+    (repo / ".github").mkdir()
+    (repo / ".github" / "copilot-instructions.md").write_text(good, encoding="utf-8")
+    commit("committed instructions")
+    (repo / "CLAUDE.md").write_text(good, encoding="utf-8")  # untracked (after commit)
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-28")
+    assert ".github/copilot-instructions.md" in ctx["instruction_files"]
+    assert "CLAUDE.md" not in ctx["instruction_files"]          # untracked -> not graded
+    assert "CLAUDE.md" in ctx["untracked_instruction_files"]    # but flagged
+
+
+def test_dangling_symlink_instruction_is_broken_ref(git_repo) -> None:
+    """Issue #34 Gap 2: a committed instruction file that is a dangling symlink
+    is an advertised-but-broken reference."""
+    import os
+    repo, commit = git_repo
+    _seed_assess(repo)
+    (repo / "README.md").write_text("# Repo", encoding="utf-8")
+    os.symlink("missing-target.md", repo / ".cursorrules")  # dangling symlink
+    commit("init with dangling .cursorrules")
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-28")
+    refs = ctx["broken_instruction_refs"]
+    assert any(r.get("path") == ".cursorrules" and "symlink" in r["reason"] for r in refs)
+
+
+def test_broken_link_to_instruction_file_is_broken_ref(git_repo) -> None:
+    """Issue #34 Gap 2: an entry doc linking a missing instruction file."""
+    repo, commit = git_repo
+    _seed_assess(repo)
+    (repo / "README.md").write_text("see the [rules](AGENTS.md)", encoding="utf-8")
+    commit("init; README links a missing AGENTS.md")
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-28")
+    refs = ctx["broken_instruction_refs"]
+    assert any(Path(r.get("target", "")).name == "AGENTS.md" for r in refs)
+
+
 def test_build_run_context_first_run(tmp_path: Path) -> None:
     """No prior .assess/, no instruction files - 'new' diff, empty instructions."""
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

Closes #34 — a `/assess`-feedback issue: Layer 0 stayed **Present** on a B+ from one unrelated committed file even though the repo's *advertised* instruction surface was broken, and an untracked local `CLAUDE.md` had inflated an earlier run of the same commit.

## Changes Made

**Gap 1 — untracked instruction files.** Grading already excludes non-tracked files (shipped in v1.9.0). This adds the *finding*: `assess_core` emits `untracked_instruction_files`, and SKILL.md tells the report to say "`<file>` present locally but untracked — commit it or it won't reach contributors", never crediting it to the grade.

**Gap 2 — broken instruction references penalise Layer 0.** New `broken_instruction_refs` signal combining:
- dangling-symlink instruction files (a committed `.cursorrules -> missing-target`), and
- broken doc links whose target is an instruction filename (an entry doc linking a missing `CLAUDE.md`/`AGENTS.md`).

SKILL.md's Layer 0 scoring gains **integrity overrides**: when `broken_instruction_refs` is non-empty, the instruction half is capped at Partial (Missing if it's the primary surface), regardless of an unrelated file's grade — a broken map scores at or below absent. It's named as a Top-3 fix, and the within-band regression the coarse bucket hides is surfaced explicitly.

## Testing

- `skills/assess/`: **117 passed** (+3: untracked-flagged-not-graded, dangling-symlink ref, broken-link-to-instruction ref).
- `scripts/`: **60 passed**; standalone ZIP rebuilds clean.
- Verified against the real reporting repo: only `.github/copilot-instructions.md` graded (B+), `.cursorrules` flagged as a dangling symlink, and three entry docs flagged for linking a missing `CLAUDE.md` — exactly the issue's scenario, now caught.

## Risk Assessment

Low, additive. New deterministic signals + a scoring rule; the LLM applies the override (consistent with the deterministic-core/LLM-scoring split). `instructions_grade` itself is unchanged (still grades content); the override happens at the layer-scoring step.

MINOR bump: `1.9.0 → 1.10.0`.
