### PR TITLE
feat(assess): add complexity × doc-staleness join (Signal C)

### DIFF
--- a/skills/assess/scripts/lib/doc_complexity_join.py
+++ b/skills/assess/scripts/lib/doc_complexity_join.py
@@ -1,0 +1,292 @@
+"""Signal C: complexity x doc-state join (joins two artifacts the skill already has).
+
+The treemap tells us *where the complexity is*; the doc-staleness metric tells
+us *whether the map beside it still tracks the territory*. Crossing them turns
+each into something neither has alone -- a judgement about whether a complex
+unit is safely *legible through a keyhole*:
+
+  - complex + **fresh doc**  -> the doc is the contract (good; footprint relieved).
+  - complex + **no doc**     -> high load, no summary an agent can read first.
+  - complex + **stale doc**  -> a *lying map* over dangerous territory. The doc
+                                tells the agent the wrong thing; worse than none.
+
+Quantified as a single signed number per unit::
+
+    doc_value = complexity_summarised x freshness
+
+where ``complexity_summarised`` is the **max cyclomatic complexity** of the code
+the doc covers, and ``freshness`` is **signed** in ``[-1, +1]`` -- positive when
+the doc keeps pace with its code, crossing to **negative** once the code has
+churned past the doc by more than a staleness threshold. Two consequences fall
+straight out of the multiplication, exactly as the PRD requires:
+
+  - trivial code  -> ``complexity_summarised`` is small  -> ``doc_value`` ~= 0
+    regardless of the doc's state (an out-of-date note on a one-liner is noise,
+    not a finding).
+  - stale doc over complex code -> ``freshness < 0`` -> ``doc_value < 0``: a doc
+    in this quadrant is *worth less than no doc*, so the recommendation is
+    fix-or-DELETE, never "preserve".
+
+**Slop-doc guard (hard constraint).** Nothing here ever recommends
+auto-generating a doc to clear a flag -- that manufactures lying maps at scale.
+An honest *undocumented* unit (``unexplained_complexity``, ``doc_value == 0``)
+must score **strictly safer** than a hollow stale summary (``lying_map``,
+``doc_value < 0``), and it does: ``0 > negative``. Recommendations are advice
+for a human, never an instruction to synthesise prose.
+
+**Doc->code mapping is deliberately fuzzy** -- nearest-ancestor by path
+proximity over the paths already present in the two input artifacts. It is a
+*candidate* signal pointing a human at a unit, not a verdict, so no filesystem
+read or symbol resolution is required (and the function stays trivially
+testable from mocked dicts).
+
+This module is **standalone**: it consumes the JSON-serialisable outputs of the
+complexity treemap (``complexity-stats.json``) and ``analyze_doc_staleness`` and
+returns a JSON-serialisable dict. Integration into ``assess_core`` /
+``run-context.json`` is a separate task's job -- nothing here imports or edits
+the core.
+"""
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+# Code that churns more than this multiple of its doc's own churn is treated as
+# having outrun the map: freshness crosses zero here and reaches -1 at twice
+# this ratio. 2.0 = "the code changed twice as often as anyone touched the doc".
+# The doc-staleness metric already computes this ratio (code_churn / doc_churn)
+# as its core decaying-map signal; we only map it onto a signed scale.
+STALENESS_RATIO_THRESHOLD = 2.0
+
+# McCabe's classic "moderate risk" line. We gate findings on the *higher* of
+# this floor and the repo's own 95th-percentile CCN, so a genuinely simple repo
+# never sprouts "high complexity" findings, while a complex repo self-calibrates
+# to flag only its worst ~5%.
+MIN_HIGH_CCN = 10.0
+
+# Per-finding advice. Every string is guidance for a human; none instructs
+# anyone (or any tool) to synthesise documentation -- see the slop-doc guard.
+_RECOMMENDATIONS = {
+    "lying_map": (
+        "Fix or DELETE this doc. A stale summary over complex code is worse "
+        "than none -- it lies to the next agent. Do not auto-generate a "
+        "replacement; a hollow summary is still a lying map."
+    ),
+    "unexplained_complexity": (
+        "Complex code with no doc and no intent source. A human should write "
+        "the missing contract. Do NOT auto-generate it -- an honest gap is "
+        "safer than a synthetic summary."
+    ),
+    "good_contract": (
+        "Keep. The doc is fresh and carries real complexity -- this is the "
+        "contract relieving the comprehension footprint."
+    ),
+}
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _extract_file_ccn(complexity_stats: dict) -> dict[str, float]:
+    """Build path -> max-CCN from whatever per-file lists the stats expose.
+
+    ``complexity-stats.json`` carries per-file CCN only in its ranked lists
+    (``top_complex`` / ``top_hotspots`` / ``top_large``); we union them (and an
+    optional full ``files`` list, for forward-compatibility) and keep the
+    highest CCN seen per path. Percentiles live elsewhere in the dict and are
+    read separately for the threshold.
+    """
+    ccn: dict[str, float] = {}
+    for key in ("files", "top_complex", "top_hotspots", "top_large"):
+        for entry in complexity_stats.get(key) or []:
+            path = entry.get("path")
+            if path is None or entry.get("ccn") is None:
+                continue
+            value = float(entry["ccn"])
+            if value > ccn.get(path, float("-inf")):
+                ccn[path] = value
+    return ccn
+
+
+def _high_ccn_threshold(complexity_stats: dict) -> float:
+    """The CCN at or above which a unit counts as 'high complexity'."""
+    p95 = float((complexity_stats.get("ccn") or {}).get("p95", 0.0) or 0.0)
+    return max(p95, MIN_HIGH_CCN)
+
+
+def _signed_freshness(doc: dict) -> float:
+    """Map the doc-staleness ``ratio`` onto a signed freshness in [-1, +1].
+
+    ``ratio`` (code churn per unit of doc maintenance) is the doc-staleness
+    metric's decaying-map signal: 0 when the code is as quiet as the doc, large
+    when the code churns while the doc sits frozen. Piecewise-linear::
+
+        ratio = 0                       -> +1.0  (doc fully keeps pace)
+        ratio = THRESHOLD               ->  0.0  (doc starts lagging)
+        ratio >= 2 * THRESHOLD          -> -1.0  (doc has outrun, clamped)
+    """
+    ratio = float(doc.get("ratio", 0.0) or 0.0)
+    return round(_clamp((STALENESS_RATIO_THRESHOLD - ratio) / STALENESS_RATIO_THRESHOLD,
+                        -1.0, 1.0), 3)
+
+
+def _doc_dir_parts(doc_path: str) -> tuple[str, ...]:
+    """Directory the doc lives in, as path parts (() for a repo-root doc)."""
+    return PurePosixPath(doc_path).parent.parts
+
+
+def _covers(doc_dir: tuple[str, ...], code_parts: tuple[str, ...]) -> bool:
+    """True if ``code`` sits in the doc's directory or any subdirectory."""
+    return code_parts[: len(doc_dir)] == doc_dir
+
+
+def _assign_code_to_docs(
+    code_paths: list[str], doc_paths: list[str],
+) -> dict[str, list[str]]:
+    """Assign each code file to its *nearest-ancestor* doc by path proximity.
+
+    A doc covers code in its own directory and below; when several docs cover
+    the same file the deepest (longest directory prefix) wins -- the same
+    nearest-match rule ``CODEOWNERS`` and the doc-staleness metric use. Ties
+    break on doc path for determinism. Files no doc covers are simply absent
+    from the result (they become ``unexplained_complexity`` candidates).
+    """
+    doc_dirs = {d: _doc_dir_parts(d) for d in doc_paths}
+    assignment: dict[str, list[str]] = {d: [] for d in doc_paths}
+    for code in code_paths:
+        code_parts = PurePosixPath(code).parts
+        candidates = [
+            (len(dir_parts), doc)
+            for doc, dir_parts in doc_dirs.items()
+            if _covers(dir_parts, code_parts)
+        ]
+        if not candidates:
+            continue
+        _, nearest = max(candidates, key=lambda t: (t[0], t[1]))
+        assignment[nearest].append(code)
+    return assignment
+
+
+def analyze_doc_complexity_join(
+    complexity_stats: dict, doc_staleness: dict, repo_root: Path,
+) -> dict:
+    """Join complexity hotspots with doc freshness into Signal C findings.
+
+    Args:
+        complexity_stats: the ``complexity-stats.json`` sidecar (per-file CCN in
+            its ranked lists; CCN percentiles under ``ccn``).
+        doc_staleness: the dict returned by ``analyze_doc_staleness`` (per-doc
+            ``ratio`` / ``confidence`` under ``docs``).
+        repo_root: repository root. Accepted for signature parity with the rest
+            of the pipeline; the join itself needs no filesystem access (the
+            doc->code mapping is path-proximity over the input artifacts), which
+            keeps it deterministic and testable from mocked dicts.
+
+    Returns a JSON-serialisable dict::
+
+        {
+          "available": bool,
+          "high_ccn_threshold": float,
+          "docs": [ {path, complexity_summarised, freshness, doc_value,
+                     finding, confidence, subject_code_count, recommendation} ],
+          "findings": {"lying_maps": [...], "unexplained_complexity": [...],
+                       "good_contracts": [...]},
+        }
+
+    The ``docs`` list mixes two unit kinds: real docs (a freshness-signed
+    ``doc_value``) and undocumented high-complexity code surfaced as
+    ``unexplained_complexity`` (``freshness == 0`` -> ``doc_value == 0``, per the
+    PRD's "missing -> 0" rule). Suitable as-is for ``run-context.json``'s
+    ``documentation`` block (task #5's job to place it there).
+    """
+    repo_root = Path(repo_root)  # parity only; unused by the deterministic join
+
+    file_ccn = _extract_file_ccn(complexity_stats)
+    threshold = _high_ccn_threshold(complexity_stats)
+
+    docs_in = (
+        doc_staleness.get("docs", [])
+        if doc_staleness.get("available", False)
+        else []
+    )
+    doc_paths = [d["path"] for d in docs_in]
+    assignment = _assign_code_to_docs(list(file_ccn), doc_paths)
+    covered_code = {c for codes in assignment.values() for c in codes}
+
+    units: list[dict] = []
+    lying_maps: list[dict] = []
+    unexplained: list[dict] = []
+    good_contracts: list[dict] = []
+
+    # --- Real docs: classify by (complexity it covers) x (its freshness) ---
+    for doc in docs_in:
+        path = doc["path"]
+        subject = assignment.get(path, [])
+        complexity_summarised = round(
+            max((file_ccn[c] for c in subject), default=0.0), 2
+        )
+        freshness = _signed_freshness(doc)
+        doc_value = round(complexity_summarised * freshness, 3)
+
+        finding: str | None = None
+        # Trivial code never produces a finding: complexity_summarised below the
+        # high bar means doc_value is already near zero, so the doc's state is
+        # noise either way.
+        if complexity_summarised >= threshold:
+            if freshness < 0:
+                finding = "lying_map"
+            elif freshness > 0:
+                finding = "good_contract"
+
+        unit = {
+            "path": path,
+            "complexity_summarised": complexity_summarised,
+            "freshness": freshness,
+            "doc_value": doc_value,
+            "finding": finding,
+            "confidence": doc.get("confidence"),
+            "subject_code_count": len(subject),
+            "recommendation": _RECOMMENDATIONS.get(finding) if finding else None,
+        }
+        units.append(unit)
+        if finding == "lying_map":
+            lying_maps.append(unit)
+        elif finding == "good_contract":
+            good_contracts.append(unit)
+
+    # --- Undocumented high-complexity code: unexplained_complexity ---
+    # No covering doc => no intent source within this signal's reach. doc_value
+    # is 0 (the "missing -> 0" branch), so an honest gap scores strictly safer
+    # than a lying map -- the slop-doc guard in numbers.
+    for code, ccn in file_ccn.items():
+        if code in covered_code or round(ccn, 2) < threshold:
+            continue
+        unit = {
+            "path": code,
+            "complexity_summarised": round(ccn, 2),
+            "freshness": 0.0,
+            "doc_value": 0.0,
+            "finding": "unexplained_complexity",
+            "confidence": None,
+            "subject_code_count": 0,
+            "recommendation": _RECOMMENDATIONS["unexplained_complexity"],
+        }
+        units.append(unit)
+        unexplained.append(unit)
+
+    # Deterministic ordering, most-actionable first within each bucket.
+    units.sort(key=lambda u: (u["doc_value"], u["path"]))
+    lying_maps.sort(key=lambda u: (u["doc_value"], u["path"]))
+    unexplained.sort(key=lambda u: (-u["complexity_summarised"], u["path"]))
+    good_contracts.sort(key=lambda u: (-u["doc_value"], u["path"]))
+
+    return {
+        "available": True,
+        "high_ccn_threshold": round(threshold, 2),
+        "docs": units,
+        "findings": {
+            "lying_maps": lying_maps,
+            "unexplained_complexity": unexplained,
+            "good_contracts": good_contracts,
+        },
+    }

--- a/skills/assess/tests/test_doc_complexity_join.py
+++ b/skills/assess/tests/test_doc_complexity_join.py
@@ -1,0 +1,158 @@
+"""Tests for Signal C: the complexity x doc-state join.
+
+Inputs are MOCKED dicts shaped like the real artifacts (``complexity-stats.json``
+and ``analyze_doc_staleness``'s return) -- no git, no filesystem -- so every
+``doc_value`` below is hand-computable from the documented formula:
+
+    freshness  = clamp((T - ratio) / T, -1, +1),   T = STALENESS_RATIO_THRESHOLD = 2.0
+    doc_value  = complexity_summarised x freshness
+    threshold  = max(ccn.p95, MIN_HIGH_CCN=10)
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lib.doc_complexity_join import (
+    MIN_HIGH_CCN,
+    STALENESS_RATIO_THRESHOLD,
+    analyze_doc_complexity_join,
+)
+
+# A repo whose 95th-percentile CCN (8) sits below the McCabe floor, so the
+# high-complexity gate is the floor, 10. core.py (CCN 30) is "complex";
+# helper.py (CCN 2) is trivial.
+COMPLEXITY_STATS = {
+    "ccn": {"p50": 3.0, "p95": 8.0, "max": 30.0},
+    "files_scored": 2,
+    "top_complex": [
+        {"path": "pkg/engine/core.py", "loc": 400, "ccn": 30.0, "commits": 50},
+        {"path": "pkg/util/helper.py", "loc": 20, "ccn": 2.0, "commits": 1},
+    ],
+    "top_hotspots": [],
+    "top_large": [],
+}
+
+
+def _staleness(docs: list[dict]) -> dict:
+    return {"available": True, "churn_window": "12mo", "docs": docs}
+
+
+def _doc(path: str, ratio: float, confidence: str = "high") -> dict:
+    return {
+        "path": path,
+        "ratio": ratio,
+        "last_commit_days": 10,
+        "doc_churn_in_window": 4,
+        "code_churn_in_window": int(ratio * 4),
+        "subject_code_count": 1,
+        "subject_method": "nearest-ancestor",
+        "confidence": confidence,
+    }
+
+
+def _by_path(result: dict) -> dict[str, dict]:
+    return {u["path"]: u for u in result["docs"]}
+
+
+def test_complex_plus_fresh_is_good_contract() -> None:
+    """Fresh doc (ratio 0.5) over CCN-30 code -> good_contract, positive value."""
+    staleness = _staleness([_doc("pkg/engine/README.md", ratio=0.5)])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/engine/README.md"]
+    # freshness = (2.0 - 0.5) / 2.0 = 0.75 ; doc_value = 30 * 0.75 = 22.5
+    assert doc["complexity_summarised"] == 30.0
+    assert doc["freshness"] == 0.75
+    assert doc["doc_value"] == 22.5
+    assert doc["doc_value"] > 0
+    assert doc["finding"] == "good_contract"
+    assert [u["path"] for u in result["findings"]["good_contracts"]] == [
+        "pkg/engine/README.md"
+    ]
+
+
+def test_complex_plus_stale_is_lying_map_negative_value() -> None:
+    """Stale doc (ratio 6.0) over CCN-30 code -> lying_map, NEGATIVE value."""
+    staleness = _staleness([_doc("pkg/engine/README.md", ratio=6.0)])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/engine/README.md"]
+    # freshness = clamp((2 - 6) / 2, -1, 1) = -1.0 ; doc_value = 30 * -1 = -30
+    assert doc["freshness"] == -1.0
+    assert doc["doc_value"] == -30.0
+    assert doc["doc_value"] < 0
+    assert doc["finding"] == "lying_map"
+    # Slop-doc guard: the recommendation never says "auto-generate".
+    rec = doc["recommendation"].lower()
+    assert "delete" in rec
+    assert "auto-generate" in rec  # ...prefixed by "do not"
+    assert "do not auto-generate" in rec
+
+
+def test_complex_plus_no_doc_is_unexplained_complexity() -> None:
+    """CCN-30 code with no doc covering it -> unexplained_complexity, value 0."""
+    # Only a doc far away that covers nothing complex.
+    staleness = _staleness([_doc("docs/unrelated/notes.md", ratio=0.5)])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    core = _by_path(result)["pkg/engine/core.py"]
+    assert core["finding"] == "unexplained_complexity"
+    assert core["freshness"] == 0.0
+    assert core["doc_value"] == 0.0  # missing -> 0
+    assert [u["path"] for u in result["findings"]["unexplained_complexity"]] == [
+        "pkg/engine/core.py"
+    ]
+    # The recommendation forbids auto-generation (slop-doc guard).
+    assert "do not auto-generate" in core["recommendation"].lower()
+
+
+def test_trivial_file_has_near_zero_doc_value_and_no_finding() -> None:
+    """A doc over CCN-2 code scores ~0 and raises no finding, fresh or stale."""
+    staleness = _staleness([_doc("pkg/util/README.md", ratio=0.5)])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/util/README.md"]
+    # complexity_summarised = 2 (helper.py) ; freshness 0.75 -> doc_value 1.5
+    assert doc["complexity_summarised"] == 2.0
+    assert doc["doc_value"] == 1.5
+    assert abs(doc["doc_value"]) < MIN_HIGH_CCN  # negligible vs a real hotspot
+    assert doc["finding"] is None
+    # The trivial doc appears in no findings bucket. (core.py, which this doc
+    # does not cover, is correctly surfaced as unexplained_complexity elsewhere.)
+    flagged = {
+        u["path"]
+        for bucket in result["findings"].values()
+        for u in bucket
+    }
+    assert "pkg/util/README.md" not in flagged
+    assert result["findings"]["lying_maps"] == []
+    assert result["findings"]["good_contracts"] == []
+
+
+def test_slop_doc_guard_honest_gap_beats_lying_map() -> None:
+    """An undocumented unit must score strictly safer than a hollow stale doc."""
+    lying = analyze_doc_complexity_join(
+        COMPLEXITY_STATS, _staleness([_doc("pkg/engine/README.md", ratio=6.0)]),
+        Path("/repo"),
+    )
+    honest = analyze_doc_complexity_join(
+        COMPLEXITY_STATS, _staleness([_doc("docs/unrelated/notes.md", ratio=0.5)]),
+        Path("/repo"),
+    )
+    lying_value = lying["findings"]["lying_maps"][0]["doc_value"]
+    honest_value = honest["findings"]["unexplained_complexity"][0]["doc_value"]
+    assert honest_value > lying_value  # 0 > -30
+
+
+def test_result_is_json_serialisable() -> None:
+    staleness = _staleness([
+        _doc("pkg/engine/README.md", ratio=6.0),
+        _doc("pkg/util/README.md", ratio=0.5),
+    ])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+    # Round-trips without error and preserves the threshold contract.
+    reloaded = json.loads(json.dumps(result))
+    assert reloaded["available"] is True
+    assert reloaded["high_ccn_threshold"] == max(8.0, MIN_HIGH_CCN)
+    assert STALENESS_RATIO_THRESHOLD == 2.0


### PR DESCRIPTION
## Summary

Adds the deterministic core for **Signal C** of the assess keyhole-readiness PRD: a standalone module that joins the complexity treemap with the doc-staleness metric into a single signed `doc_value` per unit. This is `assess-keyhole-readiness.2` from the implementation plan.

New module `skills/assess/scripts/lib/doc_complexity_join.py` (standalone — does **not** touch `assess_core.py`; integration into `run-context.json` is a later task).

## Changes Made

- `analyze_doc_complexity_join(complexity_stats, doc_staleness, repo_root) -> dict` returning JSON-serialisable `docs` (per-unit) + `findings` (`lying_maps` / `unexplained_complexity` / `good_contracts`).
- `doc_value = complexity_summarised × freshness`, where `complexity_summarised` is the **max CCN** of the code a doc covers and `freshness` is **signed** in `[-1, +1]`.
- New test file with hand-computed expectations (no git, no filesystem).

## Technical Details

- **Freshness** maps the doc-staleness `ratio` (code-churn ÷ doc-churn) onto a signed scale, piecewise-linear: `+1` at ratio 0, crossing `0` at `STALENESS_RATIO_THRESHOLD = 2.0`, clamped to `-1` at twice that.
- **High-complexity gate** = `max(ccn.p95, MIN_HIGH_CCN=10)` (McCabe's moderate-risk floor) so simple repos raise no findings and complex repos self-calibrate to their worst ~5%.
- **Findings:** complex+fresh → `good_contract` (positive value); complex+stale → `lying_map` (**negative** value — worse than no doc); complex+undocumented → `unexplained_complexity` (value 0).
- **Doc→code mapping** is fuzzy nearest-ancestor by path proximity over the input artifacts — a candidate signal, not a verdict, requiring no filesystem access.
- **Slop-doc guard:** recommendations never instruct auto-generating a doc; an honest undocumented unit (`doc_value == 0`) scores strictly safer than a hollow stale summary (`doc_value < 0`).

## Testing

- 6 new tests covering the four PRD cases (complex+fresh, complex+stale, complex+no-doc, trivial), the slop-doc guard ordering, and JSON round-trip.
- `cd skills/assess && uv run --with pytest pytest`: **177 passed** (full suite, no regressions).

## Risk Assessment

Low. Additive, standalone module with no edits to existing code; deterministic (no AI, no new dependencies).

## Deployment Notes

No `plugin.json` bump — single version bump happens in the release PR (#6).