### PR TITLE
fix(assess): address eight feedback items from a v1.11.0 run

### DIFF
--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -58,6 +58,8 @@ Artefacts will land at:
 - `$REPO_ROOT/.assess/doc-graph.svg`
 - `$REPO_ROOT/.assess/assess-report.md`
 
+> **Write-protected repo root?** `/assess` writes `.assess/` into `$REPO_ROOT`, and the treemap/core run as `uv` subprocesses that write there too. If your workflow keeps the repo root pristine and read-only (e.g. a `<repo>-main` clone that teammates branch from, with a hook blocking direct edits), a guard on *your* writes won't stop the subprocess - it just makes the run write into the directory you meant to protect. **Create a worktree first and run `/assess` from there.**
+
 ## Step 2: Generate the Code Heatmap + Doc Graph
 
 This step produces **two** views of the codebase, both colour-blind-safe (OrRd ramp, no red-green):
@@ -180,7 +182,7 @@ The script prints a one-line summary (file count, lizard vs scc coverage, churn 
 
 **Build artifacts and generated code are filtered by default.** The script excludes two classes of files:
 
-- **Build artifacts**: `main.dart.js`, `*.min.js`, `*.bundle.js`, `*.chunk.js`, `*.map`, sourcemaps, service workers, and files under `node_modules/`, `dist/`, `build/`, `.next/`, `.nuxt/`, `.output/`, `coverage/`, etc.
+- **Build artifacts**: `main.dart.js`, Flutter canvaskit/skwasm runtime bundles (`canvaskit.js`, `skwasm*.js`), `*.min.js`, `*.bundle.js`, `*.chunk.js`, `*.map`, sourcemaps, service workers, and files under `node_modules/`, `dist/`, `build/`, `.next/`, `.nuxt/`, `.output/`, `coverage/`, etc.
 - **Generated code**: protobuf bindings (`*.pb.go`, `*_grpc.pb.go`, `*.pb.gw.go`, `*.connect.go`, `*_pb.ts`, `*_pb.d.ts`, `*_pb2.py`, `*.pb.cc`, `*.pb.h`), Go generators (`*.gen.go`, `wire_gen.go`, `zz_generated_*.go`, `bindata.go`), .NET source generators (`*.designer.cs`, `*.g.cs`), Dart/Flutter codegen (`*.freezed.dart`, `*.g.dart`, `*.gr.dart`).
 
 Full list in `complexity-treemap.py`'s `EXCLUDE_DIRS` and `EXCLUDE_FILE_PATTERNS`. If you specifically want to score these (e.g., to visualise how much of the repo is generated), pass `--include-artifacts`.
@@ -296,7 +298,7 @@ Score navigability from these signals:
 - **Contradictions are out of deterministic scope — hand them to an LLM.** The remaining lint check — contradictions between pages — can't be detected structurally. When the doc set is non-trivial, add a Top-3 / Additional action telling the user to have *their* agent read the doc set for contradictions and stale claims (e.g. "run your LLM over `docs/` to flag pages that contradict each other or the code"). State plainly that `/assess` does not check this.
 - **Centrality × staleness (the priority signal).** `stale_hubs` is ranked by `pagerank × staleness ratio`. The top entry — a central doc whose subject code is churning while the doc sits frozen — is a top finding. This feeds both the docs heatmap and this score.
 - **Doc→code association as a maturity signal.** `doc_staleness.association.pct_code_under_base_doc` and `pct_docs_mapping_to_code`: if the doc→code map is derivable from structure (clean hierarchy/convention), that's positive navigability; docs floating disconnected from the code they describe is a gap.
-- **Modular base docs, size-weighted.** `doc_staleness.modularity`: a module owning a *maintained* base doc is what makes a large codebase navigable to humans and deterministically mappable for an agent. **Weight by size** — do not penalise a small/single-purpose repo (`large_repo: false`); for a `large_repo: true` with low `base_doc_coverage`, flag the Layer 0 gap with remediation "decompose into modules; add a maintained base doc per module." The per-module docs are held to the same maintenance standard — the target is *modular + maintained*, never just "more docs."
+- **Modular base docs, size-weighted.** `doc_staleness.modularity`: a module owning a *maintained* base doc is what makes a large codebase navigable to humans and deterministically mappable for an agent. **The headline metric is `base_doc_dir_ratio`** — the fraction of code-containing directories that actually hold a base doc. Do **not** lead with `base_doc_coverage_when_present`: it reaches `1.0` whenever a single root-level README is an ancestor of every file, which reads as "fully documented" even when only a handful of module dirs have docs (the two fields diverge sharply, e.g. ratio `0.04` vs when-present `1.0`). **Weight by size** — do not penalise a small/single-purpose repo (`large_repo: false`); for a `large_repo: true` with low `base_doc_dir_ratio`, flag the Layer 0 gap with remediation "decompose into modules; add a maintained base doc per module." The per-module docs are held to the same maintenance standard — the target is *modular + maintained*, never just "more docs."
 
 **Truth-pressure ordering of navigation aids** (weight maintained/executable aids higher): executable aids that run in CI (skills, doctests) **>** tests **>** linked-doc graph / MOC **>** prose. Executable aids fail loudly when they rot; prose rots silently.
 
@@ -615,7 +617,9 @@ Before scoring, check what changed since the last run:
 jq '.diff, .diff_detail' "$REPO_ROOT/.assess/run-context.json"
 ```
 
-If `prior` was None (first run), skip this section in the report. Otherwise, populate a "What Changed Since Last Run" section in the report:
+If `prior` was None (first run), skip this section in the report.
+
+**Check `diff_reliable` first.** When `run-context.json` has `diff_reliable: false`, the prior snapshot came from a different (or unstamped) plugin version (`diff_version_note` explains it) - file-filter differences across versions surface phantom "graduated"/"new" transitions that didn't really happen. **Suppress the "What Changed Since Last Run" section** in that case and instead note one line: _"Diff suppressed - prior snapshot predates version stamping or used a different file filter; comparison resumes once two runs share a plugin version."_ Otherwise, populate the section:
 
 - **Graduated** (good): list paths from `diff_detail.graduated` - hotspots that left the top list
 - **Regressed** (bad): list paths from `diff_detail.regressed` with their `ccn_delta` / `commits_delta`
@@ -658,7 +662,7 @@ The "Top 3 Actions" table at the bottom names specific files. Start there.
 - **Files scored:** <N>
 - **Churn window chosen:** <last 12mo | last 24mo | last 5y | all-time>
 - **Complexity profile:** p95 ccn <N> (max <M>); p95 LOC <N> (max <M>)
-- **Top hotspots** (composite: complexity × recent churn):
+- **Top hotspots** (composite `sqrt(ccn) × sqrt(1 + commits)` - a sub-linear blend of complexity and recent churn, so a complex-AND-active file leads, a frozen-but-complex file ranks below it, and a churny-but-trivial file can't top the list on churn alone):
   1. `<path>` — <loc> LOC, ccn <N>, <M> commits in window
   2. ...
   3. ...

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -26,6 +26,7 @@ The LLM reads run-context.json to ground that prose in deterministic data.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -40,7 +41,7 @@ from lib.doc_graph import build_doc_graph, is_repo_file
 from lib.doc_staleness import analyze_doc_staleness
 from lib.git_churn import tracked_files
 from lib.liveness_scan import scan_liveness
-from lib.stats_diff import diff_stats, load_stats
+from lib.stats_diff import diff_stats, hotspot_commits, load_stats
 from lib.wiki_writer import (
     HotspotEntry,
     LogEntry,
@@ -182,6 +183,58 @@ def _read_plugin_version() -> str:
         return "unknown"
 
 
+# Co-location test conventions, keyed off a source file's stem + suffix.
+# Each entry is a (filename-builder) applied in the file's own directory; the
+# first existing match wins. Covers the dominant per-language idioms - it is a
+# cheap precision heuristic, not a build-graph analysis, so a project that keeps
+# all tests in a far-away mirror tree still degrades to "unknown" rather than a
+# false "no".
+_TEST_SIBLING_BUILDERS = [
+    lambda stem, ext: f"{stem}_test{ext}",    # Go, Python (pytest co-located)
+    lambda stem, ext: f"{stem}.test{ext}",    # JS/TS (jest)
+    lambda stem, ext: f"{stem}.spec{ext}",    # JS/TS/Angular (jasmine/jest)
+    lambda stem, ext: f"{stem}_spec{ext}",    # Ruby (rspec), some JS
+    lambda stem, ext: f"test_{stem}{ext}",    # Python (unittest)
+    lambda stem, ext: f"{stem}Test{ext}",     # Java/Kotlin/C# (JUnit)
+    lambda stem, ext: f"{stem}Tests{ext}",    # C#/Swift (XCTest)
+]
+# Adjacent directories that conventionally hold co-located tests for the
+# files beside them. Checked for any of the sibling-name patterns above.
+_ADJACENT_TEST_DIRS = ["__tests__", "tests", "test", "spec"]
+# Suffixes/stem markers that mean the file IS itself a test - it doesn't need a
+# separate test file, so it counts as covered.
+_IS_TEST_RE = re.compile(r"(^test_|_test$|\.test$|\.spec$|_spec$|Tests?$)")
+
+
+def _has_sibling_test(repo_root: Path, rel_path: str) -> bool | None:
+    """Best-effort: does this source file have a co-located test file?
+
+    Returns True/False from a filesystem check of common co-location idioms
+    (`foo.ts` next to `foo.test.ts`, `foo_test.go`, an adjacent `__tests__/`,
+    etc.). Returns None only when the file isn't on disk (e.g. scanning a stats
+    snapshot for a since-deleted path), which honestly maps to "unknown".
+    """
+    src = (repo_root / rel_path)
+    if not src.is_file():
+        return None
+    stem, ext = src.stem, src.suffix
+    if _IS_TEST_RE.search(stem):
+        return True  # the file is itself a test
+    directory = src.parent
+    candidate_names = [build(stem, ext) for build in _TEST_SIBLING_BUILDERS]
+    for name in candidate_names:
+        if (directory / name).is_file():
+            return True
+    for sub in _ADJACENT_TEST_DIRS:
+        test_dir = directory / sub
+        if not test_dir.is_dir():
+            continue
+        for name in candidate_names + [f"{stem}{ext}"]:
+            if (test_dir / name).is_file():
+                return True
+    return False
+
+
 def _load_first_flagged(assess_dir: Path) -> dict[str, str]:
     """Load the first-flagged date map from .assess/first-flagged.json.
 
@@ -266,6 +319,24 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     prior = load_stats(assess_dir / "complexity-stats.prior.json")
     prior_exists = prior is not None
 
+    # A diff is only trustworthy when both snapshots came from the same plugin
+    # filter. When the prior snapshot predates version stamping (seeded by hand,
+    # or written by an older plugin with a looser file filter), "graduated"
+    # entries can be files the new filter simply excludes - phantom transitions,
+    # not real improvement. Detect the mismatch and flag the diff as unreliable
+    # so the report suppresses or caveats it (see SKILL.md).
+    current_version = current.get("plugin_version")
+    prior_version = prior.get("plugin_version") if prior else None
+    diff_reliable = True
+    diff_version_note = None
+    if prior_exists and prior_version != current_version:
+        diff_reliable = False
+        diff_version_note = (
+            f"prior stats from plugin {prior_version or 'unknown'}, current "
+            f"{current_version or 'unknown'}; file-filter differences across "
+            "versions may surface phantom graduated/new transitions"
+        )
+
     diff = diff_stats(prior=prior, current=current)
     instruction_files, instructions_grade, untracked_instr, dangling_instr = \
         _grade_instruction_files(repo_root)
@@ -287,35 +358,45 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # Wiki: hotspot pages for current top hotspots
     hotspot_entries: list[HotspotEntry] = []
     for h in current.get("top_hotspots", []):
-        # Preserve the original first_flagged date; only set it to run_date on first appearance.
-        if h["path"] not in first_flagged_map:
-            first_flagged_map[h["path"]] = run_date
-        first_flagged = first_flagged_map[h["path"]]
-        status = status_map.get(h["path"], "active")
+        path = h["path"]
+        # Preserve the original first_flagged date across runs. A path missing
+        # from the map is either genuinely new this run (stamp today) or it was
+        # present in the prior snapshot but we have no recorded date - e.g. the
+        # prior stats were seeded without first-flagged.json. In the latter case
+        # it predates this run, so an honest "unknown" beats a wrong today.
+        if path not in first_flagged_map:
+            first_flagged_map[path] = (
+                run_date if status_map.get(path) == "new" else "unknown"
+            )
+        first_flagged = first_flagged_map[path]
+        status = status_map.get(path, "active")
+        commits = hotspot_commits(h)
+        loc = h.get("loc", 0)
+        ccn = h.get("ccn", 0)
         hotspot_entries.append(HotspotEntry(
-            path=h["path"],
+            path=path,
             first_flagged=first_flagged,
             last_seen=run_date,
             status=status,
-            ccn=h.get("ccn", 0),
-            loc=h.get("loc", 0),
+            ccn=ccn,
+            loc=loc,
         ))
         write_hotspot_page(
             assess_dir,
-            path=h["path"],
+            path=path,
             first_flagged=first_flagged,
             last_seen=run_date,
             status=status,
-            loc=h.get("loc", 0),
-            ccn=h.get("ccn", 0),
-            commits=h.get("commits", 0),
-            has_tests=None,  # unknown until test pairing feature lands (deferred)
-            history_rows=f"| {run_date} | {h.get('loc', 0)} | {h.get('ccn', 0)} | {h.get('commits', 0)} | {status} |",
+            loc=loc,
+            ccn=ccn,
+            commits=commits,
+            has_tests=_has_sibling_test(repo_root, path),
+            history_rows=f"| {run_date} | {loc} | {ccn} | {commits} | {status} |",
             briefing=(
                 f"Hotspot ({status}). "
-                f"{h.get('loc', 0)} LOC, "
-                f"max cyclomatic complexity {h.get('ccn', 0)}, "
-                f"{h.get('commits', 0)} commits in churn window. "
+                f"{loc} LOC, "
+                f"max cyclomatic complexity {ccn}, "
+                f"{commits} commits in churn window. "
                 "(Briefing refined by LLM via assess_finalize - see Suggested actions below.)"
             ),
             actions="- Pending LLM-generated suggestions",
@@ -325,7 +406,9 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     for h in diff.graduated:
         hotspot_entries.append(HotspotEntry(
             path=h.path,
-            first_flagged=first_flagged_map.get(h.path, run_date),
+            # Graduated means it was a prior hotspot; if we have no recorded
+            # first-flagged date, it predates this run - "unknown", not today.
+            first_flagged=first_flagged_map.get(h.path, "unknown"),
             last_seen=run_date,
             status="graduated",
             ccn=0,
@@ -364,6 +447,9 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
         "instruction_files": instruction_files,
         "instructions_grade": instructions_grade,
         "diff": diff.summary(),
+        "diff_reliable": diff_reliable,
+        "diff_version_note": diff_version_note,
+        "prior_plugin_version": prior_version,
         "diff_detail": {
             "graduated": [h.__dict__ for h in diff.graduated],
             "regressed": [h.__dict__ for h in diff.regressed],

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -113,8 +113,12 @@ EXCLUDE_FILE_PATTERNS = [
     "*-bundle.js", "*-min.js",
     # Sourcemaps and build metadata
     "*.map", "*.tsbuildinfo",
-    # Flutter web outputs
+    # Flutter web outputs. `--web-renderer canvaskit` always emits the
+    # canvaskit/skwasm runtime bundles (framework code, churn=1, not source);
+    # basename globs catch them wherever the build nests them
+    # (e.g. canvaskit/chromium/canvaskit.js).
     "main.dart.js", "flutter_service_worker.js", "flutter.js",
+    "canvaskit.js", "skwasm*.js",
     # PWA / service worker stubs
     "service-worker.js", "sw.js", "workbox-*.js",
 
@@ -354,6 +358,23 @@ def render(files: list[tuple[Path, int, float, str]],
                   f"[{src:6}]  {rel}")
 
 
+def _read_plugin_version() -> str:
+    """Read the plugin version from .claude-plugin/plugin.json.
+
+    plugin.json lives three directories up from this script:
+        scripts/complexity-treemap.py -> scripts/ -> skills/assess/ -> skills/ -> repo root
+    Stamped into the stats sidecar so a later run can detect when its prior
+    snapshot came from a differently-filtered plugin and suppress a misleading
+    diff (filter-mismatched "graduated" ghosts). Returns "unknown" if absent.
+    """
+    plugin_json = Path(__file__).resolve().parents[3] / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(plugin_json.read_text(encoding="utf-8"))
+        return str(data.get("version", "unknown"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "unknown"
+
+
 def write_stats(files: list[tuple[Path, int, float, str]],
                 aux_data: dict[Path, int] | None,
                 aux_label: str | None,
@@ -362,8 +383,10 @@ def write_stats(files: list[tuple[Path, int, float, str]],
 
     Consumed by the /assess skill: percentiles drive Layer 3 (linter) scoring,
     top hotspot lists become the named files in the actions table.
-    Composite hotspot score = ccn * (1 + log1p(churn)), so a vivid
-    red block (complex AND active) outranks a frozen complex file.
+    Composite hotspot score = sqrt(ccn) * sqrt(1 + commits): a sub-linear
+    geometric mean of complexity and recent churn. Both axes are damped, so a
+    complex-AND-active file leads, a frozen-but-complex file ranks below it, and
+    a trivially-simple-but-churny file can't top the list on churn alone.
     """
     locs = [f[1] for f in files]
     ccns = [f[2] for f in files]
@@ -386,9 +409,12 @@ def write_stats(files: list[tuple[Path, int, float, str]],
             "path": rel(path),
             "loc": int(loc),
             "ccn": float(ccn),
-            "churn": int(churn) if aux_data else None,
+            # Named `commits` to match what every consumer reads (stats_diff,
+            # assess_core, the hotspot template). None when churn is unavailable
+            # (no git), so a missing value is distinct from a real 0.
+            "commits": int(churn) if aux_data else None,
             "source": src,
-            "_score": ccn * (1.0 + math.log1p(churn)),
+            "_score": math.sqrt(ccn) * math.sqrt(1.0 + churn),
         })
 
     def strip(rows: list[dict]) -> list[dict]:
@@ -399,6 +425,7 @@ def write_stats(files: list[tuple[Path, int, float, str]],
     by_loc = sorted(enriched, key=lambda f: -f["loc"])
 
     stats: dict = {
+        "plugin_version": _read_plugin_version(),
         "files_scored": len(files),
         "scoring_coverage": {
             "lizard": sum(1 for f in files if f[3] == "lizard"),

--- a/skills/assess/scripts/lib/doc_staleness.py
+++ b/skills/assess/scripts/lib/doc_staleness.py
@@ -287,7 +287,12 @@ def analyze_doc_staleness(
     module_dirs_with_base = len(base_doc_dirs)
     module_dir_count = len(code_dirs)
     base_doc_dir_ratio = module_dirs_with_base / module_dir_count if module_dir_count else 0.0
-    base_doc_coverage = pct_code_under_base
+    # `pct_code_under_base` reaches 1.0 whenever a single root-level base doc
+    # (a top README) is an ancestor of every code file - it does NOT mean every
+    # module is documented. Reported as `base_doc_coverage_when_present` so it
+    # is never misread as headline coverage; `base_doc_dir_ratio` (fraction of
+    # code-containing dirs that actually hold a base doc) is the headline.
+    base_doc_coverage_when_present = pct_code_under_base
 
     return {
         "available": True,
@@ -305,8 +310,9 @@ def analyze_doc_staleness(
         "modularity": {
             "module_dir_count": module_dir_count,
             "module_dirs_with_base_doc": module_dirs_with_base,
-            "base_doc_coverage": round(base_doc_coverage, 3),
+            # Headline first: fraction of code-containing dirs with a base doc.
             "base_doc_dir_ratio": round(base_doc_dir_ratio, 3),
+            "base_doc_coverage_when_present": round(base_doc_coverage_when_present, 3),
             "code_file_count": len(code_files),
             "large_repo": len(code_files) >= LARGE_REPO_CODE_FILES,
         },

--- a/skills/assess/scripts/lib/stats_diff.py
+++ b/skills/assess/scripts/lib/stats_diff.py
@@ -46,6 +46,18 @@ def load_stats(path: Path) -> dict | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def hotspot_commits(h: dict) -> int:
+    """Commit count for a hotspot entry.
+
+    Reads `commits` (current field name), falling back to the legacy `churn`
+    key so a prior snapshot written by an older plugin still compares cleanly.
+    """
+    val = h.get("commits")
+    if val is None:
+        val = h.get("churn", 0)
+    return int(val or 0)
+
+
 def diff_stats(*, prior: dict | None, current: dict) -> StatsDiff:
     """Compute hotspot transitions between two stats snapshots."""
     diff = StatsDiff()
@@ -69,7 +81,7 @@ def diff_stats(*, prior: dict | None, current: dict) -> StatsDiff:
 
         prior_h = prior_hotspots[path]
         ccn_delta = current_h.get("ccn", 0) - prior_h.get("ccn", 0)
-        commits_delta = current_h.get("commits", 0) - prior_h.get("commits", 0)
+        commits_delta = hotspot_commits(current_h) - hotspot_commits(prior_h)
         loc_delta = current_h.get("loc", 0) - prior_h.get("loc", 0)
 
         transition = HotspotTransition(

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -533,3 +533,151 @@ def test_briefing_includes_loc_ccn_commits_and_status(tmp_path: Path) -> None:
     assert "15 commits" in content
     # has_tests should be "unknown" now, not "no"
     assert "Has test file | unknown" in content
+
+
+def test_has_sibling_test_detects_colocated_and_adjacent(tmp_path: Path) -> None:
+    """Co-located and adjacent-dir test files lift has_tests from unknown to
+    yes/no cheaply (issue #47, observation 6)."""
+    repo = tmp_path / "repo"
+    (repo / "go").mkdir(parents=True)
+    (repo / "go" / "foo.go").write_text("package foo")
+    (repo / "go" / "foo_test.go").write_text("package foo")  # co-located
+    (repo / "ts").mkdir()
+    (repo / "ts" / "bar.ts").write_text("export const x = 1")
+    (repo / "ts" / "bar.test.ts").write_text("test")          # co-located .test.
+    (repo / "py").mkdir()
+    (repo / "py" / "baz.py").write_text("x = 1")              # no test
+    (repo / "svc").mkdir()
+    (repo / "svc" / "api.py").write_text("x = 1")
+    (repo / "svc" / "__tests__").mkdir()
+    (repo / "svc" / "__tests__" / "test_api.py").write_text("t")  # adjacent dir
+
+    assert assess_core._has_sibling_test(repo, "go/foo.go") is True
+    assert assess_core._has_sibling_test(repo, "ts/bar.ts") is True
+    assert assess_core._has_sibling_test(repo, "py/baz.py") is False
+    assert assess_core._has_sibling_test(repo, "svc/api.py") is True
+    # The file is itself a test -> counts as covered.
+    assert assess_core._has_sibling_test(repo, "go/foo_test.go") is True
+    # Not on disk (e.g. a since-deleted path in a stats snapshot) -> unknown.
+    assert assess_core._has_sibling_test(repo, "go/gone.go") is None
+
+
+def test_hotspot_page_shows_yes_when_sibling_test_exists(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "foo.go").write_text("package foo")
+    (repo / "src" / "foo_test.go").write_text("package foo")
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 10, "loc": {"p50": 10, "p95": 30, "max": 50},
+        "ccn": {"p50": 1, "p95": 3, "max": 5},
+        "top_hotspots": [{"path": "src/foo.go", "loc": 500, "ccn": 20, "commits": 5}],
+        "top_complex": [], "top_large": [],
+    }))
+    build_run_context(repo_root=repo, run_date="2026-05-22")
+    content = next((assess_dir / "hotspots").iterdir()).read_text(encoding="utf-8")
+    assert "Has test file | yes" in content
+
+
+def test_commits_read_from_legacy_churn_field(tmp_path: Path) -> None:
+    """A stats snapshot using the legacy `churn` key still shows real commits in
+    the hotspot page, not 0 (issue #47, observation 5)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 10, "loc": {"p50": 10, "p95": 30, "max": 50},
+        "ccn": {"p50": 1, "p95": 3, "max": 5},
+        "top_hotspots": [{"path": "src/foo.go", "loc": 500, "ccn": 20, "churn": 33}],
+        "top_complex": [], "top_large": [],
+    }))
+    build_run_context(repo_root=repo, run_date="2026-05-22")
+    content = next((assess_dir / "hotspots").iterdir()).read_text(encoding="utf-8")
+    assert "33 commits" in content
+    assert "Commits in churn window | 33" in content
+
+
+def test_diff_unreliable_when_prior_plugin_version_mismatches(tmp_path: Path) -> None:
+    """A prior snapshot from a different (or unstamped) plugin version flags the
+    diff as unreliable so the report can suppress phantom transitions
+    (issue #47, observation 4)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps({
+        # No plugin_version: seeded by hand / written by an older plugin.
+        "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/old.go", "loc": 500, "ccn": 20, "commits": 5}],
+    }))
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "plugin_version": "1.12.0",
+        "files_scored": 55, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/new.go", "loc": 400, "ccn": 18, "commits": 4}],
+    }))
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-22")
+    assert ctx["diff_reliable"] is False
+    assert ctx["diff_version_note"] is not None
+    assert "1.12.0" in ctx["diff_version_note"]
+
+
+def test_diff_reliable_when_plugin_versions_match(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    stats = {
+        "plugin_version": "1.12.0", "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/a.go", "loc": 500, "ccn": 20, "commits": 5}],
+    }
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps(stats))
+    (assess_dir / "complexity-stats.json").write_text(json.dumps(stats))
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-22")
+    assert ctx["diff_reliable"] is True
+    assert ctx["diff_version_note"] is None
+
+
+def test_first_flagged_unknown_when_prior_seeded_without_history(tmp_path: Path) -> None:
+    """When prior stats are seeded but first-flagged.json isn't, a hotspot that
+    predates this run must read 'unknown', not today's date
+    (issue #47, observation 7)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    # Same hotspot in prior and current -> persistent, predates this run.
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps({
+        "plugin_version": "1.12.0", "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/old.go", "loc": 500, "ccn": 20, "commits": 5}],
+    }))
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "plugin_version": "1.12.0", "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/old.go", "loc": 510, "ccn": 21, "commits": 6}],
+    }))
+    # No first-flagged.json on disk.
+    build_run_context(repo_root=repo, run_date="2026-05-22")
+    page = next((assess_dir / "hotspots").iterdir()).read_text(encoding="utf-8")
+    assert "First flagged: unknown" in page
+    assert "First flagged: 2026-05-22" not in page
+
+
+def test_first_flagged_stamps_today_for_genuinely_new_hotspot(tmp_path: Path) -> None:
+    """A hotspot absent from the prior snapshot is genuinely new -> today."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps({
+        "plugin_version": "1.12.0", "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/old.go", "loc": 500, "ccn": 20, "commits": 5}],
+    }))
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "plugin_version": "1.12.0", "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/fresh.go", "loc": 400, "ccn": 18, "commits": 4}],
+    }))
+    build_run_context(repo_root=repo, run_date="2026-05-22")
+    fresh_page = next(p for p in (assess_dir / "hotspots").iterdir()
+                      if p.name.startswith("src-fresh-go-"))
+    assert "First flagged: 2026-05-22" in fresh_page.read_text(encoding="utf-8")

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -1,0 +1,113 @@
+"""Unit tests for the pure logic inside complexity-treemap.py.
+
+The script imports lizard/matplotlib/numpy at module load (it's a CLI wrapper),
+so those are stubbed in sys.modules before import. We only exercise functions
+that don't touch the real heavy deps: the build-artifact filter, the plugin
+version stamp, and the stats-sidecar enrichment (field naming + hotspot rank).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "complexity-treemap.py"
+
+
+class _StubNumpy(types.ModuleType):
+    """Minimal numpy: only percentile, with numpy's default linear interp."""
+
+    @staticmethod
+    def percentile(values, q):
+        s = sorted(values)
+        if not s:
+            return 0.0
+        k = (len(s) - 1) * q / 100.0
+        f = int(k)
+        c = min(f + 1, len(s) - 1)
+        return float(s[f] + (s[c] - s[f]) * (k - f))
+
+
+def _load_treemap():
+    """Import complexity-treemap.py with heavy deps stubbed out."""
+    for name in ("lizard", "matplotlib", "matplotlib.pyplot", "squarify"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules.setdefault("numpy", _StubNumpy("numpy"))
+    # complexity-treemap does `import matplotlib.pyplot as plt`
+    sys.modules["matplotlib"].pyplot = sys.modules["matplotlib.pyplot"]
+    spec = importlib.util.spec_from_file_location("complexity_treemap", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def treemap():
+    return _load_treemap()
+
+
+@pytest.mark.parametrize("name", [
+    "canvaskit.js",
+    "canvaskit/chromium/canvaskit.js",  # nested, basename still matches
+    "skwasm.js",
+    "skwasm_heavy.js",
+    "main.dart.js",                     # pre-existing Flutter artifact
+])
+def test_flutter_runtime_bundles_are_filtered(treemap, name):
+    assert treemap._is_build_artifact(Path(name)) is True
+
+
+@pytest.mark.parametrize("name", ["app.js", "widget.dart", "canvaskit_helper.dart"])
+def test_real_source_is_not_filtered(treemap, name):
+    assert treemap._is_build_artifact(Path(name)) is False
+
+
+def test_plugin_version_is_stamped_from_plugin_json(treemap):
+    # Resolves the real .claude-plugin/plugin.json three dirs up; must be a real
+    # version string, never the "unknown" fallback.
+    version = treemap._read_plugin_version()
+    assert version != "unknown"
+    assert version[0].isdigit()
+
+
+def test_write_stats_uses_commits_field_and_balanced_rank(treemap, tmp_path):
+    """The per-file churn count is emitted as `commits` (what consumers read),
+    and the balanced composite ranks a moderately-complex active file above a
+    very-complex frozen one (issue #47, observation 2 + 5)."""
+    root = tmp_path
+    frozen_complex = root / "frozen.go"   # high ccn, barely touched
+    active_moderate = root / "active.go"  # moderate ccn, churning
+    files = [
+        (frozen_complex, 800, 1396.0, "lizard"),
+        (active_moderate, 300, 140.0, "lizard"),
+    ]
+    aux_data = {frozen_complex: 1, active_moderate: 45}
+    out = root / "stats.json"
+    treemap.write_stats(files, aux_data, "commits (last 12mo)", root, out)
+
+    stats = json.loads(out.read_text())
+    assert "plugin_version" in stats
+    hotspots = stats["top_hotspots"]
+    # Balanced composite: the active moderate-complexity file leads.
+    assert hotspots[0]["path"] == "active.go"
+    # Field is `commits`, not the legacy `churn`.
+    for h in hotspots:
+        assert "commits" in h
+        assert "churn" not in h
+    by_path = {h["path"]: h for h in hotspots}
+    assert by_path["active.go"]["commits"] == 45
+    assert by_path["frozen.go"]["commits"] == 1
+
+
+def test_write_stats_commits_none_without_git(treemap, tmp_path):
+    """No churn data (no git) -> commits is None, distinct from a real 0."""
+    root = tmp_path
+    f = root / "a.go"
+    out = root / "stats.json"
+    treemap.write_stats([(f, 100, 5.0, "lizard")], None, None, root, out)
+    stats = json.loads(out.read_text())
+    assert stats["top_hotspots"][0]["commits"] is None

--- a/skills/assess/tests/test_doc_staleness.py
+++ b/skills/assess/tests/test_doc_staleness.py
@@ -68,7 +68,7 @@ def test_modularity_large_repo_flag(tmp_path: Path) -> None:
         _write(tmp_path, f"mod{i}/f.py", "x")
     r = analyze_doc_staleness(tmp_path)
     assert r["modularity"]["large_repo"] is True
-    assert r["modularity"]["base_doc_coverage"] == 0.0  # no base docs anywhere
+    assert r["modularity"]["base_doc_coverage_when_present"] == 0.0  # no base docs anywhere
     assert r["modularity"]["base_doc_dir_ratio"] == 0.0
 
 
@@ -90,9 +90,9 @@ def test_base_doc_coverage_is_size_weighted(tmp_path: Path) -> None:
     # Un-weighted dir ratio is low (1 doc'd dir out of 11), but the size-weighted
     # coverage reflects that ~75% of code sits under a maintained base doc.
     assert r["modularity"]["base_doc_dir_ratio"] < 0.2
-    assert r["modularity"]["base_doc_coverage"] >= 0.7
-    # Sanity: the headline matches the same number the association block reports.
-    assert r["modularity"]["base_doc_coverage"] == r["association"]["pct_code_under_base_doc"]
+    assert r["modularity"]["base_doc_coverage_when_present"] >= 0.7
+    # Sanity: the when-present number matches what the association block reports.
+    assert r["modularity"]["base_doc_coverage_when_present"] == r["association"]["pct_code_under_base_doc"]
 
 
 def test_no_git_degrades_to_zero_churn(tmp_path: Path) -> None:

--- a/skills/assess/tests/test_stats_diff.py
+++ b/skills/assess/tests/test_stats_diff.py
@@ -9,8 +9,19 @@ import pytest
 from lib.stats_diff import (
     HotspotTransition,
     diff_stats,
+    hotspot_commits,
     load_stats,
 )
+
+
+def test_hotspot_commits_reads_commits_then_legacy_churn() -> None:
+    """`commits` is the current field; `churn` is the legacy producer name a
+    seeded/older prior snapshot may still carry (issue #47, observation 5)."""
+    assert hotspot_commits({"commits": 12}) == 12
+    assert hotspot_commits({"churn": 7}) == 7        # legacy fallback
+    assert hotspot_commits({"commits": 3, "churn": 99}) == 3  # commits wins
+    assert hotspot_commits({}) == 0
+    assert hotspot_commits({"commits": None, "churn": None}) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #47.

## Summary

Eight discrete gaps surfaced by an `/assess` v1.11.0 run, all verified against the deterministic core before fixing. Distinct from #48 (which closed #46 - a different feedback batch).

## Changes Made

| # | Observation | Fix | Files |
|---|-------------|-----|-------|
| 1 | Flutter `canvaskit/*.js` + `skwasm*.js` runtime bundles ranked as top hotspots | Added `canvaskit.js`, `skwasm*.js` to `EXCLUDE_FILE_PATTERNS` (basename globs catch nested copies) | `complexity-treemap.py` |
| 2 | `top_hotspots` ranked raw CCN over the documented composite (ccn 1396/churn 1 beat ccn 140/churn 45) | Balanced sub-linear composite `sqrt(ccn) * sqrt(1 + commits)` | `complexity-treemap.py`, `SKILL.md` |
| 3 | `base_doc_coverage` read as 100% when only a root README was an ancestor | Renamed to `base_doc_coverage_when_present`; `base_doc_dir_ratio` is now the documented headline | `doc_staleness.py`, `SKILL.md` |
| 4 | Diff unreliable across plugin versions (filter-mismatched "graduated" ghosts) | Stamp `plugin_version` into `complexity-stats.json`; detect mismatch and set `diff_reliable: false` + `diff_version_note`; SKILL.md tells the report to suppress the diff | `complexity-treemap.py`, `assess_core.py`, `SKILL.md` |
| 5 | Hotspot pages always showed `Commits in churn window: 0` | Producer emitted a per-file `churn` key while every consumer read `commits`. Now emits `commits`; consumers read it with a legacy `churn` fallback | `complexity-treemap.py`, `stats_diff.py`, `assess_core.py` |
| 6 | `Has test file: unknown` with no fallback | Co-location + adjacent-dir sibling heuristic (`foo_test.go`, `foo.test.ts`, `__tests__/`, etc.); stays `unknown` only when the file isn't on disk | `assess_core.py` |
| 7 | `first-flagged` stamped today for hotspots that predate the run when prior history wasn't seeded | A hotspot in the prior snapshot but absent from `first-flagged.json` now reads `unknown`, not today | `assess_core.py` |
| 8 | Write-protected repo root doesn't block the `uv` subprocess writing `.assess/` | SKILL.md note: run `/assess` from a worktree when the root is pristine | `SKILL.md` |

## Testing

- 34 new tests: treemap producer logic (filter, balanced rank, `commits` field, version stamp), `stats_diff` legacy fallback, the test-file heuristic, version-mismatch detection, and first-flagged degradation.
- Full assess suite: **146 passed**. Standalone-build suite: **69 passed**.
- End-to-end treemap run verified: `plugin_version` stamped, per-file `commits` key present, balanced composite orders an active moderate-complexity file above a frozen complex one.

## Versioning

**No `plugin.json` bump.** 1.12.0 is unreleased on `main` (from #45); these fixes ride in the same window and fold into the 1.12.0 release notes - matching the precedent set by #48.

## Risk Assessment

Behaviour changes are confined to `/assess` output: hotspot ordering (balanced composite), one `run-context.json` field rename (`base_doc_coverage` -> `base_doc_coverage_when_present`), and a per-file stats key rename (`churn` -> `commits`) with a backward-compatible read path for older on-disk snapshots.