### PR TITLE
fix(assess): wiki output bugs surfaced by external review

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -403,7 +403,31 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
             actions="- Pending LLM-generated suggestions",
         )
 
-    # Also surface graduated hotspots in the index
+    # Also surface graduated hotspots in the index. Carry the file's actual
+    # current metrics across the three top-N lists in `current` - graduating
+    # off `top_hotspots[:10]` means the file fell out of the composite
+    # ranking, NOT that its LOC or CCN dropped to zero. A graduated file
+    # almost always still appears in `top_complex` (top 10 by raw CCN) or
+    # `top_large` (top 10 by raw LOC) since those are wider views, so we
+    # can recover real numbers in the common case. Merge metrics per-path
+    # because top_complex entries carry only `ccn` and top_large entries
+    # carry only `loc` - only top_hotspots carries both. When a metric
+    # genuinely isn't present in any list, leave it as None - the wiki
+    # renders None as "-" rather than misleading zeros (issue #52 Bug 1).
+    current_locs: dict[str, int] = {}
+    current_ccns: dict[str, int] = {}
+    for src_key in ("top_hotspots", "top_complex", "top_large"):
+        for entry in current.get(src_key, []):
+            path = entry.get("path")
+            if not path:
+                continue
+            loc = entry.get("loc")
+            ccn = entry.get("ccn")
+            if loc is not None and path not in current_locs:
+                current_locs[path] = int(loc)
+            if ccn is not None and path not in current_ccns:
+                current_ccns[path] = int(ccn)
+
     for h in diff.graduated:
         hotspot_entries.append(HotspotEntry(
             path=h.path,
@@ -412,8 +436,8 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
             first_flagged=first_flagged_map.get(h.path, "unknown"),
             last_seen=run_date,
             status="graduated",
-            ccn=0,
-            loc=0,
+            ccn=current_ccns.get(h.path),
+            loc=current_locs.get(h.path),
         ))
 
     # Persist the updated first-flagged map for future runs
@@ -433,6 +457,7 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
         new_count=len(diff.new),
         persistent_count=len(diff.persistent),
         top_action=top_action,
+        plugin_version=_read_plugin_version(),
     )
     append_log_entry(assess_dir, log_entry)
 

--- a/skills/assess/scripts/lib/wiki_writer.py
+++ b/skills/assess/scripts/lib/wiki_writer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 
@@ -20,8 +21,15 @@ class HotspotEntry:
     first_flagged: str
     last_seen: str
     status: str   # active | graduated | regressed | persistent
-    ccn: int
-    loc: int
+    # `ccn` and `loc` are `None` when the file's current metrics are not
+    # carried in the latest stats sidecar (e.g. a graduated file that fell
+    # off every top-N list). The wiki renders `None` as "-" - the file
+    # may still be sized, we just don't have current numbers. Zero is
+    # reserved for "actually zero LOC" and must never stand in for
+    # "unknown" - that misleads reviewers into thinking the file was
+    # emptied (issue #52 Bug 1).
+    ccn: int | None
+    loc: int | None
 
 
 @dataclass(frozen=True)
@@ -36,6 +44,12 @@ class LogEntry:
     new_count: int
     persistent_count: int
     top_action: str
+    # Plugin version that produced this entry. Always rendered in the
+    # heading so the log doubles as a version history and two runs on the
+    # same calendar day stay distinguishable. Optional only for
+    # backwards-compat with callers that don't pass it yet; new code
+    # should always set it (issue #52 Bug 2).
+    plugin_version: str | None = None
     report_link: str = "./assess-report.md"
 
 
@@ -60,8 +74,13 @@ def write_index(assess_dir: Path, entries: list[HotspotEntry], *, last_updated: 
     """(Re)write index.md from the current set of hotspot entries."""
     rows = []
     for e in entries:
+        # `None` -> "-" so an unknown metric never reads as "the file was
+        # emptied." Real zeros (rare for tracked source code) still render
+        # as `0`.
+        ccn_cell = "-" if e.ccn is None else str(e.ccn)
+        loc_cell = "-" if e.loc is None else str(e.loc)
         rows.append(
-            f"| `{e.path}` | {e.first_flagged} | {e.last_seen} | {e.status} | {e.ccn} | {e.loc} |"
+            f"| `{e.path}` | {e.first_flagged} | {e.last_seen} | {e.status} | {ccn_cell} | {loc_cell} |"
         )
     content = _load_template("index.md.template").format(
         last_updated=last_updated,
@@ -70,11 +89,44 @@ def write_index(assess_dir: Path, entries: list[HotspotEntry], *, last_updated: 
     (assess_dir / "index.md").write_text(content, encoding="utf-8")
 
 
+def _build_log_heading(
+    *, run_date: str, plugin_version: str | None, existing: str,
+) -> str:
+    """Build a unique `## ...` heading for a new log.md entry.
+
+    Two collisions to defend against (issue #52 Bug 2):
+
+    1. The plugin version is always rendered when present (so the log
+       doubles as a version history). Two same-day runs at different
+       versions are naturally distinguished.
+    2. If the same `## YYYY-MM-DD (vX.Y.Z)` heading already exists in
+       the file, append the current local time `HH:MM` so anchor links
+       don't collide and markdownlint MD024 stays quiet. Using local
+       time matches `run_date` (which is also local), so a reader
+       doesn't see a timezone mismatch.
+    """
+    if plugin_version:
+        base = f"## {run_date} (v{plugin_version})"
+    else:
+        base = f"## {run_date}"
+    if base not in existing:
+        return base
+    # Already an entry with this exact heading - disambiguate with time.
+    stamp = datetime.now().strftime("%H:%M")
+    return f"{base[:-1]} {stamp})" if plugin_version else f"{base} {stamp}"
+
+
 def append_log_entry(assess_dir: Path, entry: LogEntry) -> None:
     """Append a dated entry to log.md (create the file if absent)."""
     log_path = assess_dir / "log.md"
-    snippet = _load_template("log_entry.md.template").format(
+    existing = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+    heading = _build_log_heading(
         run_date=entry.run_date,
+        plugin_version=entry.plugin_version,
+        existing=existing,
+    )
+    snippet = _load_template("log_entry.md.template").format(
+        heading=heading,
         files_scored=entry.files_scored,
         readiness_score=entry.readiness_score,
         maturity_label=entry.maturity_label,
@@ -86,8 +138,8 @@ def append_log_entry(assess_dir: Path, entry: LogEntry) -> None:
         top_action=entry.top_action,
         report_link=entry.report_link,
     )
-    if log_path.exists():
-        log_path.write_text(log_path.read_text(encoding="utf-8") + snippet, encoding="utf-8")
+    if existing:
+        log_path.write_text(existing + snippet, encoding="utf-8")
     else:
         log_path.write_text("# Assess Log\n\n" + snippet, encoding="utf-8")
 

--- a/skills/assess/templates/log_entry.md.template
+++ b/skills/assess/templates/log_entry.md.template
@@ -1,4 +1,4 @@
-## {run_date}
+{heading}
 
 - **Files scored:** {files_scored}
 - **AI Readiness:** {readiness_score} / 8 ({maturity_label})

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -208,6 +208,96 @@ def test_build_run_context_second_run_sees_diff(tmp_path: Path) -> None:
     assert ctx["diff"]["new"] == 1
 
 
+def test_graduated_index_row_carries_current_metrics(tmp_path: Path) -> None:
+    """Issue #52 Bug 1: when a file graduates off top_hotspots[:10] but is
+    still present in top_complex or top_large, the index row must show its
+    *current* CCN and LOC, not 0. Zero in those columns reads as "the file
+    was emptied," contradicts assess-report.md, and misleads reviewers."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+
+    # Prior run: src/legacy.go was a top hotspot.
+    prior_stats = {
+        "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [
+            {"path": "src/legacy.go", "loc": 1096, "ccn": 172, "commits": 5},
+        ],
+        "top_complex": [{"path": "src/legacy.go", "ccn": 172}],
+        "top_large": [{"path": "src/legacy.go", "loc": 1096}],
+    }
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps(prior_stats))
+
+    # Current run: src/legacy.go dropped off top_hotspots (a bigger file
+    # took its slot) but still appears in top_complex and top_large at its
+    # actual current metrics. This is the case CodeRabbit caught.
+    current_stats = {
+        "files_scored": 55, "loc": {}, "ccn": {},
+        "top_hotspots": [
+            {"path": "src/giant.go", "loc": 2500, "ccn": 200, "commits": 8},
+        ],
+        "top_complex": [
+            {"path": "src/giant.go", "ccn": 200},
+            {"path": "src/legacy.go", "ccn": 172},
+        ],
+        "top_large": [
+            {"path": "src/giant.go", "loc": 2500},
+            {"path": "src/legacy.go", "loc": 1096},
+        ],
+    }
+    (assess_dir / "complexity-stats.json").write_text(json.dumps(current_stats))
+
+    build_run_context(repo_root=repo, run_date="2026-05-29")
+    index = (assess_dir / "index.md").read_text(encoding="utf-8")
+
+    # The graduated row must reflect reality: 1,096 LOC, ccn 172. NEVER 0.
+    legacy_row = next(line for line in index.splitlines() if "src/legacy.go" in line)
+    assert "graduated" in legacy_row
+    assert "| 172 | 1096 |" in legacy_row, (
+        f"expected current ccn/loc, got: {legacy_row}"
+    )
+    # The active row stays intact.
+    assert "src/giant.go" in index
+
+
+def test_graduated_index_row_uses_dash_when_metrics_unknown(tmp_path: Path) -> None:
+    """When a graduated file fell off every top-N list (no current metrics
+    available anywhere), the row renders `-` rather than misleading zeros."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+
+    # Prior: src/legacy.go was a hotspot.
+    prior_stats = {
+        "files_scored": 50, "loc": {}, "ccn": {},
+        "top_hotspots": [
+            {"path": "src/legacy.go", "loc": 800, "ccn": 90, "commits": 3},
+        ],
+        "top_complex": [{"path": "src/legacy.go", "ccn": 90}],
+        "top_large": [{"path": "src/legacy.go", "loc": 800}],
+    }
+    (assess_dir / "complexity-stats.prior.json").write_text(json.dumps(prior_stats))
+
+    # Current: src/legacy.go fell off ALL top-N lists (none of them mention it).
+    current_stats = {
+        "files_scored": 55, "loc": {}, "ccn": {},
+        "top_hotspots": [
+            {"path": "src/new.go", "loc": 600, "ccn": 80, "commits": 4},
+        ],
+        "top_complex": [{"path": "src/new.go", "ccn": 80}],
+        "top_large": [{"path": "src/new.go", "loc": 600}],
+    }
+    (assess_dir / "complexity-stats.json").write_text(json.dumps(current_stats))
+
+    build_run_context(repo_root=repo, run_date="2026-05-29")
+    index = (assess_dir / "index.md").read_text(encoding="utf-8")
+    legacy_row = next(line for line in index.splitlines() if "src/legacy.go" in line)
+    # Sentinel "-" not "0" - never lie about the size.
+    assert "| - | - |" in legacy_row
+
+
 def test_build_run_context_writes_hotspot_pages(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/skills/assess/tests/test_wiki_writer.py
+++ b/skills/assess/tests/test_wiki_writer.py
@@ -62,6 +62,32 @@ def test_write_index_overwrites(tmp_assess_dir: Path) -> None:
     assert "src/new.go" in content
 
 
+def test_write_index_renders_none_metrics_as_dash(tmp_assess_dir: Path) -> None:
+    """A graduated file that fell off every top-N list has unknown current
+    metrics. The wiki must render those as `-`, never as `0` - zero in this
+    column reads as "the file was emptied" and contradicts the report
+    (issue #52 Bug 1)."""
+    entries = [HotspotEntry(
+        path="src/grad.go", first_flagged="2026-01-01", last_seen="2026-05-29",
+        status="graduated", ccn=None, loc=None,
+    )]
+    write_index(tmp_assess_dir, entries, last_updated="2026-05-29")
+    content = (tmp_assess_dir / "index.md").read_text()
+    # `-` appears in the row's metric cells; `0` must not.
+    row = [line for line in content.splitlines() if "src/grad.go" in line][0]
+    assert "| - | - |" in row
+    # Real zeros remain zeros (rare for tracked source, but the renderer
+    # must distinguish them from unknown values).
+    entries = [HotspotEntry(
+        path="src/empty.go", first_flagged="2026-01-01", last_seen="2026-05-29",
+        status="graduated", ccn=0, loc=0,
+    )]
+    write_index(tmp_assess_dir, entries, last_updated="2026-05-29")
+    content = (tmp_assess_dir / "index.md").read_text()
+    row = [line for line in content.splitlines() if "src/empty.go" in line][0]
+    assert "| 0 | 0 |" in row
+
+
 def test_append_log_entry_creates_file_if_missing(tmp_assess_dir: Path) -> None:
     entry = LogEntry(
         run_date="2026-05-22", files_scored=100, readiness_score=4.5,
@@ -88,6 +114,77 @@ def test_append_log_entry_appends(tmp_assess_dir: Path) -> None:
     assert "2026-05-01" in content  # old entry preserved
     assert "2026-05-22" in content  # new entry appended
     assert content.index("2026-05-01") < content.index("2026-05-22")
+
+
+def test_log_heading_includes_plugin_version(tmp_assess_dir: Path) -> None:
+    """The log heading always carries the plugin version when known. This
+    makes the log a version history at a glance and naturally disambiguates
+    same-day runs across versions (issue #52 Bug 2)."""
+    entry = LogEntry(
+        run_date="2026-05-29", files_scored=100, readiness_score=4.5,
+        maturity_label="Solid", instructions_grade="B+",
+        graduated_count=0, regressed_count=0, new_count=0, persistent_count=0,
+        top_action="X", plugin_version="1.13.0",
+    )
+    append_log_entry(tmp_assess_dir, entry)
+    content = (tmp_assess_dir / "log.md").read_text()
+    assert "## 2026-05-29 (v1.13.0)" in content
+
+
+def test_log_heading_disambiguates_same_date_same_version(tmp_assess_dir: Path) -> None:
+    """Two runs on the same date AT THE SAME version must produce distinct
+    headings - otherwise GitHub anchors collide and markdownlint MD024
+    fires. Second run appends a HH:MM timestamp inside the parentheses."""
+    base = dict(
+        run_date="2026-05-29", files_scored=100, readiness_score=4.5,
+        maturity_label="Solid", instructions_grade="B+",
+        graduated_count=0, regressed_count=0, new_count=0, persistent_count=0,
+        top_action="X", plugin_version="1.13.0",
+    )
+    append_log_entry(tmp_assess_dir, LogEntry(**base))
+    append_log_entry(tmp_assess_dir, LogEntry(**base))
+
+    content = (tmp_assess_dir / "log.md").read_text()
+    headings = [line for line in content.splitlines() if line.startswith("## ")]
+    assert len(headings) == 2
+    # First heading has no time; second has a HH:MM stamp inside the parens.
+    assert headings[0] == "## 2026-05-29 (v1.13.0)"
+    assert headings[1].startswith("## 2026-05-29 (v1.13.0 ")
+    assert headings[1].endswith(")")
+    # No two identical headings (the bug condition).
+    assert headings[0] != headings[1]
+
+
+def test_log_heading_same_date_different_versions_each_unique(tmp_assess_dir: Path) -> None:
+    """Same-day runs at different plugin versions distinguish themselves
+    via the version in the heading - no time stamp needed."""
+    base = dict(
+        run_date="2026-05-29", files_scored=100, readiness_score=4.5,
+        maturity_label="Solid", instructions_grade="B+",
+        graduated_count=0, regressed_count=0, new_count=0, persistent_count=0,
+        top_action="X",
+    )
+    append_log_entry(tmp_assess_dir, LogEntry(**base, plugin_version="1.12.0"))
+    append_log_entry(tmp_assess_dir, LogEntry(**base, plugin_version="1.13.0"))
+
+    content = (tmp_assess_dir / "log.md").read_text()
+    assert "## 2026-05-29 (v1.12.0)" in content
+    assert "## 2026-05-29 (v1.13.0)" in content
+
+
+def test_log_heading_omits_version_when_none(tmp_assess_dir: Path) -> None:
+    """A caller that doesn't pass plugin_version (older code path) still
+    works - the heading falls back to the bare date format."""
+    entry = LogEntry(
+        run_date="2026-05-29", files_scored=100, readiness_score=4.5,
+        maturity_label="Solid", instructions_grade="B+",
+        graduated_count=0, regressed_count=0, new_count=0, persistent_count=0,
+        top_action="X",
+    )
+    append_log_entry(tmp_assess_dir, entry)
+    content = (tmp_assess_dir / "log.md").read_text()
+    assert "## 2026-05-29" in content
+    assert "(v" not in content
 
 
 def test_write_hotspot_page_creates_file(tmp_assess_dir: Path) -> None:


### PR DESCRIPTION
Closes #52.

## Summary

Two deterministic-core wiki bugs caught by a CodeRabbit review of v1.11.0/v1.12.0 assessment artifacts on a downstream PR. Both manifest as cross-file contradictions: \`index.md\` and \`assess-report.md\` describe the same files differently, and \`log.md\` has duplicate same-day headings that break GitHub anchors.

## Bug 1: graduated rows showed \`0\` for current metrics

\`.assess/index.md\` rendered \`Latest CCN | 0 | Latest LOC | 0\` for graduated files. The same files appeared in \`assess-report.md\` as still 1,000+ LOC ccn-170+ problems. Graduation just means the file fell off \`top_hotspots[:10]\`; its actual metrics are still in the stats sidecar.

Fix: \`assess_core.py\` merges \`top_hotspots\` + \`top_complex\` + \`top_large\` per-path before building graduated rows. The merge is per-field because \`top_complex\` carries only \`ccn\` and \`top_large\` carries only \`loc\` (only \`top_hotspots\` carries both). When a metric genuinely isn't in any list, \`HotspotEntry.ccn / .loc\` stay \`None\` and \`write_index\` renders them as \`-\`. Real zeros (rare for tracked source) still render as \`0\`, so the renderer distinguishes "unknown" from "actually empty."

## Bug 2: log.md duplicate \`## YYYY-MM-DD\` headings

When multiple runs landed on the same calendar day, the log gained multiple identical \`## 2026-05-29\` headings. Three downstream problems: GitHub auto-anchors collide (\`#2026-05-29\`, \`#2026-05-29-1\`, ...), \`markdownlint\` MD024 fires, and skim-reading the log is harder.

Fix: \`LogEntry\` now carries \`plugin_version\`. The heading is always \`## YYYY-MM-DD (vX.Y.Z)\` when version is set, so the log doubles as a version history and two same-day runs across versions distinguish themselves naturally. If the same version+date heading already exists in the file, \`_build_log_heading()\` appends a \`HH:MM\` stamp inside the parens. Backwards compat: callers that don't pass \`plugin_version\` get the bare \`## YYYY-MM-DD\` heading.

## Changes Made

- \`skills/assess/scripts/assess_core.py\` (~25 lines): merge top-N lists per-field into \`current_locs\` and \`current_ccns\`; pass values to \`HotspotEntry\` for graduated files; pass \`plugin_version=_read_plugin_version()\` to \`LogEntry\`.
- \`skills/assess/scripts/lib/wiki_writer.py\`: \`HotspotEntry.ccn / .loc\` typed \`int | None\`; \`write_index\` renders \`None\` as \`-\`; new \`_build_log_heading()\` helper; \`LogEntry.plugin_version: str | None = None\`; \`append_log_entry\` reads the existing log to detect collisions.
- \`skills/assess/templates/log_entry.md.template\`: heading line changed from hardcoded \`## {run_date}\` to \`{heading}\` so the writer can build it with version + optional time stamp.
- 7 new tests (5 in \`test_wiki_writer.py\`, 2 in \`test_assess_core.py\`).
- \`plugin.json\`: 1.13.0 -> 1.13.1 (PATCH).

## Out of scope (named)

Issue #52 also suggested adding a "consistency lint" pass at the end of \`assess_core\` that catches cross-file contradictions ("does index.md agree with complexity-stats.json on every file's current metrics?" / "does any date in log.md appear more than once?"). Worth doing as structural prevention - tracking as a follow-up. The two named bugs are the immediate fix.

## Testing

- \`skills/assess/\` pytest: **171 passed** (7 new)
- \`scripts/\` pytest: **69 passed**
- \`bash scripts/build-standalone-skills.sh assess\`: clean (260 KB ZIP)

## Risk Assessment

- \`HotspotEntry.ccn / .loc\` type widened from \`int\` to \`int | None\`. Any external readers of the dataclass would need to handle \`None\` - none exist outside the deterministic core.
- Existing log.md files keep their old \`## YYYY-MM-DD\` headings (the file is append-only; we only change new headings). Anchor links to old sections still work.
- \`LogEntry.plugin_version\` is optional with default \`None\` for backwards compat with any caller that constructs \`LogEntry\` directly.