### PR TITLE
feat(assess): add static dependency structure analysis (Signals A1-A4)

### DIFF
--- a/skills/assess/pyproject.toml
+++ b/skills/assess/pyproject.toml
@@ -5,6 +5,7 @@ description = "Deterministic core for /assess skill"
 requires-python = ">=3.11"
 dependencies = [
     "networkx>=3.0",
+    "grimp>=3.0",
 ]
 
 [dependency-groups]

--- a/skills/assess/scripts/lib/assess_config.py
+++ b/skills/assess/scripts/lib/assess_config.py
@@ -106,6 +106,35 @@ def _string_list(config: dict, key: str) -> list[str]:
     return [str(x) for x in value if isinstance(x, str)]
 
 
+# Default comprehension-footprint budget (A1). A unit whose footprint --
+# size + the public surface of its direct deps + its own exposed surface --
+# exceeds this is one no agent can change completely from inside a single
+# context window. The number is a tunable proxy for "a fraction of a reference
+# window"; repos calibrate it via `.assess/config.toml` `[structure]`.
+DEFAULT_KEYHOLE_BUDGET = 2000
+
+
+def load_structure_config(repo_root: Path) -> dict:
+    """Return the `[structure]` settings from `.assess/config.toml`.
+
+    Currently a single key, `keyhole_budget` (the A1 comprehension-footprint
+    budget), defaulting to `DEFAULT_KEYHOLE_BUDGET`. Honours the same
+    "degrade silently" contract as the exclude loaders: a missing file,
+    missing section, or malformed value falls back to the default rather
+    than blocking the assessment.
+    """
+    cfg = load_config(repo_root)
+    section = cfg.get("structure", {})
+    budget = DEFAULT_KEYHOLE_BUDGET
+    if isinstance(section, dict):
+        value = section.get("keyhole_budget")
+        # bool is an int subclass; reject it so `keyhole_budget = true` doesn't
+        # silently become a budget of 1. Only a positive int is a valid budget.
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            budget = value
+    return {"keyhole_budget": budget}
+
+
 def load_excludes(repo_root: Path) -> tuple[set[str], list[str]]:
     """Return `(extra_exclude_dirs, extra_exclude_patterns)` from the config.
 

--- a/skills/assess/scripts/lib/structure_graph.py
+++ b/skills/assess/scripts/lib/structure_graph.py
@@ -1,0 +1,520 @@
+"""Static dependency-structure analysis for the keyhole-readiness signals.
+
+The keyhole is the binding constraint once a codebase outgrows a single
+context window: every actor -- the agent's window and the human reviewing a
+diff -- sees a narrow slice by construction. A change is safe only when the
+*unit being changed plus the contracts at its boundary* fit inside that slice.
+This module measures the static, language-specific (Python-first) half of that
+question off the import graph:
+
+  - **A1 comprehension footprint** -> for a unit X, ``size(X) +
+    public_surface(direct deps of X) + surface X exposes to dependents``.
+    DIRECT dependencies only -- transitive closure would explode the metric
+    for anything depending on common utilities and flag the whole repo. A unit
+    whose footprint exceeds the **keyhole budget** is one no agent can change
+    completely from inside the window.
+  - **A2 blob vs modular** -> strongly-connected components (a cycle of length
+    > 1 is a definitional blob) plus a Newman modularity score *Q*. High Q =
+    cohesive clusters with sparse cross-talk; low / negative Q = either a blob
+    (everything coupled) or confetti (a hundred tiny packages cross-talking).
+  - **A3 contracts** -> the fraction of cross-package inbound edges that land
+    on a package's *front door* (its ``__init__`` / public API) versus
+    **burrow** into internals. Deep-reaching imports mean there is no real
+    contract and refactors leak.
+  - **A4 breakup candidates** -> a package whose internal modules fall into
+    well-separated sub-clusters is several packages wearing one coat; the
+    sub-clusters *are* the proposed cut-lines.
+
+Core dependencies are ``grimp`` (Python import-graph) and ``networkx``
+(community detection / SCCs). Mirroring ``doc_graph``, the module degrades to
+an ``available=False`` result rather than crashing when either is missing --
+the assessment never blocks. The analysis is purely static (AST-level import
+parsing via grimp; no code execution) and deterministic, so it is reproducible
+run to run.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:  # grimp + networkx are the core deps; degrade rather than crash if absent.
+    import grimp
+
+    _GRIMP_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on a broken env
+    grimp = None  # type: ignore[assignment]
+    _GRIMP_AVAILABLE = False
+
+try:
+    import networkx as nx
+
+    _NETWORKX_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on a broken env
+    nx = None  # type: ignore[assignment]
+    _NETWORKX_AVAILABLE = False
+
+from lib.assess_config import DEFAULT_KEYHOLE_BUDGET
+
+# Directories never worth walking for packages. Mirrors doc_graph's EXCLUDE_DIRS
+# (kept local so this module pulls in no heavy deps) -- build artefacts, vendor
+# trees, virtualenvs and /assess's own output are not the repo's source.
+EXCLUDE_DIRS = {
+    ".git", "node_modules", "dist", "build", "target", "vendor",
+    ".venv", "venv", "__pycache__", ".gradle", ".idea", ".mvn",
+    "worktree", ".understand-anything", ".obsidian", ".taskmaster",
+    ".claude", ".next", ".nuxt", ".output", ".svelte-kit", ".astro",
+    "out", "coverage", "htmlcov", "Pods", "DerivedData", "flutter_assets",
+    ".assess", "tests", "test",
+}
+
+# Below this many internal modules a package is too small to be worth proposing
+# a split for -- two or three modules are a unit, not a hidden multi-package.
+MIN_PACKAGE_MODULES_FOR_BREAKUP = 4
+
+# A package's internal community split only counts as a real seam (a breakup
+# candidate) when the sub-clusters are this well separated. Below it the
+# package is cohesive and the "clusters" are an artefact of sparse edges.
+BREAKUP_MODULARITY_THRESHOLD = 0.25
+
+# networkx's greedy_modularity_communities is good for small graphs; louvain
+# scales better. Switch over at this node count (matches the PRD guidance).
+GREEDY_MAX_NODES = 500
+
+# Caps so a pathological repo can't bloat run-context.json.
+MAX_FOOTPRINTS = 200
+MAX_BURROW_EDGES = 100
+MAX_SCCS = 50
+
+
+@dataclass
+class StructureGraphResult:
+    available: bool = True
+    reason: str = ""
+    keyhole_budget: int = DEFAULT_KEYHOLE_BUDGET
+    # A1: [{module, size, dep_surface, exposed_surface, total, over_budget}]
+    footprints: list[dict] = field(default_factory=list)
+    # A2: strongly-connected components of length > 1 (import cycles = blobs).
+    sccs: list[list[str]] = field(default_factory=list)
+    # A2: Newman modularity Q in [-0.5, 1] over the module graph.
+    modularity_q: float = 0.0
+    # A3: fraction of cross-package inbound edges landing on a front door.
+    front_door_ratio: float = 1.0
+    # A3: the burrowing edges (imports that reach into another package's
+    # internals instead of its public API). [{importer, imported}].
+    internal_burrow_edges: list[dict] = field(default_factory=list)
+    # A4: [{package, clusters: [[mod, ...], ...], num_clusters, modularity_q}].
+    breakup_candidates: list[dict] = field(default_factory=list)
+    module_count: int = 0
+    edge_count: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "available": self.available,
+            "reason": self.reason,
+            "keyhole_budget": self.keyhole_budget,
+            "footprints": self.footprints,
+            "sccs": self.sccs,
+            "modularity_q": round(self.modularity_q, 4),
+            "front_door_ratio": round(self.front_door_ratio, 4),
+            "internal_burrow_edges": self.internal_burrow_edges,
+            "breakup_candidates": self.breakup_candidates,
+            "module_count": self.module_count,
+            "edge_count": self.edge_count,
+        }
+
+
+# --------------------------------------------------------------------------
+# Package discovery + grimp graph construction
+# --------------------------------------------------------------------------
+
+def _is_excluded(path: Path, repo_root: Path, extra: set[str]) -> bool:
+    try:
+        rel = path.relative_to(repo_root)
+    except ValueError:
+        return True
+    return any(part in EXCLUDE_DIRS or part in extra for part in rel.parts)
+
+
+def discover_packages(
+    repo_root: Path, extra_exclude_dirs: set[str] | None = None,
+) -> list[Path]:
+    """Return the top-level importable package directories under repo_root.
+
+    A package directory contains an ``__init__.py``. We keep only *top-level*
+    packages -- a directory whose parent is not itself a package -- because
+    grimp is given the package root and walks down from there. ``repo_root``
+    itself counts if it is a package (the integration case: pointing the
+    analysis straight at ``scripts/lib``).
+    """
+    repo_root = repo_root.resolve()
+    extra = extra_exclude_dirs or set()
+    init_dirs: set[Path] = set()
+    # repo_root itself may be a package.
+    if (repo_root / "__init__.py").is_file():
+        init_dirs.add(repo_root)
+    for init in repo_root.rglob("__init__.py"):
+        if not init.is_file():
+            continue
+        if _is_excluded(init.parent, repo_root, extra):
+            continue
+        init_dirs.add(init.parent.resolve())
+    # Keep only roots: a package whose parent is also a package is a subpackage.
+    return sorted(d for d in init_dirs if d.parent not in init_dirs)
+
+
+@contextmanager
+def _syspath_prepended(paths: list[Path]):
+    """Temporarily prepend `paths` to sys.path, restoring it afterwards.
+
+    grimp locates a package by importable name via sys.path; we add each
+    package's parent so ``grimp.build_graph("lib")`` resolves. Restored in a
+    finally so a scan never leaves the interpreter's import state mutated.
+    """
+    added = [str(p) for p in paths]
+    original = list(sys.path)
+    for p in added:
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    try:
+        yield
+    finally:
+        sys.path[:] = original
+
+
+def _module_file(module: str, roots: dict[str, Path]) -> Path | None:
+    """Resolve a dotted module name to its source file via its package root.
+
+    ``roots`` maps a top-level package name to its directory; the module's
+    file lives under that directory's *parent* (the sys.path root), since the
+    dotted name already includes the package as its first component.
+    """
+    top = module.split(".", 1)[0]
+    root = roots.get(top)
+    if root is None:
+        return None
+    base = root.parent
+    rel = module.replace(".", "/")
+    candidate = base / f"{rel}.py"
+    if candidate.is_file():
+        return candidate
+    pkg_init = base / rel / "__init__.py"
+    if pkg_init.is_file():
+        return pkg_init
+    return None
+
+
+# --------------------------------------------------------------------------
+# Source-surface measurement (size + public API)
+# --------------------------------------------------------------------------
+
+def _count_loc(path: Path | None) -> int:
+    """Non-blank source lines in a module file (0 if unreadable / absent)."""
+    if path is None:
+        return 0
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return 0
+    return sum(1 for line in text.splitlines() if line.strip())
+
+
+def _public_surface(path: Path | None) -> int:
+    """Count public top-level definitions (the API a module exposes).
+
+    Public = a module-level ``def`` / ``async def`` / ``class`` whose name does
+    not start with ``_``. This is the surface a dependent must comprehend to
+    use the module -- the contract, not the implementation.
+    """
+    if path is None:
+        return 0
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+    except (OSError, SyntaxError):
+        return 0
+    count = 0
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                count += 1
+    return count
+
+
+# --------------------------------------------------------------------------
+# A1 -- comprehension footprint
+# --------------------------------------------------------------------------
+
+def compute_footprint(
+    module: str,
+    direct_deps: list[str],
+    surfaces: dict[str, int],
+    sizes: dict[str, int],
+    keyhole_budget: int,
+) -> dict:
+    """A1 footprint for one module: size + direct-dep surface + own surface.
+
+    ``direct_deps`` is the module's DIRECT imports only -- no transitive
+    closure. A depends on B depends on C must NOT pull C's surface into A's
+    footprint, or every module transitively touching a common utility would
+    blow the budget and the whole repo would be flagged.
+    """
+    size = sizes.get(module, 0)
+    dep_surface = sum(surfaces.get(dep, 0) for dep in direct_deps)
+    exposed_surface = surfaces.get(module, 0)
+    total = size + dep_surface + exposed_surface
+    return {
+        "module": module,
+        "size": size,
+        "dep_surface": dep_surface,
+        "exposed_surface": exposed_surface,
+        "total": total,
+        "over_budget": total > keyhole_budget,
+    }
+
+
+# --------------------------------------------------------------------------
+# A2 -- blob vs modular
+# --------------------------------------------------------------------------
+
+def _detect_communities(undirected) -> list[set]:
+    """Community partition of an undirected graph (greedy / louvain by size)."""
+    if undirected.number_of_nodes() == 0:
+        return []
+    from networkx.algorithms.community import (
+        greedy_modularity_communities,
+        louvain_communities,
+    )
+    if undirected.number_of_edges() == 0:
+        # No edges: every node is its own community.
+        return [{n} for n in undirected.nodes()]
+    if undirected.number_of_nodes() < GREEDY_MAX_NODES:
+        return [set(c) for c in greedy_modularity_communities(undirected)]
+    # louvain needs a deterministic seed to stay reproducible run to run.
+    return [set(c) for c in louvain_communities(undirected, seed=1)]
+
+
+def _modularity_q(undirected, communities: list[set]) -> float:
+    """Newman Q for a partition, clamped to the theoretical [-0.5, 1] range."""
+    if not communities or undirected.number_of_edges() == 0:
+        return 0.0
+    from networkx.algorithms.community import modularity
+    try:
+        q = modularity(undirected, communities)
+    except (ZeroDivisionError, KeyError):  # pragma: no cover - defensive
+        return 0.0
+    return max(-0.5, min(1.0, q))
+
+
+def compute_modularity(graph) -> tuple[list[list[str]], float]:
+    """A2: import cycles (SCCs len > 1) and the Newman modularity Q.
+
+    Returns ``(sccs, q)`` where ``sccs`` is the list of strongly-connected
+    components of length > 1 (each a definitional blob -- a cycle through which
+    a change in any member can reach every other), and ``q`` is the modularity
+    of the best community partition of the undirected projection.
+    """
+    sccs = sorted(
+        (sorted(c) for c in nx.strongly_connected_components(graph) if len(c) > 1),
+        key=lambda c: (-len(c), c),
+    )
+    undirected = graph.to_undirected()
+    communities = _detect_communities(undirected)
+    q = _modularity_q(undirected, communities)
+    return sccs, q
+
+
+# --------------------------------------------------------------------------
+# A3 -- contracts (front door vs burrow)
+# --------------------------------------------------------------------------
+
+def _top_package(module: str) -> str:
+    return module.split(".", 1)[0]
+
+
+def compute_front_door_ratio(
+    graph, packages: set[str],
+) -> tuple[float, list[dict]]:
+    """A3: fraction of cross-package edges landing on a front door.
+
+    Only *cross-package* edges carry a contract -- intra-package edges are
+    internal cohesion. An edge into another package is a **front door** when
+    its target is a package module itself (importing the ``__init__`` / public
+    API) and a **burrow** when it reaches a plain submodule inside that package.
+
+    A vacuous graph (no cross-package edges) is treated as fully contracted
+    (ratio 1.0) -- there are no boundaries being violated.
+    """
+    front, burrow = 0, 0
+    burrow_edges: list[dict] = []
+    for importer, imported in graph.edges():
+        if _top_package(importer) == _top_package(imported):
+            continue  # intra-package: not a contract edge
+        if imported in packages:
+            front += 1
+        else:
+            burrow += 1
+            burrow_edges.append({"importer": importer, "imported": imported})
+    total = front + burrow
+    ratio = 1.0 if total == 0 else front / total
+    burrow_edges.sort(key=lambda e: (e["importer"], e["imported"]))
+    return ratio, burrow_edges
+
+
+# --------------------------------------------------------------------------
+# A4 -- breakup candidates
+# --------------------------------------------------------------------------
+
+def find_breakup_candidates(
+    package: str, internal_graph,
+) -> dict | None:
+    """A4: propose cut-lines for a package that is several packages in one.
+
+    ``internal_graph`` holds only the package's own modules and the edges
+    between them. A package is a breakup candidate when its internal modules
+    fall into two or more well-separated communities -- the sub-clusters are
+    the proposed cut-lines. Returns ``None`` when the package is too small to
+    bother splitting, or when its modules form one cohesive cluster (the
+    community split is weak: Q below the threshold).
+    """
+    if internal_graph.number_of_nodes() < MIN_PACKAGE_MODULES_FOR_BREAKUP:
+        return None
+    undirected = internal_graph.to_undirected()
+    communities = _detect_communities(undirected)
+    communities = [c for c in communities if c]
+    if len(communities) < 2:
+        return None
+    q = _modularity_q(undirected, communities)
+    if q < BREAKUP_MODULARITY_THRESHOLD:
+        return None  # cohesive enough: one coat, one package
+    clusters = sorted(
+        (sorted(c) for c in communities), key=lambda c: (-len(c), c),
+    )
+    return {
+        "package": package,
+        "clusters": clusters,
+        "num_clusters": len(clusters),
+        "modularity_q": round(q, 4),
+    }
+
+
+# --------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------
+
+def _build_grimp_graph(package_dirs: list[Path]):
+    """Build the grimp import graph for the discovered packages.
+
+    Returns ``(import_graph, package_names, roots)`` or raises on failure.
+    ``roots`` maps each top-level package name to its source directory, used to
+    resolve module names back to files for surface measurement.
+    """
+    names = [d.name for d in package_dirs]
+    roots = {d.name: d for d in package_dirs}
+    parents = list({d.parent for d in package_dirs})
+    with _syspath_prepended(parents):
+        # cache_dir=None: never write grimp's cache into the target repo.
+        import_graph = grimp.build_graph(*names, cache_dir=None)
+    return import_graph, names, roots
+
+
+def analyze_structure(
+    repo_root: Path,
+    keyhole_budget: int | None = None,
+    extra_exclude_dirs: set[str] | None = None,
+) -> StructureGraphResult:
+    """Run the A1-A4 static structure analysis over the repo's Python packages.
+
+    Degrades gracefully (``available=False``) when grimp or networkx is missing
+    or no importable Python package is found. The result is JSON-serialisable
+    via ``as_dict()`` and deterministic for a given source tree.
+    """
+    repo_root = Path(repo_root).resolve()
+    budget = keyhole_budget if keyhole_budget is not None else DEFAULT_KEYHOLE_BUDGET
+
+    if not _GRIMP_AVAILABLE or not _NETWORKX_AVAILABLE:
+        missing = "grimp" if not _GRIMP_AVAILABLE else "networkx"
+        return StructureGraphResult(
+            available=False,
+            reason=f"{missing} not installed; static structure not assessed",
+            keyhole_budget=budget,
+        )
+
+    package_dirs = discover_packages(repo_root, extra_exclude_dirs)
+    if not package_dirs:
+        return StructureGraphResult(
+            available=True,
+            reason="no importable Python packages found",
+            keyhole_budget=budget,
+        )
+
+    try:
+        import_graph, package_names, roots = _build_grimp_graph(package_dirs)
+    except Exception as e:  # pragma: no cover - grimp parse failure on odd trees
+        return StructureGraphResult(
+            available=False,
+            reason=f"grimp failed to build import graph ({e})",
+            keyhole_budget=budget,
+        )
+
+    modules = sorted(import_graph.modules)
+    package_set = set(package_names) | {
+        m for m in modules if _module_file(m, roots) and
+        _module_file(m, roots).name == "__init__.py"
+    }
+
+    # Measure each module's size and public surface once.
+    sizes: dict[str, int] = {}
+    surfaces: dict[str, int] = {}
+    for m in modules:
+        f = _module_file(m, roots)
+        sizes[m] = _count_loc(f)
+        surfaces[m] = _public_surface(f)
+
+    # Build the networkx digraph (nodes = modules, edges = direct imports).
+    graph = nx.DiGraph()
+    graph.add_nodes_from(modules)
+    for m in modules:
+        for dep in import_graph.find_modules_directly_imported_by(m):
+            if dep in graph:  # ignore imports of external / unknown modules
+                graph.add_edge(m, dep)
+
+    # A1 footprints (direct deps only).
+    footprints = [
+        compute_footprint(
+            m, sorted(graph.successors(m)), surfaces, sizes, budget,
+        )
+        for m in modules
+    ]
+    footprints.sort(key=lambda fp: (-fp["total"], fp["module"]))
+
+    # A2 SCCs + modularity.
+    sccs, q = compute_modularity(graph)
+
+    # A3 front-door ratio.
+    front_door_ratio, burrow_edges = compute_front_door_ratio(graph, package_set)
+
+    # A4 breakup candidates -- one analysis per top-level package.
+    breakup: list[dict] = []
+    for pkg in sorted(package_names):
+        members = [
+            m for m in modules if m == pkg or m.startswith(pkg + ".")
+        ]
+        internal = graph.subgraph(members)
+        candidate = find_breakup_candidates(pkg, internal)
+        if candidate is not None:
+            breakup.append(candidate)
+
+    return StructureGraphResult(
+        available=True,
+        keyhole_budget=budget,
+        footprints=footprints[:MAX_FOOTPRINTS],
+        sccs=sccs[:MAX_SCCS],
+        modularity_q=q,
+        front_door_ratio=front_door_ratio,
+        internal_burrow_edges=burrow_edges[:MAX_BURROW_EDGES],
+        breakup_candidates=breakup,
+        module_count=graph.number_of_nodes(),
+        edge_count=graph.number_of_edges(),
+    )

--- a/skills/assess/tests/test_structure_graph.py
+++ b/skills/assess/tests/test_structure_graph.py
@@ -1,0 +1,282 @@
+"""Tests for the static dependency-structure analysis (Signals A1-A4).
+
+The deterministic core's contract: every signal is reproducible and verifiable
+from a fixed source tree. These tests pin each signal's arithmetic (A1
+footprint additivity + direct-only-ness), graph semantics (A2 SCCs and Q range,
+A3 front-door vs burrow, A4 cut-lines), the config read, and graceful
+degradation when grimp / networkx are absent -- plus an integration run against
+this package itself.
+"""
+from __future__ import annotations
+
+import networkx as nx
+
+from lib import structure_graph as sg
+from lib.assess_config import DEFAULT_KEYHOLE_BUDGET
+
+
+# --------------------------------------------------------------------------
+# Graceful degradation
+# --------------------------------------------------------------------------
+
+def test_degrades_when_grimp_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(sg, "_GRIMP_AVAILABLE", False)
+    result = sg.analyze_structure(tmp_path)
+    assert result.available is False
+    assert "grimp" in result.reason
+    # Still JSON-serialisable and carries the budget.
+    assert result.as_dict()["available"] is False
+
+
+def test_degrades_when_networkx_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(sg, "_NETWORKX_AVAILABLE", False)
+    result = sg.analyze_structure(tmp_path)
+    assert result.available is False
+    assert "networkx" in result.reason
+
+
+def test_no_packages_is_available_but_empty(tmp_path):
+    (tmp_path / "loose.py").write_text("x = 1\n")  # no __init__.py anywhere
+    result = sg.analyze_structure(tmp_path)
+    assert result.available is True
+    assert result.footprints == []
+    assert "no importable" in result.reason
+
+
+# --------------------------------------------------------------------------
+# A1 -- comprehension footprint
+# --------------------------------------------------------------------------
+
+def test_footprint_components_sum_to_total():
+    surfaces = {"A": 3, "B": 2}
+    sizes = {"A": 100, "B": 40}
+    fp = sg.compute_footprint("A", ["B"], surfaces, sizes, keyhole_budget=2000)
+    assert fp["size"] == 100
+    assert fp["dep_surface"] == 2          # public_surface(B)
+    assert fp["exposed_surface"] == 3      # public_surface(A)
+    assert fp["total"] == fp["size"] + fp["dep_surface"] + fp["exposed_surface"]
+    assert fp["total"] == 105
+
+
+def test_footprint_over_budget_flag():
+    fp = sg.compute_footprint(
+        "A", [], {"A": 0}, {"A": 5000}, keyhole_budget=2000,
+    )
+    assert fp["over_budget"] is True
+    fp2 = sg.compute_footprint(
+        "A", [], {"A": 0}, {"A": 10}, keyhole_budget=2000,
+    )
+    assert fp2["over_budget"] is False
+
+
+def test_footprint_uses_direct_deps_only():
+    # A -> B -> C. A's direct dep is only B. C's surface must NOT leak in.
+    surfaces = {"A": 1, "B": 2, "C": 999}
+    sizes = {"A": 10, "B": 10, "C": 10}
+    fp = sg.compute_footprint("A", ["B"], surfaces, sizes, keyhole_budget=2000)
+    assert fp["dep_surface"] == 2  # B only, not B + C
+    # Changing C's surface leaves A's footprint untouched (transitive isolation).
+    surfaces["C"] = 1
+    fp_again = sg.compute_footprint("A", ["B"], surfaces, sizes, keyhole_budget=2000)
+    assert fp_again["total"] == fp["total"]
+
+
+# --------------------------------------------------------------------------
+# A2 -- blob vs modular
+# --------------------------------------------------------------------------
+
+def test_cycle_is_one_scc():
+    g = nx.DiGraph()
+    g.add_edges_from([("A", "B"), ("B", "C"), ("C", "A")])
+    sccs, q = sg.compute_modularity(g)
+    assert len(sccs) == 1
+    assert sccs[0] == ["A", "B", "C"]
+    assert -0.5 <= q <= 1.0
+
+
+def test_acyclic_has_no_multi_member_scc():
+    g = nx.DiGraph()
+    g.add_edges_from([("A", "B"), ("B", "C")])
+    sccs, q = sg.compute_modularity(g)
+    assert sccs == []
+    assert -0.5 <= q <= 1.0
+
+
+def test_separated_clusters_score_higher_than_dense_crosstalk():
+    # Two tight triangles joined by a single bridge edge: clear modularity.
+    separated = nx.DiGraph()
+    separated.add_edges_from([
+        ("a1", "a2"), ("a2", "a3"), ("a3", "a1"),
+        ("b1", "b2"), ("b2", "b3"), ("b3", "b1"),
+        ("a1", "b1"),
+    ])
+    _, q_sep = sg.compute_modularity(separated)
+
+    # Everything wired to everything: near-zero / negative modularity.
+    dense = nx.DiGraph()
+    nodes = ["n1", "n2", "n3", "n4"]
+    for u in nodes:
+        for v in nodes:
+            if u != v:
+                dense.add_edge(u, v)
+    _, q_dense = sg.compute_modularity(dense)
+
+    assert q_sep > q_dense
+    assert -0.5 <= q_sep <= 1.0
+    assert -0.5 <= q_dense <= 1.0
+
+
+# --------------------------------------------------------------------------
+# A3 -- contracts (front door vs burrow)
+# --------------------------------------------------------------------------
+
+def test_all_imports_via_front_door_ratio_is_one():
+    g = nx.DiGraph()
+    # app imports the pkg package itself (its __init__ / public API).
+    g.add_edge("app", "pkg")
+    ratio, burrow = sg.compute_front_door_ratio(g, packages={"app", "pkg"})
+    assert ratio == 1.0
+    assert burrow == []
+
+
+def test_burrowing_lowers_ratio_and_records_edges():
+    g = nx.DiGraph()
+    g.add_edge("app", "pkg")            # front door
+    g.add_edge("app", "pkg.internal")   # burrow into internals
+    ratio, burrow = sg.compute_front_door_ratio(g, packages={"app", "pkg"})
+    assert ratio == 0.5  # 1 front / 2 total -- exactly representable
+    assert burrow == [{"importer": "app", "imported": "pkg.internal"}]
+
+
+def test_intra_package_edges_are_not_contract_edges():
+    g = nx.DiGraph()
+    g.add_edge("pkg.a", "pkg.b")  # same package -> internal cohesion, ignored
+    ratio, burrow = sg.compute_front_door_ratio(g, packages={"pkg"})
+    assert ratio == 1.0
+    assert burrow == []
+
+
+# --------------------------------------------------------------------------
+# A4 -- breakup candidates
+# --------------------------------------------------------------------------
+
+def test_cohesive_package_is_not_a_breakup_candidate():
+    # One dense cluster of 4 modules -> cohesive, no proposed split.
+    g = nx.DiGraph()
+    mods = ["p.a", "p.b", "p.c", "p.d"]
+    for u in mods:
+        for v in mods:
+            if u != v:
+                g.add_edge(u, v)
+    assert sg.find_breakup_candidates("p", g) is None
+
+
+def test_two_clusters_yield_a_candidate_with_two_cuts():
+    g = nx.DiGraph()
+    # Two tight triangles, one thin bridge -> two natural cut-lines.
+    g.add_edges_from([
+        ("p.a1", "p.a2"), ("p.a2", "p.a3"), ("p.a3", "p.a1"),
+        ("p.b1", "p.b2"), ("p.b2", "p.b3"), ("p.b3", "p.b1"),
+        ("p.a1", "p.b1"),
+    ])
+    candidate = sg.find_breakup_candidates("p", g)
+    assert candidate is not None
+    assert candidate["package"] == "p"
+    assert candidate["num_clusters"] == 2
+    assert len(candidate["clusters"]) == 2
+    # Every module is assigned to exactly one cut-line.
+    flat = [m for cluster in candidate["clusters"] for m in cluster]
+    assert sorted(flat) == sorted(g.nodes())
+
+
+def test_too_small_package_returns_none():
+    g = nx.DiGraph()
+    g.add_edges_from([("p.a", "p.b"), ("p.c", "p.a")])  # 3 nodes < threshold
+    assert sg.find_breakup_candidates("p", g) is None
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+def test_keyhole_budget_default_when_no_config(tmp_path):
+    from lib.assess_config import load_structure_config
+    cfg = load_structure_config(tmp_path)
+    assert cfg["keyhole_budget"] == DEFAULT_KEYHOLE_BUDGET
+
+
+def test_keyhole_budget_read_from_config(tmp_path):
+    from lib.assess_config import load_structure_config
+    assess = tmp_path / ".assess"
+    assess.mkdir()
+    (assess / "config.toml").write_text(
+        "[structure]\nkeyhole_budget = 1500\n"
+    )
+    cfg = load_structure_config(tmp_path)
+    assert cfg["keyhole_budget"] == 1500
+
+
+def test_keyhole_budget_rejects_malformed_value(tmp_path):
+    from lib.assess_config import load_structure_config
+    assess = tmp_path / ".assess"
+    assess.mkdir()
+    # A non-positive / wrong-typed value falls back to the default.
+    (assess / "config.toml").write_text(
+        '[structure]\nkeyhole_budget = "lots"\n'
+    )
+    cfg = load_structure_config(tmp_path)
+    assert cfg["keyhole_budget"] == DEFAULT_KEYHOLE_BUDGET
+
+
+# --------------------------------------------------------------------------
+# Package discovery
+# --------------------------------------------------------------------------
+
+def test_discover_packages_finds_top_level_only(tmp_path):
+    pkg = tmp_path / "pkg"
+    sub = pkg / "sub"
+    pkg.mkdir()
+    sub.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (sub / "__init__.py").write_text("")
+    found = sg.discover_packages(tmp_path)
+    assert found == [pkg.resolve()]  # sub is a subpackage, not top-level
+
+
+def test_discover_packages_skips_excluded_dirs(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "__init__.py").write_text("")
+    venv_pkg = tmp_path / ".venv" / "junk"
+    venv_pkg.mkdir(parents=True)
+    (venv_pkg / "__init__.py").write_text("")
+    found = sg.discover_packages(tmp_path)
+    assert found == [real.resolve()]
+
+
+# --------------------------------------------------------------------------
+# Integration -- analyse this package itself
+# --------------------------------------------------------------------------
+
+def test_analyze_structure_on_lib_itself():
+    from pathlib import Path
+    lib_dir = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+    result = sg.analyze_structure(lib_dir)
+    assert result.available is True
+    assert result.reason == ""
+    assert result.module_count > 0
+
+    modules = {fp["module"] for fp in result.footprints}
+    assert "lib.structure_graph" in modules
+    assert "lib.assess_config" in modules
+
+    # Q is computed and in range; result round-trips to JSON-friendly dict.
+    assert -0.5 <= result.modularity_q <= 1.0
+    d = result.as_dict()
+    assert d["module_count"] == result.module_count
+    assert isinstance(d["footprints"], list)
+    # Every footprint exposes the expected arithmetic shape.
+    sample = result.footprints[0]
+    assert sample["total"] == (
+        sample["size"] + sample["dep_surface"] + sample["exposed_surface"]
+    )


### PR DESCRIPTION
## Summary

Implements Phase 3 of the assess-keyhole-readiness PRD: the static, Python-first half of the keyhole-fit question, derived from the import graph. New deterministic-core module `lib/structure_graph.py` plus a `[structure]` config reader. No `assess_core.py` wiring yet (task #5 consumes the `structure` block later); no plugin version bump (release PR #6 owns that).

## Changes Made

- **`skills/assess/pyproject.toml`** — add `grimp>=3.0` alongside `networkx>=3.0`.
- **`lib/assess_config.py`** — `load_structure_config(repo_root)` reads `[structure].keyhole_budget` (default 2000, `DEFAULT_KEYHOLE_BUDGET`); rejects malformed/non-positive values, degrading silently like the existing exclude loaders.
- **`lib/structure_graph.py`** — new module mirroring `doc_graph.py`'s graceful-degradation pattern (`available=False` with a reason when grimp/networkx absent). Signals:
  - **A1 comprehension footprint** — `size(X) + public_surface(direct deps) + exposed_surface(X)`; **direct dependencies only** (no transitive closure); `over_budget` vs the keyhole budget.
  - **A2 blob vs modular** — strongly-connected components (cycle len > 1 = blob) + Newman modularity Q (greedy < 500 nodes, else louvain), clamped to [-0.5, 1].
  - **A3 contracts** — front-door ratio: fraction of cross-package inbound edges landing on a package `__init__`/public API vs burrowing into internals; returns ratio + burrow edges.
  - **A4 breakup candidates** — per-package internal community split with sufficient modularity → proposed cut-lines; `None` when too small or cohesive.
  - `analyze_structure(repo_root, keyhole_budget=None, extra_exclude_dirs=None) -> StructureGraphResult` entry point; JSON-serialisable `as_dict()`.

## Technical Details

- grimp 3.14's real API used directly (`build_graph(*names, cache_dir=None)`, `find_modules_directly_imported_by`, `modules`). Package roots are discovered by `__init__.py`, their parents temporarily prepended to `sys.path` (restored in a `finally`) so grimp can resolve them; `cache_dir=None` keeps grimp's cache out of the target repo.
- Static only (AST-level import parsing, no execution) and deterministic — louvain seeded for reproducibility.
- `uv.lock` is gitignored; CI resolves grimp from `pyproject.toml` via `uv run`.

## Testing

`cd skills/assess && uv run --with pytest pytest -v` — 21 new tests in `tests/test_structure_graph.py`, full suite 192 passed. Covers graceful degradation (grimp/networkx absent), A1 additivity + direct-only isolation, A2 SCC/acyclic/Q-range/separated-vs-dense, A3 front-door=1.0 vs burrow<1.0, A4 cohesive/two-cluster/too-small, config default + read + malformed, package discovery, and an integration run of `analyze_structure()` against `scripts/lib/` itself (non-degraded grimp path; asserts known modules present and Q computed).

## Risk Assessment

Additive only — no edits to `assess_core.py` or existing modules beyond one new config function. grimp/networkx degrade gracefully when absent, so the assessment never blocks.