### PR TITLE
fix(assess): Step 5 push-detection uses viewerPermission

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -805,34 +805,44 @@ After writing the files, first **check whether a direct PR is even possible** be
 
 ```bash
 # Detect push capability. `gh` returns viewer fields for the current user.
-PUSH_INFO=$(gh repo view --json viewerPermission,viewerCanPush,viewerCanAdminister,nameWithOwner 2>/dev/null || true)
+# Push capability is derived from `viewerPermission` (one of ADMIN |
+# MAINTAIN | WRITE | TRIAGE | READ | NONE) - GitHub's GraphQL Repository
+# type has no `viewerCanPush` field, so don't request it (the CLI errors
+# and the whole call returns empty, silently degrading every write-
+# accessible repo to the "leave local" branch).
+PUSH_INFO=$(gh repo view --json viewerPermission,viewerCanAdminister,nameWithOwner 2>/dev/null || true)
+PERM=$(echo "$PUSH_INFO" | jq -r '.viewerPermission // empty')
+case "$PERM" in
+  ADMIN|MAINTAIN|WRITE) CAN_PUSH=1 ;;
+  *)                    CAN_PUSH=0 ;;
+esac
 # If the command failed (no remote, no gh, not a GitHub repo, unauthenticated),
-# fall back to the local-branch flow with the reason - never silently assume
-# push works.
+# $PUSH_INFO is empty and $PERM stays empty - fall back to the local-branch
+# flow with the reason. Never silently assume push works.
 ```
 
 Interpret the result:
 
-- `viewerCanPush: true` (any of `WRITE` / `MAINTAIN` / `ADMIN` viewerPermission, or push-eligible fork access): offer the direct PR flow below.
-- `viewerCanPush: false` and `viewerPermission` is `READ` / `TRIAGE`: name the constraint, then offer the fork-based PR flow ("fork `<owner>/<repo>` and open the PR from your fork?") as an alternative to "leave local". Do not offer the direct flow.
-- `gh` unavailable / not a GitHub remote / not authenticated: skip both PR offers entirely and surface only the "leave local" outcome, naming the reason ("no GitHub remote detected" / "`gh` not authenticated").
+- `CAN_PUSH=1` (viewerPermission is `WRITE` / `MAINTAIN` / `ADMIN`, or the remote is a push-eligible fork): offer the direct PR flow below.
+- `CAN_PUSH=0` and viewerPermission is `READ` / `TRIAGE`: name the constraint, then offer the fork-based PR flow ("fork `<owner>/<repo>` and open the PR from your fork?") as an alternative to "leave local". Do not offer the direct flow.
+- `gh` unavailable / not a GitHub remote / not authenticated (`$PUSH_INFO` empty): skip both PR offers entirely and surface only the "leave local" outcome, naming the reason ("no GitHub remote detected" / "`gh` not authenticated").
 
 Then surface the question - verbatim, picking the shape that matches the access tier.
 
-Push-capable target (`viewerCanPush: true`):
+Push-capable target (`CAN_PUSH=1`):
 
 > Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. Want me to open a PR in this repo with these files, or leave them local for you to review first?
 
-Read-only target (`READ` / `TRIAGE`):
+Read-only target (viewerPermission `READ` / `TRIAGE`):
 
 > Wrote `.assess/assess-report.md`, `.assess/complexity-heatmap.svg`, and `.assess/doc-graph.svg` in `<repo-name>`. You have `READ` access to `<owner/repo>`, so a direct PR isn't possible. I can fork `<owner/repo>` to your account and open the PR from there, or leave the files local for you to review.
 
-If the user says **yes / PR** (direct flow, `viewerCanPush: true`):
+If the user says **yes / PR** (direct flow, `CAN_PUSH=1`):
 1. Create a branch in the target repo: `assess/snapshot-<YYYY-MM-DD>` (use the existing worktree workflow if `<repo>-main` + `worktree/` layout is present; otherwise branch in place).
 2. Stage and commit the report, the complexity heatmap, and the doc graph. Commit message: `docs: Add AI-readiness assessment + complexity and doc-navigability snapshots`.
 3. Push the branch and open a PR. Title: `docs: Codebase assessment — <YYYY-MM-DD>`.
 
-If the user says **yes / PR** (fork flow, `viewerCanPush: false` on the upstream):
+If the user says **yes / PR** (fork flow, `CAN_PUSH=0` on the upstream):
 1. `gh repo fork <owner>/<repo> --clone=false --remote=true` (creates the fork under the user's account and adds it as a remote named `origin` or similar; the upstream becomes `upstream` if the original was already `origin`).
 2. Create the branch as above, push to the **fork** (`git push -u <fork-remote> <branch>`), and open the PR via `gh pr create --repo <owner>/<repo>` (head defaults to the fork).
 3. Commit message, PR title, and body are unchanged from the direct flow.


### PR DESCRIPTION
Closes #55.

## Summary

v1.13.1's new Step 5 push-detection requested \`viewerCanPush\` from \`gh repo view --json\`, but **GitHub's GraphQL Repository type has no such field**. The CLI errors and prints the valid field list; the existing \`2>/dev/null\` mask hides the error but \`\$PUSH_INFO\` comes back empty, downstream logic falls into the "no GitHub remote / unauthenticated" branch, and on **every** write-accessible repo the user gets "leave local" instead of the push-vs-fork offer the v1.13.1 feature was meant to add.

## Validation (before / after)

\`\`\`bash
\$ gh repo view --json viewerPermission,viewerCanPush,viewerCanAdminister,nameWithOwner
Unknown JSON field: "viewerCanPush"
Available fields:
  archivedAt
  assignableUsers
  ...

\$ gh repo view --json viewerPermission,viewerCanAdminister,nameWithOwner
{"nameWithOwner":"bjcoombs/ai-native-toolkit","viewerCanAdminister":true,"viewerPermission":"ADMIN"}
\`\`\`

And the full fixed block end-to-end on this repo:

\`\`\`
PUSH_INFO={"nameWithOwner":"bjcoombs/ai-native-toolkit","viewerCanAdminister":true,"viewerPermission":"ADMIN"}
PERM=ADMIN
CAN_PUSH=1
\`\`\`

## Changes Made

- \`skills/assess/SKILL.md\` Step 5:
  - Detection block: dropped \`viewerCanPush\` from the field list, added a \`PERM\` extraction and a \`case\` statement that sets \`CAN_PUSH\` from the \`viewerPermission\` enum.
  - Interpretation bullets: read \`CAN_PUSH=1\` / \`CAN_PUSH=0\` plus \`viewerPermission\` instead of the non-existent flag. Empty-\`\$PUSH_INFO\` case kept as the fallback for "no remote / no gh / unauthenticated."
  - Prompt-shape headers and the two yes/PR conditions (direct flow, fork flow) updated for consistency.
  - Added an inline comment explaining *why* \`viewerCanPush\` isn't requested, so the next reader doesn't reinstate it.
- \`.claude-plugin/plugin.json\`: 1.13.1 -> 1.13.2 (PATCH).

## Testing

- \`skills/assess/\` pytest: **171 passed** (no test changes; this is SKILL.md prose only)
- \`scripts/\` pytest: **69 passed**
- \`bash scripts/build-standalone-skills.sh assess\`: clean (261 KB ZIP)
- Manual: validated the exact bash block from the fixed SKILL.md against this repo; returns \`PERM=ADMIN\`, \`CAN_PUSH=1\` as expected.

## Risk Assessment

- SKILL.md prose only. No code changes, no API surface, no schema change.
- The fix restores the intended v1.13.1 behaviour on write-accessible repos; no behaviour change for read-only repos (which were already correctly handled by the \`viewerPermission\` check in the same step).