### PR TITLE
chore: Bump plugin to 1.11.1 (docs-only patch)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"


### PR DESCRIPTION
Catches up plugin.json with the two docs-only PRs merged after v1.11.0 (#42 README hero swap, #43 dismiss-false-positives PRD). Skills/agents/commands payload unchanged. Bumping makes the standalone build pipeline rebuild the ZIPs and gives `/plugin update` a version to move to.

## Test Plan
- [ ] CI green
- [ ] Standalone build rebuilds on merge