### PR TITLE
feat(assess): add hidden-coupling + refactor-boundary detection (B3)

### DIFF
--- a/skills/assess/scripts/lib/coupling_analysis.py
+++ b/skills/assess/scripts/lib/coupling_analysis.py
@@ -1,0 +1,222 @@
+"""B3 static-vs-historical disagreement: the A x B cross for the /assess core.
+
+The static lens (``lib.structure_graph``, A2/A3) reads the import graph and asks
+"does this *look* modular?"; the historical lens (``lib.change_coupling``, B1/B2)
+reads the commit log and asks "does it *behave* modularly -- do edits stay
+contained?". Each is blind to what the other sees. Where they **disagree** is
+the most valuable output of the whole assessment (PRD Signal B3 + the derived-
+findings table):
+
+  - **Hidden coupling** -- a module that looks modular statically (high
+    modularity / a clean front door) yet bleeds historically (low containment:
+    its commits keep dragging in files elsewhere). The static boundary is lying;
+    recommend *investigating the seam* before trusting it.
+  - **Bleeding module** -- the v1 graceful fallback. When no static graph is
+    available (a non-Python repo, or grimp/networkx absent) we have only the
+    historical lens, so a low-containment module is flagged on history alone
+    rather than cross-checked against a (missing) static boundary.
+  - **Looks-coupled-but-never-co-changes** -- the inverse disagreement. The
+    static graph says "coupled" but history shows the edits stay contained. This
+    is fine in practice, so it is **suppressed** (``finding=None``): the static
+    graph already surfaces the coupling via its SCCs / burrow edges, and there
+    is no behavioural bleed to act on.
+  - **Refactor boundary** *(the one positive finding)* -- high containment plus
+    low external coupling: empirically, edits here stay put. This is the direct
+    yes to the assessment's core question -- *can an agent safely change this
+    area through a keyhole?* -- so these are surfaced as safe zones.
+
+This module is a pure function of its inputs (containment ratios + an optional
+per-directory static-modularity view); it runs no git or grimp itself. That
+keeps it cheap to test (mock the two inputs) and lets task #5 wire the real
+``containment_by_dir`` / ``change_coupling_pairs`` / ``analyze_structure``
+outputs into the run-context ``behaviour`` block. All returned structures are
+JSON-serialisable (paths as strings, plain dict/list/number/None).
+
+**Static-modularity input shape.** ``static_modularity`` maps a directory path
+(matching the keys of ``containment_by_dir``) to a metrics dict
+``{'modularity_q': float | None, 'front_door_ratio': float | None}``. Because
+``lib.structure_graph`` currently emits repo-level ``modularity_q`` /
+``front_door_ratio``, the caller (task #5) is responsible for projecting those
+onto the directories it cares about; this module only consumes the per-directory
+view. ``None`` for the whole argument means "no static graph at all" -> the
+graceful historical-only path. A directory absent from an otherwise-present dict
+is treated the same way per-directory (no static evidence for *that* dir).
+"""
+from __future__ import annotations
+
+# Containment below this fraction means a module bleeds: most of its commits
+# drag in files outside it. The PRD leaves the exact island threshold open for
+# calibration (Open Question: "what containment ratio counts as an island?");
+# 0.3 / 0.7 are the v1 defaults and are overridable per call.
+DEFAULT_LOW_CONTAINMENT = 0.3
+DEFAULT_HIGH_CONTAINMENT = 0.7
+
+# A directory "looks modular" statically when EITHER its modularity is high
+# (cohesive clusters, sparse cross-talk -- A2) OR most inbound cross-package
+# edges hit its front door rather than burrowing into internals (a real
+# contract -- A3). Either clean-boundary signal is enough to make the static map
+# *claim* modularity; when history then contradicts it, that claim is the lie
+# worth investigating. OR (not AND) is deliberate: it makes hidden-coupling
+# detection more sensitive, erring toward surfacing a seam for human review.
+DEFAULT_HIGH_MODULARITY_Q = 0.3
+DEFAULT_HIGH_FRONT_DOOR_RATIO = 0.7
+
+
+def _looks_modular(
+    metrics: dict | None,
+    high_modularity_q: float,
+    high_front_door_ratio: float,
+) -> bool:
+    """True if a directory's static metrics present a clean (modular) boundary.
+
+    ``metrics`` is ``{'modularity_q': float | None, 'front_door_ratio': float |
+    None}`` (or ``None`` when there is no static evidence for the directory).
+    Modular = high modularity OR high front-door ratio; ``None`` sub-metrics are
+    simply skipped, so a dict carrying only one of the two still works.
+    """
+    if not metrics:
+        return False
+    q = metrics.get("modularity_q")
+    fd = metrics.get("front_door_ratio")
+    if q is not None and q >= high_modularity_q:
+        return True
+    if fd is not None and fd >= high_front_door_ratio:
+        return True
+    return False
+
+
+def detect_hidden_coupling(
+    containment_by_dir: dict[str, float],
+    static_modularity: dict | None = None,
+    threshold_low_containment: float = DEFAULT_LOW_CONTAINMENT,
+    high_modularity_q: float = DEFAULT_HIGH_MODULARITY_Q,
+    high_front_door_ratio: float = DEFAULT_HIGH_FRONT_DOOR_RATIO,
+) -> list[dict]:
+    """B3: cross static modularity with historical containment to find lying boundaries.
+
+    For each directory in ``containment_by_dir`` whose containment is **below**
+    ``threshold_low_containment`` (it bleeds historically), classify the bleed
+    against the static lens:
+
+      - static graph present *and* the directory looks modular -> ``'hidden_coupling'``
+        (the static boundary is lying; recommend investigating the seam),
+      - no static graph at all (``static_modularity is None``) or no static
+        evidence for this directory -> ``'bleeding_module'`` (historical-only
+        fallback),
+      - static graph present *and* the directory also looks coupled -> ``None``
+        (static and history agree it is coupled; not *hidden*, and already
+        visible in the static SCC / burrow-edge output -- nothing new to flag).
+
+    Directories that do **not** bleed (containment at or above the threshold) are
+    not the concern of this function -- the inverse "looks-coupled-but-never-co-
+    changes" case is suppressed here and the positive case is handled by
+    :func:`find_refactor_boundaries` -- so they are omitted from the result.
+
+    Returns a list of ``{'path', 'containment_ratio', 'finding', 'recommendation'}``
+    sorted by containment ascending (worst bleed first), then path. ``finding``
+    is ``'hidden_coupling'``, ``'bleeding_module'`` or ``None`` (suppressed but
+    reported, so a caller can see the directory was evaluated and consciously
+    left alone).
+    """
+    results: list[dict] = []
+    for path in sorted(containment_by_dir):
+        containment = containment_by_dir[path]
+        if containment >= threshold_low_containment:
+            continue  # does not bleed: not this function's concern
+
+        metrics = static_modularity.get(path) if static_modularity is not None else None
+        has_static_evidence = static_modularity is not None and metrics is not None
+
+        if has_static_evidence:
+            if _looks_modular(metrics, high_modularity_q, high_front_door_ratio):
+                finding: str | None = "hidden_coupling"
+                recommendation = (
+                    "investigate the seam - the static boundary looks modular but "
+                    "its commits bleed outside it; the boundary is lying"
+                )
+            else:
+                # Static and history agree this is coupled. Not hidden, and the
+                # static SCC / burrow-edge output already surfaces it.
+                finding = None
+                recommendation = (
+                    "static and historical lenses agree this is coupled; already "
+                    "visible in the static structure output, nothing hidden to flag"
+                )
+        else:
+            finding = "bleeding_module"
+            recommendation = (
+                "edits here bleed outside the directory (low containment); no "
+                "static import graph available to cross-check the boundary"
+            )
+
+        results.append(
+            {
+                "path": path,
+                "containment_ratio": containment,
+                "finding": finding,
+                "recommendation": recommendation,
+            }
+        )
+
+    results.sort(key=lambda d: (d["containment_ratio"], d["path"]))
+    return results
+
+
+def find_refactor_boundaries(
+    containment_by_dir: dict[str, float],
+    threshold_high_containment: float = DEFAULT_HIGH_CONTAINMENT,
+    static_modularity: dict | None = None,
+    high_modularity_q: float = DEFAULT_HIGH_MODULARITY_Q,
+    high_front_door_ratio: float = DEFAULT_HIGH_FRONT_DOOR_RATIO,
+) -> list[dict]:
+    """B3 positive finding: directories an agent can safely refactor in isolation.
+
+    A directory whose containment is **above** ``threshold_high_containment`` is
+    a refactor boundary: empirically its edits stay put, so it answers the
+    assessment's core question -- *can an agent safely change this through a
+    keyhole?* -- with a yes. Containment (B2) is itself the direct
+    low-external-coupling signal, so high containment alone qualifies a boundary
+    even with no static graph (the v1 graceful path).
+
+    ``static_modularity``, when present, only *enriches* the recommendation: a
+    boundary that also looks modular statically gets a stronger "static and
+    historical lenses agree" note, while one that looks coupled statically still
+    qualifies (it never co-changes in practice -- the benign inverse-disagreement
+    case) but is noted as historically-backed only. It never disqualifies a
+    boundary, because lived behaviour (containment) outranks the static guess.
+
+    Returns ``{'path', 'containment_ratio', 'finding': 'refactor_boundary',
+    'recommendation'}`` entries, sorted by containment descending (safest first),
+    then path.
+    """
+    results: list[dict] = []
+    for path in sorted(containment_by_dir):
+        containment = containment_by_dir[path]
+        if containment <= threshold_high_containment:
+            continue
+
+        metrics = static_modularity.get(path) if static_modularity is not None else None
+        if metrics is not None and _looks_modular(
+            metrics, high_modularity_q, high_front_door_ratio
+        ):
+            recommendation = (
+                "safe to hand an agent in isolation - high containment and a "
+                "clean static boundary agree this area does not bleed"
+            )
+        else:
+            recommendation = (
+                "safe to hand an agent in isolation - edits here stay contained "
+                "(high containment)"
+            )
+
+        results.append(
+            {
+                "path": path,
+                "containment_ratio": containment,
+                "finding": "refactor_boundary",
+                "recommendation": recommendation,
+            }
+        )
+
+    results.sort(key=lambda d: (-d["containment_ratio"], d["path"]))
+    return results

--- a/skills/assess/tests/test_coupling_analysis.py
+++ b/skills/assess/tests/test_coupling_analysis.py
@@ -1,0 +1,215 @@
+"""Tests for the B3 static-vs-historical disagreement cross (coupling_analysis).
+
+The inputs (per-directory containment ratios + an optional per-directory
+static-modularity view) are **mocked directly** rather than derived from real
+git histories and grimp graphs: B3 is a pure function of those two upstream
+signals, which already have their own contract tests (test_change_coupling.py,
+test_structure_graph.py). Mocking keeps these tests fast and makes the
+disagreement logic auditable in isolation. Expected classifications are spelled
+out in each test so the contract is explicit.
+"""
+from __future__ import annotations
+
+from lib.coupling_analysis import (
+    DEFAULT_HIGH_CONTAINMENT,
+    DEFAULT_LOW_CONTAINMENT,
+    detect_hidden_coupling,
+    find_refactor_boundaries,
+)
+
+
+def _finding_for(results: list[dict], path: str):
+    """The `finding` for `path` in a results list, or KeyError-free None."""
+    for r in results:
+        if r["path"] == path:
+            return r["finding"]
+    return "ABSENT"
+
+
+# --------------------------------------------------------------------------
+# detect_hidden_coupling
+# --------------------------------------------------------------------------
+
+def test_high_static_modularity_plus_low_containment_is_hidden_coupling():
+    """Looks modular statically (high Q) but bleeds historically -> hidden_coupling."""
+    containment = {"pkg/a": 0.1}
+    static = {"pkg/a": {"modularity_q": 0.6, "front_door_ratio": 0.95}}
+    results = detect_hidden_coupling(containment, static_modularity=static)
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["finding"] == "hidden_coupling"
+    assert entry["path"] == "pkg/a"
+    assert entry["containment_ratio"] == 0.1
+    assert "seam" in entry["recommendation"].lower()
+
+
+def test_high_front_door_alone_triggers_hidden_coupling():
+    """Front-door ratio high (A3) is enough to count as 'looks modular'."""
+    containment = {"pkg/a": 0.2}
+    # modularity low, but a clean front door -> still looks modular statically.
+    static = {"pkg/a": {"modularity_q": 0.0, "front_door_ratio": 0.9}}
+    results = detect_hidden_coupling(containment, static_modularity=static)
+    assert _finding_for(results, "pkg/a") == "hidden_coupling"
+
+
+def test_low_containment_no_static_input_is_bleeding_module():
+    """No static graph at all -> graceful historical-only fallback label."""
+    containment = {"pkg/a": 0.15}
+    results = detect_hidden_coupling(containment, static_modularity=None)
+    assert len(results) == 1
+    assert results[0]["finding"] == "bleeding_module"
+    assert results[0]["path"] == "pkg/a"
+
+
+def test_low_containment_dir_absent_from_static_dict_is_bleeding_module():
+    """Static graph present but no evidence for THIS dir -> per-dir fallback."""
+    containment = {"pkg/a": 0.15}
+    static = {"pkg/other": {"modularity_q": 0.6, "front_door_ratio": 0.9}}
+    results = detect_hidden_coupling(containment, static_modularity=static)
+    assert _finding_for(results, "pkg/a") == "bleeding_module"
+
+
+def test_low_static_and_high_containment_is_suppressed():
+    """Looks coupled statically + never co-changes (high containment) -> suppressed.
+
+    The static graph already surfaces the coupling; with no behavioural bleed
+    there is nothing new to flag, so the directory is simply omitted (it does
+    not bleed, so it is not this function's concern).
+    """
+    containment = {"pkg/a": 0.95}  # high: edits stay contained
+    static = {"pkg/a": {"modularity_q": -0.1, "front_door_ratio": 0.2}}
+    results = detect_hidden_coupling(containment, static_modularity=static)
+    assert results == []
+
+
+def test_low_static_and_low_containment_agree_coupled_finding_none():
+    """Static AND history agree it's coupled -> reported but finding=None (not hidden)."""
+    containment = {"pkg/a": 0.1}  # bleeds
+    static = {"pkg/a": {"modularity_q": -0.2, "front_door_ratio": 0.1}}  # looks coupled
+    results = detect_hidden_coupling(containment, static_modularity=static)
+    assert len(results) == 1
+    assert results[0]["finding"] is None
+    assert results[0]["path"] == "pkg/a"
+
+
+def test_non_bleeding_dirs_are_omitted():
+    """Directories at or above the low threshold are not hidden-coupling concerns."""
+    containment = {"safe": 0.8, "edge": DEFAULT_LOW_CONTAINMENT, "bleeds": 0.1}
+    results = detect_hidden_coupling(containment, static_modularity=None)
+    paths = {r["path"] for r in results}
+    assert paths == {"bleeds"}  # 0.8 and the 0.3 edge are excluded
+
+
+def test_low_containment_threshold_is_strict_lower_bound():
+    """containment == threshold is NOT low (boundary not flagged); just below IS."""
+    containment = {"at": DEFAULT_LOW_CONTAINMENT, "below": DEFAULT_LOW_CONTAINMENT - 0.01}
+    results = detect_hidden_coupling(containment, static_modularity=None)
+    assert _finding_for(results, "at") == "ABSENT"
+    assert _finding_for(results, "below") == "bleeding_module"
+
+
+def test_custom_low_threshold_is_honoured():
+    containment = {"pkg/a": 0.45}
+    # default 0.3 would not flag 0.45; raise the bar to 0.5 and it bleeds.
+    assert detect_hidden_coupling(containment, threshold_low_containment=0.3) == []
+    results = detect_hidden_coupling(containment, threshold_low_containment=0.5)
+    assert _finding_for(results, "pkg/a") == "bleeding_module"
+
+
+def test_hidden_coupling_results_sorted_worst_bleed_first():
+    containment = {"a": 0.05, "b": 0.25, "c": 0.15}
+    results = detect_hidden_coupling(containment, static_modularity=None)
+    assert [r["path"] for r in results] == ["a", "c", "b"]
+    assert [r["containment_ratio"] for r in results] == [0.05, 0.15, 0.25]
+
+
+def test_partial_static_metrics_only_modularity():
+    """A static dict carrying only modularity_q (no front_door) still classifies."""
+    containment = {"pkg/a": 0.2}
+    static = {"pkg/a": {"modularity_q": 0.5}}  # front_door_ratio missing
+    assert _finding_for(
+        detect_hidden_coupling(containment, static_modularity=static), "pkg/a"
+    ) == "hidden_coupling"
+
+
+def test_empty_containment_returns_empty():
+    assert detect_hidden_coupling({}, static_modularity=None) == []
+    assert detect_hidden_coupling({}, static_modularity={}) == []
+
+
+# --------------------------------------------------------------------------
+# find_refactor_boundaries
+# --------------------------------------------------------------------------
+
+def test_high_containment_is_refactor_boundary():
+    """High containment (> 0.7) -> safe zone, even with no static graph."""
+    containment = {"pkg/island": 0.9}
+    results = find_refactor_boundaries(containment)
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["finding"] == "refactor_boundary"
+    assert entry["path"] == "pkg/island"
+    assert entry["containment_ratio"] == 0.9
+    assert "isolation" in entry["recommendation"].lower()
+
+
+def test_high_containment_threshold_is_strict_upper_bound():
+    """containment == threshold is NOT high enough; just above IS."""
+    containment = {"at": DEFAULT_HIGH_CONTAINMENT, "above": DEFAULT_HIGH_CONTAINMENT + 0.01}
+    results = find_refactor_boundaries(containment)
+    paths = {r["path"] for r in results}
+    assert paths == {"above"}
+
+
+def test_low_containment_is_not_a_refactor_boundary():
+    containment = {"pkg/bleeds": 0.2}
+    assert find_refactor_boundaries(containment) == []
+
+
+def test_refactor_boundary_static_agreement_enriches_recommendation():
+    """A modular static boundary that agrees gets the 'lenses agree' note."""
+    containment = {"pkg/clean": 0.9, "pkg/quiet": 0.85}
+    static = {
+        "pkg/clean": {"modularity_q": 0.6, "front_door_ratio": 0.95},  # looks modular
+        "pkg/quiet": {"modularity_q": -0.1, "front_door_ratio": 0.2},  # looks coupled
+    }
+    results = find_refactor_boundaries(containment, static_modularity=static)
+    by_path = {r["path"]: r for r in results}
+    # Both qualify on containment; static only changes the wording.
+    assert by_path["pkg/clean"]["finding"] == "refactor_boundary"
+    assert by_path["pkg/quiet"]["finding"] == "refactor_boundary"
+    assert "agree" in by_path["pkg/clean"]["recommendation"].lower()
+    assert "agree" not in by_path["pkg/quiet"]["recommendation"].lower()
+
+
+def test_refactor_boundaries_sorted_safest_first():
+    containment = {"a": 0.75, "b": 0.99, "c": 0.85}
+    results = find_refactor_boundaries(containment)
+    assert [r["path"] for r in results] == ["b", "c", "a"]
+
+
+def test_custom_high_threshold_is_honoured():
+    containment = {"pkg/a": 0.6}
+    assert find_refactor_boundaries(containment, threshold_high_containment=0.7) == []
+    results = find_refactor_boundaries(containment, threshold_high_containment=0.5)
+    assert _finding_for(results, "pkg/a") == "refactor_boundary"
+
+
+def test_refactor_empty_containment_returns_empty():
+    assert find_refactor_boundaries({}) == []
+
+
+# --------------------------------------------------------------------------
+# The two functions partition the bleed/island space cleanly
+# --------------------------------------------------------------------------
+
+def test_hidden_coupling_and_refactor_boundaries_are_disjoint():
+    """No directory is both a bleed concern and a safe refactor boundary."""
+    containment = {"bleeds": 0.1, "island": 0.95, "middle": 0.5}
+    static = {"bleeds": {"modularity_q": 0.6, "front_door_ratio": 0.9}}
+    hidden = {r["path"] for r in detect_hidden_coupling(containment, static_modularity=static)}
+    safe = {r["path"] for r in find_refactor_boundaries(containment, static_modularity=static)}
+    assert hidden == {"bleeds"}
+    assert safe == {"island"}
+    assert hidden.isdisjoint(safe)
+    # "middle" (0.3 <= c <= 0.7) is neither flagged nor declared safe.


### PR DESCRIPTION
## Summary

Implements PRD Signal **B3** (static-vs-historical disagreement) as a standalone deterministic module `skills/assess/scripts/lib/coupling_analysis.py`. This is the A×B cross: it joins the static lens (`structure_graph` modularity / front-door ratio, A2/A3) against the historical lens (`change_coupling` containment ratio, B2) to find boundaries that lie.

`assess-keyhole-readiness.4`. Does **not** touch `assess_core.py` (integration is task #5) and does **not** bump `plugin.json` (single bump in the release PR #6).

## Changes Made

- `lib/coupling_analysis.py`:
  - `detect_hidden_coupling(containment_by_dir, static_modularity=None, threshold_low_containment=0.3)` — classifies low-containment (bleeding) directories:
    - looks modular statically ∧ bleeds → `hidden_coupling` (investigate the seam — the boundary is lying)
    - no static graph available → `bleeding_module` (graceful historical-only fallback)
    - looks coupled statically ∧ bleeds → `None` (static and history agree; not *hidden*)
  - `find_refactor_boundaries(containment_by_dir, threshold_high_containment=0.7, static_modularity=None)` — the one positive finding: high containment → `refactor_boundary` (safe to hand an agent in isolation). Static metrics only enrich the recommendation, never disqualify.
- `tests/test_coupling_analysis.py` — 20 tests with mocked containment + static-modularity inputs.

## Technical Details

- Pure function of its two inputs (no git/grimp run here) — cheap to test, lets task #5 wire real outputs into the run-context `behaviour` block.
- "Looks modular" = high modularity_q **OR** high front-door ratio (sensitive, errs toward surfacing a seam for human review).
- JSON-serialisable returns: `[{'path', 'containment_ratio', 'finding', 'recommendation'}]`, sorted worst-bleed-first / safest-first.
- Strict inequalities at thresholds (`< low`, `> high`) so the two functions partition the space disjointly.

## Testing

- New file: 20 passing. Full `skills/assess/` suite: 236 passing, no regressions.
- Deterministic core: reproducible, no AI, no new deps.

## Risk Assessment

Low — additive standalone module, not yet wired into any orchestrator.