### PR TITLE
fix(assess): bundle four feedback fixes from a v1.11.0 run

### DIFF
--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -81,9 +81,12 @@ command -v scc >/dev/null 2>&1 && SCC_PRESENT=1 || SCC_PRESENT=0
 [ -f "$REPO_ROOT/.assess/.no-scc" ] && SCC_DECLINED=1 || SCC_DECLINED=0
 
 # 3. Is the repo mostly markdown/data/config (where lizard alone will be sparse)?
-#    Cheap heuristic: count non-code files vs code files.
-CODE_FILES=$(fd -t f -e py -e js -e ts -e tsx -e jsx -e go -e java -e kt -e rs -e rb -e cs -e swift -e dart -e cpp -e c -e h -e php "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
-NONCODE_FILES=$(fd -t f -e md -e json -e yaml -e yml -e toml -e sh -e sql "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+#    Cheap heuristic: count non-code files vs code files. The `.` argument is
+#    the regex pattern (matches every path) and "$REPO_ROOT" is the search
+#    path - without `.`, fd treats $REPO_ROOT as the pattern itself, matches
+#    nothing, and silently returns 0.
+CODE_FILES=$(fd -t f -e py -e js -e ts -e tsx -e jsx -e go -e java -e kt -e rs -e rb -e cs -e swift -e dart -e cpp -e c -e h -e php . "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+NONCODE_FILES=$(fd -t f -e md -e json -e yaml -e yml -e toml -e sh -e sql . "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
 ```
 
 **Offer the install only if all three are true:** `SCC_PRESENT=0`, `SCC_DECLINED=0`, and the repo looks lizard-sparse (`CODE_FILES < NONCODE_FILES` or `CODE_FILES < 10`). Otherwise skip straight to 2b (or 2c if 2b has nothing to offer).
@@ -122,9 +125,9 @@ Layer 1's intra-repo dead-code scan calls a per-language tool (`vulture` for Pyt
 Detect languages with cheap `fd` counts (mirroring Step 2a's heuristic - the treemap script's own classification isn't exposed in the stats sidecar, and shelling out is fine here):
 
 ```bash
-PY_FILES=$(fd -t f -e py "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
-TS_FILES=$(fd -t f -e ts -e tsx "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
-GO_FILES=$(fd -t f -e go "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+PY_FILES=$(fd -t f -e py . "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+TS_FILES=$(fd -t f -e ts -e tsx . "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+GO_FILES=$(fd -t f -e go . "$REPO_ROOT" 2>/dev/null | wc -l | tr -d ' ')
 
 # Per-language candidate tool. Prefer the read-only tool first - `ts-prune` over
 # `knip` for TS, `staticcheck` over `deadcode` for Go - so the user isn't asked
@@ -774,14 +777,37 @@ The plugin footer is important — it's how other engineers viewing the report i
 
 ## Step 5: Ask Whether to Open a PR
 
-After writing the files, surface them and ask the user — verbatim — something like:
+After writing the files, first **check whether a direct PR is even possible** before offering one. A user on `READ` or `TRIAGE` access can't push a branch to the target repo, so an unconditional "open a PR?" offer is infeasible and wastes a turn.
+
+```bash
+# Detect push capability. `gh` returns viewer fields for the current user.
+PUSH_INFO=$(gh repo view --json viewerPermission,viewerCanPush,viewerCanAdminister,nameWithOwner 2>/dev/null || true)
+# If the command failed (no remote, no gh, not a GitHub repo, unauthenticated),
+# fall back to the local-branch flow with the reason - never silently assume
+# push works.
+```
+
+Interpret the result:
+
+- `viewerCanPush: true` (any of `WRITE` / `MAINTAIN` / `ADMIN` viewerPermission, or push-eligible fork access): offer the direct PR flow below.
+- `viewerCanPush: false` and `viewerPermission` is `READ` / `TRIAGE`: name the constraint, then offer the fork-based PR flow ("fork `<owner>/<repo>` and open the PR from your fork?") as an alternative to "leave local". Do not offer the direct flow.
+- `gh` unavailable / not a GitHub remote / not authenticated: skip both PR offers entirely and surface only the "leave local" outcome, naming the reason ("no GitHub remote detected" / "`gh` not authenticated").
+
+Then surface the question - verbatim, picking the shape that matches the access tier:
 
 > Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. Want me to open a PR in this repo with these files, or leave them local for you to review first?
 
-If the user says **yes / PR**:
+> Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. You have `READ` access to `<owner/repo>`, so a direct PR isn't possible. I can fork `<owner/repo>` to your account and open the PR from there, or leave the files local for you to review.
+
+If the user says **yes / PR** (direct flow, `viewerCanPush: true`):
 1. Create a branch in the target repo: `assess/snapshot-<YYYY-MM-DD>` (use the existing worktree workflow if `<repo>-main` + `worktree/` layout is present; otherwise branch in place).
 2. Stage and commit the report, the complexity heatmap, and the doc graph. Commit message: `docs: Add AI-readiness assessment + complexity and doc-navigability snapshots`.
 3. Push the branch and open a PR. Title: `docs: Codebase assessment — <YYYY-MM-DD>`.
+
+If the user says **yes / PR** (fork flow, `viewerCanPush: false` on the upstream):
+1. `gh repo fork <owner>/<repo> --clone=false --remote=true` (creates the fork under the user's account and adds it as a remote named `origin` or similar; the upstream becomes `upstream` if the original was already `origin`).
+2. Create the branch as above, push to the **fork** (`git push -u <fork-remote> <branch>`), and open the PR via `gh pr create --repo <owner>/<repo>` (head defaults to the fork).
+3. Commit message, PR title, and body are unchanged from the direct flow.
 4. **PR body must include the plugin reference at the bottom** so reviewers can install the tool that generated the report. Use this body template:
 
    ```markdown
@@ -821,22 +847,39 @@ If the user says **yes**, proceed agnostically - **don't assume GitHub** (or any
 
 ### 6a: Identify the user's issue tracker
 
-Look at every signal available and pick the one the user actually uses. Examples of signals (not an exhaustive list):
+**Start with the deterministic git-remote signal before anything else.** A GitHub / GitLab remote with issues enabled is the cheapest, most reliable tracker signal in front of you - skipping it forces the model into judgment-mode on a question that has a clear answer.
+
+```bash
+# Cheapest tracker signal: a git remote that hosts issues.
+GIT_REMOTE=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+if [ -n "$GIT_REMOTE" ]; then
+  # `gh` works against any git remote pointing at github.com (including forks);
+  # hasIssuesEnabled distinguishes a code-only mirror from a real tracker.
+  GH_TRACKER=$(gh repo view --json hasIssuesEnabled,nameWithOwner 2>/dev/null || true)
+fi
+```
+
+Treat a non-empty `GH_TRACKER` with `hasIssuesEnabled: true` as a **detected tracker** (subject to the same write-access check as Step 5 - read-only repos still get tracking items via the user's fork or their personal tracker, not the upstream issues list). Same logic for `glab repo view --output json` on GitLab remotes.
+
+When the deterministic signal is clear and unambiguous, use it without asking. Only fall back to judgment / multiple-signal disambiguation when the remote check is empty, ambiguous, or contradicted by something the user has told you.
+
+Other signals - examples, not an exhaustive list, used only as fallback or to choose between equally-plausible options:
 
 - **The user's global instructions** (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`) often state the tracker explicitly: "issues live in Linear project FOO", "we use Task Master", "Jira project ABC", etc.
 - **Project-level instructions** in the target repo's `CLAUDE.md` / `AGENTS.md` / contribution docs.
-- **Project files**: `.taskmaster/` directory, `.acli/` config, `.linear/` dotfiles, GitHub/GitLab remote, a Notion link in the README, etc.
+- **Project files**: `.taskmaster/` directory, `.acli/` config, `.linear/` dotfiles, a Notion link in the README, etc.
 - **Authenticated CLIs**: `gh auth status`, `glab auth status`, `acli` configuration, `linear` CLI tokens, anything similar.
 - **Conversation history**: if the user just used a tracker, prefer that one.
 
-This is not a fixed list. The user might track work in Omnifocus, Apple Notes, a Google Doc, a Notion database, a Slack channel, or anything else. **Use judgment**, don't enumerate.
+The user might track work in Omnifocus, Apple Notes, a Google Doc, a Notion database, a Slack channel, or anything else. **Use judgment** on these soft signals; do not let them override a clear deterministic git-remote hit.
 
 **Decision rules:**
 
-1. **One clear signal** (e.g. only `.taskmaster/` present, or global CLAUDE.md says "use Linear") - use that tracker without asking.
-2. **Multiple plausible signals** (e.g. GitHub remote + `.taskmaster/` + Jira project mentioned) - **ask the user**. List what you saw and let them pick:
-   > I see signals for both Task Master (`.taskmaster/` directory) and GitHub Issues (GitHub remote, `gh` authenticated). Which should I create the tracking items in?
-3. **No clear signal** - ask:
+1. **Deterministic GitHub/GitLab remote with issues enabled** - use that tracker without asking (subject to write-access check). This is the common case for OSS work and most personal repos.
+2. **One clear soft signal** (e.g. only `.taskmaster/` present, or global CLAUDE.md says "use Linear") and no contradicting remote - use that tracker without asking.
+3. **Conflicting signals** (e.g. GitHub remote + `.taskmaster/` directory + global says "use Linear") - **ask the user**. List what you saw and let them pick:
+   > I see signals for Task Master (`.taskmaster/`), GitHub Issues (remote points at `<owner/repo>` with issues enabled), and Linear (your global CLAUDE.md mentions it). Which should I create the tracking items in?
+4. **No clear signal** - ask:
    > I couldn't tell which tracker you use. Where should I create the tracking items? (e.g. GitHub Issues, Task Master, Jira, Linear, somewhere else - or skip)
 
 When asking, use **AskUserQuestion** with the detected options plus a "something else" / "skip" escape hatch.

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -793,9 +793,13 @@ Interpret the result:
 - `viewerCanPush: false` and `viewerPermission` is `READ` / `TRIAGE`: name the constraint, then offer the fork-based PR flow ("fork `<owner>/<repo>` and open the PR from your fork?") as an alternative to "leave local". Do not offer the direct flow.
 - `gh` unavailable / not a GitHub remote / not authenticated: skip both PR offers entirely and surface only the "leave local" outcome, naming the reason ("no GitHub remote detected" / "`gh` not authenticated").
 
-Then surface the question - verbatim, picking the shape that matches the access tier:
+Then surface the question - verbatim, picking the shape that matches the access tier.
+
+Push-capable target (`viewerCanPush: true`):
 
 > Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. Want me to open a PR in this repo with these files, or leave them local for you to review first?
+
+Read-only target (`READ` / `TRIAGE`):
 
 > Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. You have `READ` access to `<owner/repo>`, so a direct PR isn't possible. I can fork `<owner/repo>` to your account and open the PR from there, or leave the files local for you to review.
 

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -88,6 +88,25 @@ _MDLINK_RE = re.compile(r"(?<!\!)\[(?:[^\]]*)\]\(([^)]+)\)")
 # Schemes / forms that are not intra-repo file links.
 _EXTERNAL_RE = re.compile(r"^[a-z][a-z0-9+.-]*://|^mailto:|^tel:", re.IGNORECASE)
 _FENCE_RE = re.compile(r"```.*?\n.*?```", re.DOTALL)  # fenced code blocks
+# Inline-code spans: backtick-delimited segments on a single logical line. A
+# link target inside `[[foo]]` or `[text](./foo.md)` is documentation syntax
+# (an Obsidian skill teaching wikilinks, a FORMAT-spec showing a sample), not
+# a real navigation edge - the writer formatted it as code on purpose. Caps
+# match-length to avoid spanning paragraphs when stray backticks appear.
+_INLINE_CODE_RE = re.compile(r"`[^`\n]{1,200}`")
+
+
+def _strip_code_spans(text: str) -> str:
+    """Remove fenced code blocks and inline-code spans before link extraction.
+
+    Without this, a markdown doc that *teaches* link syntax (a FORMAT spec, an
+    Obsidian-skill how-to) contributes phantom edges to the navigation graph
+    and inflates `dangling_links`. The writer formatted those targets as code
+    precisely because they are samples, not navigation.
+    """
+    # Strip fenced blocks first so an inline-code regex can't snag content
+    # inside a fence that legitimately contains backticks of its own.
+    return _INLINE_CODE_RE.sub("", _FENCE_RE.sub("", text))
 
 # Caps so a pathological repo can't bloat run-context.json.
 MAX_BROKEN_LINKS = 60
@@ -461,8 +480,12 @@ def build_doc_graph(
             # whole graph build (Layer 0 stays best-effort).
             continue
         texts[d] = text
+        # Strip code spans before harvesting links: a link target inside a
+        # fence or backtick span is a documentation sample (FORMAT specs,
+        # wikilink-syntax demos), not a navigation edge.
+        link_text = _strip_code_spans(text)
         # Wikilinks resolve by note name across the vault.
-        for m in _WIKILINK_RE.finditer(text):
+        for m in _WIKILINK_RE.finditer(link_text):
             tgt, amb = _resolve_wikilink(
                 m.group(1), d, repo_root, by_relpath, by_name, by_stem,
             )
@@ -474,7 +497,7 @@ def build_doc_graph(
             if tgt in doc_set and tgt != d:
                 graph.add_edge(rel(d), rel(tgt))
         # CommonMark links resolve relative to the doc's directory.
-        for m in _MDLINK_RE.finditer(text):
+        for m in _MDLINK_RE.finditer(link_text):
             raw = m.group(1)
             tgt = _resolve_mdlink(raw, d, repo_root)
             if tgt is None:

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -92,6 +92,65 @@ def test_dangling_wikilink_counted(tmp_path: Path) -> None:
     assert r.dangling_links >= 1
 
 
+def test_wikilink_inside_fenced_code_block_is_not_counted(tmp_path: Path) -> None:
+    """A FORMAT spec or Obsidian-syntax tutorial that *shows* `[[foo]]` as a
+    sample inside a fenced code block must not contribute a phantom edge or
+    a dangling link. The writer formatted it as code on purpose.
+    """
+    _write(
+        tmp_path,
+        "obsidian-skill.md",
+        "How to write wikilinks:\n\n```markdown\n[[Note Title]]\n[[wikilinks]]\n```\n",
+    )
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert "Note Title" not in targets
+    assert "wikilinks" not in targets
+
+
+def test_mdlink_inside_fenced_code_block_is_not_counted(tmp_path: Path) -> None:
+    """FORMAT specs commonly show `[Ordering](./src/ordering/CONTEXT.md)` as a
+    sample of the format they teach. Inside a fence, that's documentation
+    syntax, not navigation - it must not show up in broken_links.
+    """
+    _write(
+        tmp_path,
+        "context-FORMAT.md",
+        "Example layout:\n\n```markdown\n[Ordering](./src/ordering/CONTEXT.md)\n```\n",
+    )
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert "./src/ordering/CONTEXT.md" not in targets
+
+
+def test_link_inside_inline_code_span_is_not_counted(tmp_path: Path) -> None:
+    """Inline-code spans (single backticks) are equally code: `[[wikilinks]]`
+    in a sentence is teaching syntax, not navigating.
+    """
+    _write(
+        tmp_path,
+        "guide.md",
+        "Use the `[[Note Title]]` syntax to link notes. "
+        "Markdown form looks like `[label](./file.md)`.\n",
+    )
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+
+
+def test_real_links_outside_code_still_extracted(tmp_path: Path) -> None:
+    """Prose-form links to real docs must still build edges. Stripping code
+    spans is meant to reduce false positives, not break navigation."""
+    _write(tmp_path, "README.md", "see [the guide](./guide.md)\n")
+    _write(tmp_path, "guide.md", "real doc")
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    # Edge must be present.
+    edges = {(h["path"], h.get("pagerank", 0)) for h in r.hubs}
+    assert any(p == "guide.md" for p, _ in edges) or r.edge_count >= 1
+
+
 def test_excludes_assess_and_vendor_dirs(tmp_path: Path) -> None:
     _write(tmp_path, "README.md", "real doc")
     _write(tmp_path, ".assess/log.md", "our own output")


### PR DESCRIPTION
Closes #46.

## Summary

Four discrete bugs surfaced by an `/assess` v1.11.0 run on a public skills/content repo where the user had `READ`-only access. All four verified against the run before fixing.

## Changes Made

### Point 1: Step 5 PR offer gated on write access (`SKILL.md`)

The skill offered "open a PR in this repo?" unconditionally. On a `READ`-access target it was infeasible. Now runs `gh repo view --json viewerPermission,viewerCanPush,viewerCanAdminister,nameWithOwner` first and picks one of three flows:

- `viewerCanPush: true` -> direct PR (existing flow)
- `READ` / `TRIAGE` -> fork-based PR offer (`gh repo fork --remote=true`, push to the fork, `gh pr create --repo upstream`)
- No GitHub remote / no `gh` / unauthenticated -> "leave local" with the reason named

### Point 2: Step 6a starts with the deterministic git-remote signal (`SKILL.md`)

Step 6a previously listed signals to "use judgment" over, but never mandated `git remote -v` / `gh repo view`. The reported run asserted "no GitHub issue tracker detected" on a repo with a GitHub remote, issues enabled, and 270+ open issues. Now the deterministic remote check is the first step; soft signals (`.taskmaster/`, global CLAUDE.md mentions, etc.) are explicit fallback only.

### Point 3: `fd` path bug in Steps 2a/2b (`SKILL.md`)

`fd -t f -e md "$REPO_ROOT"` treats `$REPO_ROOT` as a regex pattern, not a search path. Both `CODE_FILES`/`NONCODE_FILES` (Step 2a scc-offer) and `PY/TS/GO_FILES` (Step 2b dead-code offer, added in v1.11.0) silently returned 0. **Real v1.11.0 regression** - the install-offer heuristics I added two days ago were always corrupted.

Fixed by inserting `.` as the explicit pattern argument:

```diff
- fd -t f -e py "$REPO_ROOT" 2>/dev/null
+ fd -t f -e py . "$REPO_ROOT" 2>/dev/null
```

Verified locally: `fd -t f -e md "$REPO_ROOT"` -> `0`; `fd -t f -e md . "$REPO_ROOT"` -> `28`. Inline comment added so future contributors don't reintroduce it.

### Point 4: doc_graph filters code-fence and inline-code links (`lib/doc_graph.py`)

`dangling_links` and `broken_links` counted link targets inside fenced code blocks and inline-code spans. A FORMAT spec teaching link syntax (`[Ordering](./src/ordering/CONTEXT.md)` as a sample of the format it teaches) or an Obsidian skill documenting `[[Note Title]]` and `[[wikilinks]]` as syntax all became "broken links", inflating the metric and adding phantom ghost nodes to the SVG.

New `_strip_code_spans()` removes fenced blocks (existing `_FENCE_RE`) and inline-code spans (new `_INLINE_CODE_RE`) before link extraction. Four new tests cover: wikilink in fence, mdlink in fence, link in inline-code span, and "real prose links still count" (regression guard).

## Versioning

**No `plugin.json` bump.** `plugin.json` is already at 1.12.0 on main from #45 (`/deslop` skill, unreleased). All four points here are bug fixes - they ride along in the same 1.12.0 window and will fold into v1.12.0 release notes whenever you cut that release.

## Testing

- `skills/assess/` pytest: **127 passed** (4 new tests on `test_doc_graph.py`)
- `scripts/` pytest: **69 passed** (standalone build pipeline)
- `bash scripts/build-standalone-skills.sh assess`: clean (232 KB ZIP)

## Risk Assessment

- Point 3 changes `fd` invocations - verified the new form returns the right counts locally. The `.` regex matches every path; no filtering side-effect.
- Point 4 changes `dangling_links` magnitude downward across all existing repos (false positives stop counting). The headline metric will drop on repos with format-spec docs or syntax-teaching skills. This is the intended fix; existing readers ignore additional ghost-node absences.
- Points 1 and 2 are SKILL.md prose changes to LLM-driven steps - no automated test surface, but the agent following the new instructions will get strictly more information than before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-count detection in code analysis workflows.
  * Corrected documentation link extraction to ignore code examples within documentation.
  * Updated PR and issue-tracking workflows to respect user repository permissions and system availability.

* **Tests**
  * Added tests verifying proper handling of link syntax within code blocks during documentation analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->