### PR TITLE
feat(assess): add git-log change-coupling primitives (B1/B2/B4)

### DIFF
--- a/skills/assess/scripts/lib/change_coupling.py
+++ b/skills/assess/scripts/lib/change_coupling.py
@@ -1,0 +1,378 @@
+"""Git-log change-coupling and authorship primitives for the /assess core.
+
+Three deterministic signals derived purely from ``git log``, mirroring the
+subprocess+stdlib style of ``lib.git_churn`` (no AI, no heavy deps, every git
+call capped by ``GIT_TIMEOUT_SECONDS`` and degrading to an empty/neutral result
+on failure):
+
+  - **B1 change-coupling** (:func:`change_coupling_pairs`) - file pairs that
+    keep co-changing in the same commit. Hidden edges an agent can't see from
+    the import graph: edit A and you probably need to edit B.
+  - **B2 containment** (:func:`containment_ratio`) - what fraction of the
+    commits that touch a module touch *only* that module. High = a safe island
+    an agent can change without ripples leaking out.
+  - **B4 authorship** (:func:`authorship_analysis`) - whether a path has a human
+    anchor and a human intent source, and a deliberately conservative
+    human/agent/mixed/unknown class. We never label a human's work "agent" on
+    weak evidence (PRD Open Question 6): detection is e-mail-based, never on a
+    person's *name* (someone really can be called "Claude").
+
+All returned structures are JSON-serialisable (paths as strings, plain
+dict/list/bool/number) so task #5 can drop them straight into run-context.json.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from itertools import combinations
+from pathlib import Path
+
+# Cap every git call so a stuck invocation (huge repo, lock contention, a hung
+# credential prompt) degrades to "no data" rather than blocking the run. Same
+# value and rationale as lib.git_churn.
+GIT_TIMEOUT_SECONDS = 20
+
+# Commits that touch more files than this are bulk/mechanical (mass renames,
+# vendoring, reformatting, license headers). Pairing every file in them would
+# both explode combinatorially (n^2) and drown the genuine coupling signal in
+# noise, so they are excluded from pair generation. They still count toward the
+# commit total (the support_pct denominator).
+MAX_COMMIT_FILES_FOR_COUPLING = 50
+
+# --- Agent detection (e-mail based, conservative) ----------------------------
+# We classify by e-mail, NEVER by display name: "Claude", "Cursor" and "Codex"
+# are all real human given names/surnames, and mislabelling a person's work as
+# agent-generated is the failure mode PRD Open Question 6 tells us to avoid.
+# `[bot]` is the GitHub Apps convention (dependabot, renovate, github-actions,
+# copilot all commit as `name[bot]`); the anthropic/copilot addresses cover the
+# common Co-Authored-By trailers. We deliberately do NOT treat bare
+# `noreply@github.com` / `users.noreply.github.com` as a bot - those are the
+# privacy addresses humans use for web-UI commits.
+AI_EMAIL_HINTS = (
+    "[bot]",
+    "noreply@anthropic.com",
+    "copilot@",
+)
+
+_CO_AUTHORED_BY = re.compile(r"co-authored-by:\s*(.+)", re.IGNORECASE)
+
+
+def _repo_top(repo_root: Path) -> str | None:
+    """Absolute repo top-level for ``repo_root``, or None if not in a git repo."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def parse_commit_file_sets(repo_root: Path, since: str | None = None) -> list[set[Path]]:
+    """Return one set of touched files per commit, parsed from ``git log``.
+
+    Each set holds the repo-relative paths (as git prints them with
+    ``--name-only``) changed by a single commit, newest first. Merge commits and
+    commits that changed no files yield an empty set, so the list length equals
+    the number of commits in the window - callers that need a commit count can
+    use ``len(...)``. Returns ``[]`` when ``repo_root`` is not inside a git repo.
+
+    Pass ``since`` as a git date expression (e.g. ``"12 months ago"``) to window
+    the history; ``None`` (default) means full history reachable from HEAD.
+    Renames are not followed - a file appears only under its current name.
+    """
+    repo_top = _repo_top(repo_root)
+    if repo_top is None:
+        return []
+
+    # \x1e (ASCII record separator) marks the start of each commit so we can
+    # split unambiguously; the name-only file list follows on its own lines.
+    cmd = ["git", "-C", repo_top, "log", "--name-only", "--pretty=format:\x1e%H"]
+    if since:
+        cmd.append(f"--since={since}")
+    try:
+        raw = subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+
+    commit_sets: list[set[Path]] = []
+    for chunk in raw.split("\x1e"):
+        if not chunk.strip():
+            continue
+        lines = chunk.splitlines()
+        # lines[0] is the commit hash; the rest are touched files.
+        files: set[Path] = set()
+        for line in lines[1:]:
+            line = line.strip()
+            if line:
+                files.add(Path(line))
+        commit_sets.append(files)
+    return commit_sets
+
+
+def change_coupling_pairs(
+    commit_sets: list[set[Path]], min_support: int = 3,
+) -> list[dict]:
+    """B1: file pairs that co-change, from :func:`parse_commit_file_sets` output.
+
+    For every commit, all unordered file pairs are tallied; a pair is reported
+    only when its ``co_change_count`` reaches ``min_support`` (default 3). Each
+    entry is ``{file_a, file_b, co_change_count, support_pct}`` with paths as
+    strings and ``file_a < file_b`` lexicographically. ``support_pct`` is the
+    percentage of *all* commits in the window in which the pair co-changed
+    (``100 * co_change_count / len(commit_sets)``).
+
+    Commits touching more than ``MAX_COMMIT_FILES_FOR_COUPLING`` files are
+    skipped for pairing (bulk/mechanical noise) but still count toward the
+    support denominator. Results are sorted by count descending, then path.
+    """
+    total_commits = len(commit_sets)
+    counts: dict[tuple[str, str], int] = {}
+    for files in commit_sets:
+        if len(files) < 2 or len(files) > MAX_COMMIT_FILES_FOR_COUPLING:
+            continue
+        # sorted() over Paths gives a deterministic, file_a<file_b ordering.
+        for a, b in combinations(sorted(files), 2):
+            key = (str(a), str(b))
+            counts[key] = counts.get(key, 0) + 1
+
+    pairs = [
+        {
+            "file_a": a,
+            "file_b": b,
+            "co_change_count": count,
+            "support_pct": round(100.0 * count / total_commits, 2) if total_commits else 0.0,
+        }
+        for (a, b), count in counts.items()
+        if count >= min_support
+    ]
+    pairs.sort(key=lambda d: (-d["co_change_count"], d["file_a"], d["file_b"]))
+    return pairs
+
+
+def _normalise_module(repo_root: Path, module_path: Path | str) -> Path:
+    """Return ``module_path`` as a repo-relative Path to match commit file sets."""
+    mod = Path(module_path)
+    if mod.is_absolute():
+        repo_top = _repo_top(repo_root)
+        if repo_top:
+            try:
+                mod = mod.resolve().relative_to(Path(repo_top).resolve())
+            except ValueError:
+                pass
+    return mod
+
+
+def containment_ratio(
+    repo_root: Path, module_path: Path | str, commit_sets: list[set[Path]],
+) -> float:
+    """B2: fraction of commits touching ``module_path`` that touch *only* it.
+
+    ``commits touching only files in the module / commits touching the module at
+    all``. 1.0 means every change to the module was self-contained (a safe
+    island an agent can edit without ripples); a low value means edits to the
+    module routinely drag in files elsewhere.
+
+    ``module_path`` may be a directory or a file, absolute or repo-relative; it
+    is normalised to the repo-relative form that :func:`parse_commit_file_sets`
+    produces. A file is "in the module" if it equals or sits under that path.
+
+    **Zero commits touch the module -> returns 1.0.** With no observed bleed
+    there is nothing to contradict containment, so it is treated as vacuously
+    contained. Callers that must tell "safe island" from "no history" should
+    check module activity separately (e.g. via churn).
+    """
+    mod = _normalise_module(repo_root, module_path)
+
+    def in_module(f: Path) -> bool:
+        if f == mod:
+            return True
+        try:
+            f.relative_to(mod)
+            return True
+        except ValueError:
+            return False
+
+    touching = 0
+    only = 0
+    for files in commit_sets:
+        if not files:
+            continue
+        in_mod = [f for f in files if in_module(f)]
+        if in_mod:
+            touching += 1
+            if len(in_mod) == len(files):
+                only += 1
+
+    if touching == 0:
+        return 1.0
+    return only / touching
+
+
+def _identity_is_agent(email: str, name: str = "") -> bool:
+    """True if an identity belongs to a known bot/agent.
+
+    Matches the ``[bot]`` GitHub Apps marker in either name or e-mail (a reserved
+    convention no human carries, so safe to match on the name), plus the
+    AI-tool e-mail hints. AI tool *names* ("Claude", "Cursor") are never matched
+    - those are real human names too (PRD Open Question 6).
+    """
+    e = email.lower()
+    n = name.lower()
+    if "[bot]" in e or "[bot]" in n:
+        return True
+    return any(hint in e for hint in AI_EMAIL_HINTS)
+
+
+def _coauthors_have_agent(coauthor_field: str) -> bool:
+    """True if any Co-Authored-By trailer names an agent (matched on its e-mail)."""
+    # Trailer values look like "Claude <noreply@anthropic.com>"; we match the
+    # bracketed e-mail, never the display name.
+    for value in coauthor_field.split("\x1d"):
+        value = value.strip()
+        if not value:
+            continue
+        emails = re.findall(r"<([^>]+)>", value)
+        target = emails[0] if emails else value
+        if _identity_is_agent(target):
+            return True
+    return False
+
+
+def authorship_analysis(repo_root: Path, path: Path | str) -> dict:
+    """B4: human-anchor / intent-source signals and a conservative class for ``path``.
+
+    Returns ``{human_anchor, authorship_class, intent_source, contributors}``:
+
+      - ``human_anchor`` (bool): a confirmed human authored at least one commit -
+        someone who can be asked about the code.
+      - ``intent_source`` (bool): a human authored *or* committed at least one
+        commit - a human directed the change even if an agent wrote the diff.
+      - ``authorship_class``: one of ``'human'``, ``'agent'``, ``'mixed'``,
+        ``'unknown'``. Deliberately cautious - ``'agent'`` requires that *every*
+        commit is a confirmed agent with no human and no ambiguous author;
+        anything uncertain falls back to ``'unknown'`` rather than risk
+        attributing a person's work to a machine (PRD Open Question 6).
+      - ``contributors``: per-author ``{name, email, commits, lines_added,
+        lines_removed, classification}``, sorted by commit count descending.
+
+    Degrades to ``{human_anchor: False, authorship_class: 'unknown',
+    intent_source: False, contributors: []}`` when there is no git history (path
+    untracked, repo absent, git missing/slow).
+    """
+    default = {
+        "human_anchor": False,
+        "authorship_class": "unknown",
+        "intent_source": False,
+        "contributors": [],
+    }
+    repo_top = _repo_top(repo_root)
+    if repo_top is None:
+        return default
+
+    # One record per commit, RS-delimited; fields US-delimited. Co-author
+    # trailers are folded onto one line with a GS (\x1d) separator so the header
+    # stays single-line and numstat rows follow it cleanly.
+    fmt = "\x1e%H\x1f%an\x1f%ae\x1f%cn\x1f%ce\x1f%(trailers:key=Co-authored-by,valueonly,separator=%x1d)"
+    try:
+        raw = subprocess.run(
+            ["git", "-C", repo_top, "log", "--no-merges", "--numstat",
+             f"--format={fmt}", "--", str(path)],
+            capture_output=True, text=True, check=True, timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return default
+
+    any_agent = False
+    any_human = False
+    n_unknown = 0
+    intent_source = False
+    # Aggregate per author identity (name, email).
+    contributors: dict[tuple[str, str], dict] = {}
+    total_commits = 0
+
+    for chunk in raw.split("\x1e"):
+        if not chunk.strip():
+            continue
+        lines = chunk.split("\n")
+        fields = lines[0].split("\x1f")
+        # Pad in case a field is empty/missing.
+        fields += [""] * (6 - len(fields))
+        _h, an, ae, cn, ce, coauthors = fields[:6]
+        total_commits += 1
+
+        author_agent = _identity_is_agent(ae, an)
+        committer_agent = _identity_is_agent(ce, cn)
+        coauthor_agent = _coauthors_have_agent(coauthors)
+        author_human = bool(ae.strip()) and "@" in ae and not author_agent
+        committer_human = bool(ce.strip()) and "@" in ce and not committer_agent
+
+        agent_involved = author_agent or committer_agent or coauthor_agent
+        if agent_involved:
+            any_agent = True
+        if author_human:
+            any_human = True
+        if author_human or committer_human:
+            intent_source = True
+        if not author_human and not agent_involved:
+            n_unknown += 1
+
+        # Line stats: numstat rows are "added\tremoved\tfile"; "-" marks binary.
+        added = removed = 0
+        for row in lines[1:]:
+            row = row.strip()
+            if not row:
+                continue
+            parts = row.split("\t")
+            if len(parts) >= 2:
+                added += int(parts[0]) if parts[0].isdigit() else 0
+                removed += int(parts[1]) if parts[1].isdigit() else 0
+
+        if author_agent:
+            classification = "agent"
+        elif author_human:
+            classification = "human"
+        else:
+            classification = "unknown"
+        key = (an, ae)
+        agg = contributors.get(key)
+        if agg is None:
+            contributors[key] = {
+                "name": an,
+                "email": ae,
+                "commits": 1,
+                "lines_added": added,
+                "lines_removed": removed,
+                "classification": classification,
+            }
+        else:
+            agg["commits"] += 1
+            agg["lines_added"] += added
+            agg["lines_removed"] += removed
+
+    if total_commits == 0:
+        return default
+
+    if any_agent and any_human:
+        authorship_class = "mixed"
+    elif any_agent and not any_human:
+        # Agent evidence but no confirmed human. Only call it pure 'agent' when
+        # there is zero ambiguity; otherwise stay 'unknown' to avoid claiming a
+        # possibly-human commit was agent-made.
+        authorship_class = "agent" if n_unknown == 0 else "unknown"
+    elif any_human and not any_agent:
+        authorship_class = "human"
+    else:
+        authorship_class = "unknown"
+
+    contributor_list = sorted(
+        contributors.values(), key=lambda c: (-c["commits"], c["name"], c["email"]),
+    )
+    return {
+        "human_anchor": any_human,
+        "authorship_class": authorship_class,
+        "intent_source": intent_source,
+        "contributors": contributor_list,
+    }

--- a/skills/assess/tests/test_change_coupling.py
+++ b/skills/assess/tests/test_change_coupling.py
@@ -1,0 +1,288 @@
+"""Tests for the git-log change-coupling and authorship primitives (B1/B2/B4).
+
+Fixtures build synthetic git histories in tmp dirs. Expected values are
+hand-computed in each test's docstring/comments so the contract is auditable.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from lib.change_coupling import (
+    authorship_analysis,
+    change_coupling_pairs,
+    containment_ratio,
+    parse_commit_file_sets,
+)
+
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> None:
+    full_env = {**os.environ, **(env or {})}
+    subprocess.run(["git", "-C", str(repo), *args],
+                   check=True, capture_output=True, text=True, env=full_env)
+
+
+def _write(repo: Path, rel: str, text: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _commit(
+    repo: Path,
+    files: dict[str, str],
+    message: str = "change",
+    *,
+    author: tuple[str, str] | None = None,
+    committer: tuple[str, str] | None = None,
+    co_authors: list[str] | None = None,
+) -> None:
+    """Write ``files`` (rel path -> contents), stage, and commit.
+
+    ``author``/``committer`` are (name, email) tuples; ``co_authors`` is a list
+    of "Name <email>" strings folded into Co-Authored-By trailers.
+    """
+    for rel, text in files.items():
+        _write(repo, rel, text)
+    _git(repo, "add", "-A")
+    body = message
+    for ca in co_authors or []:
+        body += f"\n\nCo-Authored-By: {ca}"
+    env: dict[str, str] = {}
+    if author:
+        env["GIT_AUTHOR_NAME"], env["GIT_AUTHOR_EMAIL"] = author
+    if committer:
+        env["GIT_COMMITTER_NAME"], env["GIT_COMMITTER_EMAIL"] = committer
+    _git(repo, "commit", "-q", "-m", body, env=env)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dev@example.com")
+    _git(repo, "config", "user.name", "Dev Human")
+    return repo
+
+
+# --- parse_commit_file_sets --------------------------------------------------
+
+def test_parse_commit_file_sets_one_set_per_commit(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"a.py": "1", "b.py": "1"}, "c1")
+    _commit(repo, {"a.py": "2"}, "c2")
+
+    sets = parse_commit_file_sets(repo)
+    # Newest first: [{a.py}, {a.py, b.py}]
+    assert len(sets) == 2
+    assert sets[0] == {Path("a.py")}
+    assert sets[1] == {Path("a.py"), Path("b.py")}
+
+
+def test_parse_commit_file_sets_no_git_returns_empty(tmp_path: Path) -> None:
+    plain = tmp_path / "nogit"
+    plain.mkdir()
+    (plain / "a.py").write_text("x", encoding="utf-8")
+    assert parse_commit_file_sets(plain) == []
+
+
+def test_parse_commit_file_sets_since_window(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    old_date = "2020-01-01T00:00:00"
+    _commit_env = {"GIT_AUTHOR_DATE": old_date, "GIT_COMMITTER_DATE": old_date}
+    _write(repo, "old.py", "x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "old", env=_commit_env)
+    _commit(repo, {"new.py": "y"}, "new")  # committed "now"
+
+    sets = parse_commit_file_sets(repo, since="1 year ago")
+    flat = {p for s in sets for p in s}
+    assert Path("new.py") in flat
+    assert Path("old.py") not in flat
+
+
+# --- change_coupling_pairs (B1) ----------------------------------------------
+
+def test_change_coupling_detects_co_changing_trio(tmp_path: Path) -> None:
+    """Three files always committed together over 4 commits -> 3 pairs, count 4."""
+    repo = _init_repo(tmp_path)
+    for i in range(4):
+        _commit(repo, {"a.py": str(i), "b.py": str(i), "c.py": str(i)}, f"c{i}")
+
+    sets = parse_commit_file_sets(repo)
+    pairs = change_coupling_pairs(sets, min_support=3)
+    # combinations of {a,b,c} = (a,b),(a,c),(b,c); each co-changed 4 times.
+    assert len(pairs) == 3
+    for p in pairs:
+        assert p["co_change_count"] == 4
+        # 4 of 4 commits -> 100% support.
+        assert p["support_pct"] == 100.0
+    keys = {(p["file_a"], p["file_b"]) for p in pairs}
+    assert keys == {("a.py", "b.py"), ("a.py", "c.py"), ("b.py", "c.py")}
+
+
+def test_change_coupling_respects_min_support(tmp_path: Path) -> None:
+    """A pair co-changing only twice is dropped at the default min_support=3."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"x.py": "1", "y.py": "1"}, "c1")
+    _commit(repo, {"x.py": "2", "y.py": "2"}, "c2")  # x,y co-change = 2
+    _commit(repo, {"x.py": "3"}, "c3")
+
+    sets = parse_commit_file_sets(repo)
+    assert change_coupling_pairs(sets, min_support=3) == []
+    # Lowering the threshold surfaces it.
+    low = change_coupling_pairs(sets, min_support=2)
+    assert len(low) == 1
+    assert low[0]["co_change_count"] == 2
+    assert (low[0]["file_a"], low[0]["file_b"]) == ("x.py", "y.py")
+
+
+def test_change_coupling_single_file_commits_yield_no_pairs(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    for i in range(5):
+        _commit(repo, {"solo.py": str(i)}, f"c{i}")
+    sets = parse_commit_file_sets(repo)
+    assert change_coupling_pairs(sets) == []
+
+
+def test_change_coupling_empty_input() -> None:
+    assert change_coupling_pairs([]) == []
+
+
+# --- containment_ratio (B2) --------------------------------------------------
+
+def test_containment_fully_contained_module(tmp_path: Path) -> None:
+    """A module whose commits never reach outside it has ratio 1.0."""
+    repo = _init_repo(tmp_path)
+    for i in range(3):
+        _commit(repo, {f"mod/f{i}.py": str(i), "mod/core.py": str(i)}, f"c{i}")
+    sets = parse_commit_file_sets(repo)
+    assert containment_ratio(repo, "mod", sets) == 1.0
+
+
+def test_containment_bleeding_module(tmp_path: Path) -> None:
+    """Module edits that routinely drag in outside files give a low ratio."""
+    repo = _init_repo(tmp_path)
+    # 1 self-contained commit...
+    _commit(repo, {"mod/a.py": "1"}, "contained")
+    # ...and 3 that also touch files outside the module.
+    for i in range(3):
+        _commit(repo, {"mod/a.py": f"v{i}", "other/b.py": f"v{i}"}, f"bleed{i}")
+    sets = parse_commit_file_sets(repo)
+    # 4 commits touch mod, only 1 touches mod-only -> 1/4 = 0.25
+    assert containment_ratio(repo, "mod", sets) == 0.25
+
+
+def test_containment_zero_commits_returns_one(tmp_path: Path) -> None:
+    """A module no commit touches is vacuously contained (documented: 1.0)."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"other/a.py": "1"}, "c1")
+    sets = parse_commit_file_sets(repo)
+    assert containment_ratio(repo, "nonexistent", sets) == 1.0
+
+
+def test_containment_accepts_absolute_module_path(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    for i in range(2):
+        _commit(repo, {f"mod/f{i}.py": str(i)}, f"c{i}")
+    sets = parse_commit_file_sets(repo)
+    # Absolute path is normalised to repo-relative internally.
+    assert containment_ratio(repo, repo / "mod", sets) == 1.0
+
+
+# --- authorship_analysis (B4) ------------------------------------------------
+
+def test_authorship_human_only(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"app.py": "1"}, "c1",
+            author=("Alice", "alice@example.com"),
+            committer=("Alice", "alice@example.com"))
+    r = authorship_analysis(repo, "app.py")
+    assert r["authorship_class"] == "human"
+    assert r["human_anchor"] is True
+    assert r["intent_source"] is True
+    assert r["contributors"][0]["email"] == "alice@example.com"
+    assert r["contributors"][0]["classification"] == "human"
+
+
+def test_authorship_mixed_human_author_agent_coauthor(tmp_path: Path) -> None:
+    """Human author + Claude co-author = agent involvement alongside a human."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"app.py": "1"}, "feat: thing",
+            author=("Bob", "bob@example.com"),
+            committer=("Bob", "bob@example.com"),
+            co_authors=["Claude <noreply@anthropic.com>"])
+    r = authorship_analysis(repo, "app.py")
+    assert r["authorship_class"] == "mixed"
+    assert r["human_anchor"] is True
+    assert r["intent_source"] is True
+
+
+def test_authorship_pure_agent_via_bot_committer(tmp_path: Path) -> None:
+    """Bot author + bot committer with no human anywhere -> 'agent'."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"dep.lock": "1"}, "chore: bump",
+            author=("dependabot[bot]", "49699333+dependabot[bot]@users.noreply.github.com"),
+            committer=("dependabot[bot]", "49699333+dependabot[bot]@users.noreply.github.com"))
+    r = authorship_analysis(repo, "dep.lock")
+    assert r["authorship_class"] == "agent"
+    assert r["human_anchor"] is False
+    assert r["intent_source"] is False
+    assert r["contributors"][0]["classification"] == "agent"
+
+
+def test_authorship_agent_authored_human_committed(tmp_path: Path) -> None:
+    """Bot author + human committer: class is 'agent', but intent_source is True."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"x.py": "1"}, "apply bot patch",
+            author=("renovate[bot]", "29139614+renovate[bot]@users.noreply.github.com"),
+            committer=("Carol", "carol@example.com"))
+    r = authorship_analysis(repo, "x.py")
+    # agent author + human committer: agent involved, but no human *author*, and
+    # n_unknown==0, so the class is 'agent'. The human committer still makes
+    # them the intent source (a human directed/applied the change).
+    assert r["authorship_class"] == "agent"
+    assert r["human_anchor"] is False
+    assert r["intent_source"] is True
+
+
+def test_authorship_human_named_claude_not_libelled(tmp_path: Path) -> None:
+    """A real human named 'Claude' with a normal e-mail must NOT be called agent."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"app.py": "1"}, "c1",
+            author=("Claude Dupont", "claude.dupont@example.com"),
+            committer=("Claude Dupont", "claude.dupont@example.com"))
+    r = authorship_analysis(repo, "app.py")
+    assert r["authorship_class"] == "human"
+    assert r["human_anchor"] is True
+    assert r["contributors"][0]["classification"] == "human"
+
+
+def test_authorship_no_history_degrades(tmp_path: Path) -> None:
+    plain = tmp_path / "nogit"
+    plain.mkdir()
+    r = authorship_analysis(plain, "whatever.py")
+    assert r == {
+        "human_anchor": False,
+        "authorship_class": "unknown",
+        "intent_source": False,
+        "contributors": [],
+    }
+
+
+def test_authorship_contributor_line_stats(tmp_path: Path) -> None:
+    """numstat line counts aggregate per author across commits."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"app.py": "line1\nline2\n"}, "c1",
+            author=("Alice", "alice@example.com"),
+            committer=("Alice", "alice@example.com"))
+    _commit(repo, {"app.py": "line1\nline2\nline3\n"}, "c2",
+            author=("Alice", "alice@example.com"),
+            committer=("Alice", "alice@example.com"))
+    r = authorship_analysis(repo, "app.py")
+    alice = r["contributors"][0]
+    assert alice["commits"] == 2
+    # First commit adds 2 lines; second adds 1 more. 3 added total, 0 removed.
+    assert alice["lines_added"] == 3
+    assert alice["lines_removed"] == 0


### PR DESCRIPTION
## Summary

Adds `skills/assess/scripts/lib/change_coupling.py` - a standalone, deterministic module (subprocess + stdlib only, no AI, no new deps) providing three git-log-derived signals for the assess-keyhole-readiness feature. Dormant internal code; no caller wired up yet (task #5 will consume these into `run-context.json`).

## Changes Made

- **`parse_commit_file_sets(repo_root, since=None)`** - parses `git log --name-only` into one set of touched files per commit. Returns `[]` outside a git repo.
- **`change_coupling_pairs(commit_sets, min_support=3)`** (B1) - co-changing file pairs as `{file_a, file_b, co_change_count, support_pct}`, only at/above `min_support`. Bulk/mechanical commits (>50 files) are excluded from pairing but still count toward the support denominator.
- **`containment_ratio(repo_root, module_path, commit_sets)`** (B2) - commits touching only the module / commits touching it at all. Documented choice: a module no commit touches returns **1.0** (vacuously contained). Accepts absolute or repo-relative module paths.
- **`authorship_analysis(repo_root, path)`** (B4) - `{human_anchor, authorship_class, intent_source, contributors}`. Agent detection is **e-mail/`[bot]`-marker based, never on display name** - a real human named "Claude" is not libelled (PRD Open Question 6). `authorship_class` is conservative: `'agent'` only when every commit is a confirmed agent with no ambiguity, else `'unknown'`.

All return structures are JSON-serialisable for downstream consumption.

## Technical Details

Modelled on the existing `lib/git_churn.py`: `GIT_TIMEOUT_SECONDS = 20` cap on every git call, graceful degradation to empty/neutral results on `CalledProcessError` / `TimeoutExpired` / `FileNotFound`. Commit boundaries use ASCII record/unit separators in the `git log` format string for unambiguous parsing.

## Testing

`skills/assess/tests/test_change_coupling.py` - 18 tests over synthetic git histories with hand-computed expected values: co-change trio detection, min_support threshold, containment (contained / bleeding / zero-commit / absolute-path), and authorship (human-only, human+agent-coauthor mixed, pure-bot agent, agent-authored/human-committed, human-named-Claude not libelled, no-history degradation, line-stat aggregation).

Full assess suite: **189 passed**.

## Risk Assessment

Low. Additive module with no existing callers; deterministic and reproducible. No `plugin.json` bump (per feature plan - version bumps once in the release PR #6).