### PR TITLE
feat(assess): add understanding analysis + velocity clock (B4/D2)

### DIFF
--- a/skills/assess/scripts/lib/understanding_analysis.py
+++ b/skills/assess/scripts/lib/understanding_analysis.py
@@ -1,0 +1,248 @@
+"""Signals B4 + D2: where understanding lives, and the velocity clock.
+
+The keyhole question the rest of `/assess` can't answer on its own: for a
+complex module that no single context window can hold, *does anyone still
+understand it*? Classic ownership ("who wrote the most lines") is the wrong
+lens in the AI era - a directory churned by hundreds of agent sessions has
+enormous activity and effectively zero retained understanding. So instead of an
+owner we compute, per module:
+
+  - **human anchor** (B4) - has a confirmed human substantively authored it?
+    Someone who can be asked. (Straight from
+    ``change_coupling.authorship_analysis`` - reused, never re-derived, so the
+    conservative agent/human classification stays defined one way.)
+  - **intent source** (B4) - is there an externalised spec/doc stating what the
+    code *should* do? Computed from doc->code association (a doc whose directory
+    is an ancestor of the module), the same path-proximity edges
+    ``doc_staleness`` / the C-signal join use. Presence, not freshness: a stale
+    doc still externalises intent (its *staleness* is signal C's lying-map
+    finding, not this one's).
+  - **authorship class** (B4) - human / agent / mixed / unknown, passed through
+    from the authorship analysis.
+  - **days_since_comprehension_event** (D2, the velocity clock) - calendar age
+    is dead under AI velocity; "legacy" means *orphaned understanding*, which
+    can happen on day one. So age is measured from the last
+    **comprehension-event**: a human-authored commit touching the module (the
+    git-log-reachable, deterministic instance of "a human-originated act that
+    demonstrates understanding"). Fully automated commits don't count. ``None``
+    when no human-authored commit is found (indeterminate, not "fresh").
+
+The primary finding is **orphaned understanding**: high complexity ∧ no human
+anchor ∧ no intent source - code agents wrote that no human understands and no
+spec explains. The worst case, and the direct feed for the velocity clock.
+
+This module is **standalone**: it consumes the JSON-serialisable outputs of
+``authorship_analysis`` (per path), ``analyze_doc_staleness``, and the
+complexity treemap (``complexity-stats.json``), and returns a JSON-serialisable
+dict. It never imports or edits ``assess_core`` - wiring the ``understanding``
+block into ``run-context.json`` is a separate task's job.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import subprocess
+from pathlib import Path, PurePosixPath
+
+# Reuse the shared, deliberately conservative agent-detection primitives from
+# the change-coupling module rather than re-implementing them: agent/human
+# classification must be defined exactly once (PRD Open Question 6 - never
+# libel a human author), and the velocity clock's "human-authored commit" test
+# has to agree with what `authorship_analysis` already called a human.
+from lib.change_coupling import (
+    GIT_TIMEOUT_SECONDS,
+    _identity_is_agent,
+    _repo_top,
+)
+
+# McCabe's classic "moderate risk" line, used as the floor for "high
+# complexity". We gate the orphaned-understanding finding on the *higher* of
+# this floor and the repo's own 95th-percentile CCN, so a genuinely simple repo
+# never sprouts findings while a complex repo self-calibrates to its worst ~5%.
+# Same value and rationale as the C-signal join (``doc_complexity_join``), kept
+# consistent so "high complexity" means one thing across both findings.
+MIN_HIGH_CCN = 10.0
+
+# Advice for a human, never an instruction to a tool. The orphaned-understanding
+# remedy is to put a person back in the loop before the next change - not to
+# auto-generate a doc (that manufactures lying maps; see the C-signal guard).
+_ORPHANED_RECOMMENDATION = (
+    "Assign a human anchor before further change. This is complex code with no "
+    "confirmed human author and no spec stating what it should do - agents can "
+    "keep changing it, but no one retains the understanding to review them. Do "
+    "NOT auto-generate a doc to clear this; a synthetic summary is a lying map."
+)
+
+
+def _extract_file_ccn(complexity_stats: dict) -> dict[str, float]:
+    """Build path -> max-CCN from the per-file lists the stats expose.
+
+    ``complexity-stats.json`` carries per-file CCN in its ranked lists
+    (``top_complex`` / ``top_hotspots`` / ``top_large``) and, optionally, a full
+    ``files`` list; we union them and keep the highest CCN seen per path. Mirrors
+    the C-signal join's extraction so both findings read complexity identically.
+    """
+    ccn: dict[str, float] = {}
+    for key in ("files", "top_complex", "top_hotspots", "top_large"):
+        for entry in complexity_stats.get(key) or []:
+            path = entry.get("path")
+            if path is None or entry.get("ccn") is None:
+                continue
+            value = float(entry["ccn"])
+            if value > ccn.get(path, float("-inf")):
+                ccn[path] = value
+    return ccn
+
+
+def _high_ccn_threshold(complexity_stats: dict) -> float:
+    """The CCN at or above which a module counts as 'high complexity'."""
+    p95 = float((complexity_stats.get("ccn") or {}).get("p95", 0.0) or 0.0)
+    return max(p95, MIN_HIGH_CCN)
+
+
+def _doc_dirs(doc_staleness: dict) -> list[tuple[str, ...]]:
+    """Directory parts of every doc, only when the staleness signal is available.
+
+    A repo-root doc yields ``()`` (it is an ancestor of everything), matching the
+    doc->code association the C-signal join and ``doc_staleness`` use.
+    """
+    if not doc_staleness.get("available", False):
+        return []
+    return [
+        PurePosixPath(doc["path"]).parent.parts
+        for doc in doc_staleness.get("docs", [])
+        if doc.get("path")
+    ]
+
+
+def _has_intent_source(code_path: str, doc_dirs: list[tuple[str, ...]]) -> bool:
+    """True if any doc's directory is an ancestor of ``code_path``.
+
+    Same path-proximity rule as the doc-staleness association: a doc covers code
+    in its own directory and below. A repo-root doc (``()``) therefore covers
+    everything - intentionally, so this stays consistent with how the C-signal
+    join decides a unit is documented; the orphaned-understanding finding is
+    deliberately conservative (it should fire only when there is *no* externalised
+    intent anywhere up the tree).
+    """
+    code_parts = PurePosixPath(code_path).parts
+    return any(code_parts[: len(d)] == d for d in doc_dirs)
+
+
+def _days_since_last_human_commit(repo_top: str, path: str) -> int | None:
+    """Velocity clock (D2): days since the last human-authored commit on ``path``.
+
+    A comprehension-event is a human-originated act demonstrating understanding;
+    the deterministic, git-log-reachable instance is a commit whose *author* is a
+    confirmed human (same human/agent test ``authorship_analysis`` uses). ``git
+    log`` lists newest-first, so the first human-authored commit we hit is the
+    most recent. Returns ``None`` when git is unavailable or no human-authored
+    commit exists (indeterminate - never silently treated as "fresh").
+    """
+    fmt = "\x1e%ct\x1f%an\x1f%ae"
+    try:
+        raw = subprocess.run(
+            ["git", "-C", repo_top, "log", "--no-merges", f"--format={fmt}", "--", path],
+            capture_output=True, text=True, check=True, timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    now = _dt.datetime.now().timestamp()
+    for chunk in raw.split("\x1e"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = chunk.split("\x1f")
+        parts += [""] * (3 - len(parts))
+        ct, an, ae = parts[:3]
+        author_agent = _identity_is_agent(ae, an)
+        author_human = bool(ae.strip()) and "@" in ae and not author_agent
+        if not author_human:
+            continue
+        try:
+            ts = int(ct)
+        except ValueError:
+            continue
+        return max(0, int((now - ts) // 86400))
+    return None
+
+
+def analyze_understanding(
+    repo_root: Path,
+    authorship_by_path: dict[str, dict],
+    doc_staleness: dict,
+    complexity_stats: dict,
+) -> dict:
+    """Signals B4 + D2: per-module understanding signals and the orphaned finding.
+
+    Args:
+        repo_root: repository root, used only for the velocity-clock git query.
+        authorship_by_path: ``{path: authorship_analysis(...) result}`` - each
+            value carries ``human_anchor`` / ``authorship_class`` from
+            ``change_coupling.authorship_analysis``. The set of keys defines the
+            modules analysed.
+        doc_staleness: the dict returned by ``analyze_doc_staleness`` (its
+            ``docs[].path`` list drives intent-source detection).
+        complexity_stats: the ``complexity-stats.json`` sidecar (per-file CCN in
+            its ranked lists; CCN percentiles under ``ccn``).
+
+    Returns a JSON-serialisable dict::
+
+        {
+          "available": bool,             # there was authorship data to analyse
+          "high_ccn_threshold": float,   # CCN gate used for the finding
+          "modules": [ {path, human_anchor, intent_source, authorship_class,
+                        days_since_comprehension_event, finding, recommendation} ],
+          "orphaned_understanding": [ ...paths ],
+        }
+
+    ``finding`` is ``"orphaned_understanding"`` when a module is high-complexity
+    ∧ has no human anchor ∧ has no intent source, else ``None``. The module list
+    covers every path in ``authorship_by_path`` (full understanding picture for
+    the report), not only the flagged ones. Suitable as-is for
+    ``run-context.json``'s ``understanding`` block (a later task's job to place).
+    """
+    repo_root = Path(repo_root)
+    repo_top = _repo_top(repo_root)
+
+    file_ccn = _extract_file_ccn(complexity_stats)
+    threshold = _high_ccn_threshold(complexity_stats)
+    doc_dirs = _doc_dirs(doc_staleness)
+
+    modules: list[dict] = []
+    orphaned: list[str] = []
+
+    for path in sorted(authorship_by_path):
+        record = authorship_by_path[path] or {}
+        human_anchor = bool(record.get("human_anchor", False))
+        authorship_class = record.get("authorship_class", "unknown")
+        intent_source = _has_intent_source(path, doc_dirs)
+        is_high_complexity = file_ccn.get(path, 0.0) >= threshold
+
+        days_since = (
+            _days_since_last_human_commit(repo_top, path)
+            if repo_top is not None
+            else None
+        )
+
+        finding: str | None = None
+        if is_high_complexity and not human_anchor and not intent_source:
+            finding = "orphaned_understanding"
+            orphaned.append(path)
+
+        modules.append({
+            "path": path,
+            "human_anchor": human_anchor,
+            "intent_source": intent_source,
+            "authorship_class": authorship_class,
+            "days_since_comprehension_event": days_since,
+            "finding": finding,
+            "recommendation": _ORPHANED_RECOMMENDATION if finding else None,
+        })
+
+    return {
+        "available": bool(authorship_by_path),
+        "high_ccn_threshold": round(threshold, 2),
+        "modules": modules,
+        "orphaned_understanding": sorted(orphaned),
+    }

--- a/skills/assess/tests/test_understanding_analysis.py
+++ b/skills/assess/tests/test_understanding_analysis.py
@@ -1,0 +1,266 @@
+"""Tests for the understanding analysis (B4) + velocity clock (D2).
+
+Two styles, matching the contract:
+  - Pure-logic tests mock ``authorship_by_path`` / ``doc_staleness`` /
+    ``complexity_stats`` and assert the orphaned-understanding logic and
+    intent-source detection in isolation (repo_root is a non-git temp dir, so
+    the velocity clock is exercised through its ``None`` degrade path).
+  - Git-integration tests build synthetic histories with controlled commit
+    metadata, feed the *real* ``authorship_analysis`` output in, and assert the
+    end-to-end classification and the velocity clock against backdated commits.
+
+Expected values are hand-noted so the contract stays auditable.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import subprocess
+from pathlib import Path
+
+from lib.change_coupling import authorship_analysis
+from lib.understanding_analysis import analyze_understanding
+
+
+# --- git fixture helpers (local, for full control of author/committer/date) --
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> None:
+    full_env = {**os.environ, **(env or {})}
+    subprocess.run(["git", "-C", str(repo), *args],
+                   check=True, capture_output=True, text=True, env=full_env)
+
+
+def _write(repo: Path, rel: str, text: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _commit(
+    repo: Path,
+    files: dict[str, str],
+    message: str = "change",
+    *,
+    author: tuple[str, str] | None = None,
+    committer: tuple[str, str] | None = None,
+    co_authors: list[str] | None = None,
+    days_ago: int | None = None,
+) -> None:
+    """Write ``files`` (rel path -> contents), stage, and commit.
+
+    ``author``/``committer`` are (name, email) tuples; ``co_authors`` is a list
+    of "Name <email>" strings folded into Co-Authored-By trailers; ``days_ago``
+    backdates author + committer time (git rejects relative strings, so we emit
+    a strict ISO timestamp) to drive the velocity clock.
+    """
+    for rel, text in files.items():
+        _write(repo, rel, text)
+    _git(repo, "add", "-A")
+    body = message
+    for ca in co_authors or []:
+        body += f"\n\nCo-Authored-By: {ca}"
+    env: dict[str, str] = {}
+    if author:
+        env["GIT_AUTHOR_NAME"], env["GIT_AUTHOR_EMAIL"] = author
+    if committer:
+        env["GIT_COMMITTER_NAME"], env["GIT_COMMITTER_EMAIL"] = committer
+    if days_ago is not None:
+        when = _dt.datetime.now() - _dt.timedelta(days=days_ago)
+        stamp = when.strftime("%Y-%m-%dT%H:%M:%S")
+        env["GIT_AUTHOR_DATE"] = stamp
+        env["GIT_COMMITTER_DATE"] = stamp
+    _git(repo, "commit", "-q", "-m", body, env=env)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dev@example.com")
+    _git(repo, "config", "user.name", "Dev Human")
+    return repo
+
+
+# Complexity stats with one high-CCN file. p95 absent -> MIN_HIGH_CCN (10) floor.
+def _stats_high(path: str, ccn: float = 25.0) -> dict:
+    return {"ccn": {"p95": 0.0}, "top_complex": [{"path": path, "ccn": ccn}]}
+
+
+def _no_docs() -> dict:
+    return {"available": False, "docs": []}
+
+
+# --- pure-logic: the orphaned-understanding finding --------------------------
+
+def test_orphaned_when_agent_high_complexity_no_doc(tmp_path: Path) -> None:
+    """High complexity ∧ no human anchor ∧ no intent source -> orphaned."""
+    authorship = {"lib/x.py": {"human_anchor": False, "authorship_class": "agent",
+                               "intent_source": False, "contributors": []}}
+    result = analyze_understanding(
+        tmp_path, authorship, _no_docs(), _stats_high("lib/x.py"))
+
+    assert result["available"] is True
+    assert result["orphaned_understanding"] == ["lib/x.py"]
+    mod = result["modules"][0]
+    assert mod["finding"] == "orphaned_understanding"
+    assert mod["authorship_class"] == "agent"
+    assert mod["human_anchor"] is False
+    assert mod["intent_source"] is False
+    assert mod["recommendation"] is not None
+    # Non-git repo_root -> the velocity clock degrades to None, never "fresh".
+    assert mod["days_since_comprehension_event"] is None
+
+
+def test_human_anchor_suppresses_orphan(tmp_path: Path) -> None:
+    authorship = {"lib/x.py": {"human_anchor": True, "authorship_class": "human",
+                               "intent_source": True, "contributors": []}}
+    result = analyze_understanding(
+        tmp_path, authorship, _no_docs(), _stats_high("lib/x.py"))
+
+    assert result["orphaned_understanding"] == []
+    assert result["modules"][0]["finding"] is None
+    assert result["modules"][0]["recommendation"] is None
+
+
+def test_intent_source_suppresses_orphan(tmp_path: Path) -> None:
+    """A co-located doc is an intent source even with no human anchor."""
+    authorship = {"lib/x.py": {"human_anchor": False, "authorship_class": "agent",
+                               "intent_source": False, "contributors": []}}
+    doc_staleness = {"available": True, "docs": [{"path": "lib/README.md"}]}
+    result = analyze_understanding(
+        tmp_path, authorship, doc_staleness, _stats_high("lib/x.py"))
+
+    assert result["orphaned_understanding"] == []
+    mod = result["modules"][0]
+    assert mod["intent_source"] is True
+    assert mod["finding"] is None
+
+
+def test_low_complexity_not_orphaned(tmp_path: Path) -> None:
+    """Below the CCN gate, agent + no doc is still not orphaned."""
+    authorship = {"lib/x.py": {"human_anchor": False, "authorship_class": "agent",
+                               "intent_source": False, "contributors": []}}
+    # ccn 3 is below the MIN_HIGH_CCN (10) floor.
+    result = analyze_understanding(
+        tmp_path, authorship, _no_docs(), _stats_high("lib/x.py", ccn=3.0))
+
+    assert result["orphaned_understanding"] == []
+    assert result["modules"][0]["finding"] is None
+
+
+def test_root_doc_covers_everything(tmp_path: Path) -> None:
+    """A repo-root doc is an ancestor of all paths -> intent source everywhere."""
+    authorship = {"lib/x.py": {"human_anchor": False, "authorship_class": "agent",
+                               "intent_source": False, "contributors": []}}
+    doc_staleness = {"available": True, "docs": [{"path": "README.md"}]}
+    result = analyze_understanding(
+        tmp_path, authorship, doc_staleness, _stats_high("lib/x.py"))
+
+    assert result["modules"][0]["intent_source"] is True
+    assert result["orphaned_understanding"] == []
+
+
+def test_unrelated_doc_is_not_intent_source(tmp_path: Path) -> None:
+    """A doc in a sibling subtree does not cover the module."""
+    authorship = {"lib/x.py": {"human_anchor": False, "authorship_class": "agent",
+                               "intent_source": False, "contributors": []}}
+    doc_staleness = {"available": True, "docs": [{"path": "other/README.md"}]}
+    result = analyze_understanding(
+        tmp_path, authorship, doc_staleness, _stats_high("lib/x.py"))
+
+    assert result["modules"][0]["intent_source"] is False
+    assert result["orphaned_understanding"] == ["lib/x.py"]
+
+
+def test_unavailable_when_no_authorship(tmp_path: Path) -> None:
+    result = analyze_understanding(tmp_path, {}, _no_docs(), {})
+    assert result["available"] is False
+    assert result["modules"] == []
+    assert result["orphaned_understanding"] == []
+
+
+def test_mixed_class_passthrough(tmp_path: Path) -> None:
+    authorship = {"lib/x.py": {"human_anchor": True, "authorship_class": "mixed",
+                               "intent_source": True, "contributors": []}}
+    result = analyze_understanding(
+        tmp_path, authorship, _no_docs(), _stats_high("lib/x.py"))
+    assert result["modules"][0]["authorship_class"] == "mixed"
+
+
+# --- git-integration: real authorship + the velocity clock -------------------
+
+def test_agent_only_repo_is_orphaned(tmp_path: Path) -> None:
+    """Only agent commits, no doc, high complexity -> orphaned; clock is None."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"svc.py": "v1"}, "feat",
+            author=("dependabot[bot]", "49699333+dependabot[bot]@users.noreply.github.com"),
+            committer=("dependabot[bot]", "49699333+dependabot[bot]@users.noreply.github.com"))
+
+    authorship = {"svc.py": authorship_analysis(repo, "svc.py")}
+    assert authorship["svc.py"]["authorship_class"] == "agent"
+
+    result = analyze_understanding(repo, authorship, _no_docs(), _stats_high("svc.py"))
+    assert result["orphaned_understanding"] == ["svc.py"]
+    mod = result["modules"][0]
+    assert mod["finding"] == "orphaned_understanding"
+    # No human-authored commit exists -> clock indeterminate.
+    assert mod["days_since_comprehension_event"] is None
+
+
+def test_human_commit_sets_anchor_and_clock(tmp_path: Path) -> None:
+    """A backdated human commit -> human_anchor, no orphan, dated velocity clock."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"svc.py": "v1"}, "feat",
+            author=("Alice", "alice@example.com"),
+            committer=("Alice", "alice@example.com"),
+            days_ago=30)
+
+    authorship = {"svc.py": authorship_analysis(repo, "svc.py")}
+    assert authorship["svc.py"]["human_anchor"] is True
+
+    result = analyze_understanding(repo, authorship, _no_docs(), _stats_high("svc.py"))
+    assert result["orphaned_understanding"] == []
+    mod = result["modules"][0]
+    assert mod["finding"] is None
+    # Clock reads ~30 days; allow a day of rounding/clock drift.
+    assert mod["days_since_comprehension_event"] is not None
+    assert 29 <= mod["days_since_comprehension_event"] <= 31
+
+
+def test_mixed_repo_classified_mixed(tmp_path: Path) -> None:
+    """Human author + agent co-author -> mixed, and the clock follows the human."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"svc.py": "v1"}, "feat",
+            author=("Bob", "bob@example.com"),
+            committer=("Bob", "bob@example.com"),
+            co_authors=["Claude <noreply@anthropic.com>"],
+            days_ago=10)
+
+    authorship = {"svc.py": authorship_analysis(repo, "svc.py")}
+    assert authorship["svc.py"]["authorship_class"] == "mixed"
+
+    result = analyze_understanding(repo, authorship, _no_docs(), _stats_high("svc.py"))
+    mod = result["modules"][0]
+    assert mod["authorship_class"] == "mixed"
+    assert mod["human_anchor"] is True
+    assert mod["finding"] is None
+    assert 9 <= mod["days_since_comprehension_event"] <= 11
+
+
+def test_agent_commit_does_not_count_as_comprehension_event(tmp_path: Path) -> None:
+    """Newest commit is an agent's; the clock dates the older human commit."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"svc.py": "v1"}, "human work",
+            author=("Carol", "carol@example.com"),
+            committer=("Carol", "carol@example.com"),
+            days_ago=40)
+    _commit(repo, {"svc.py": "v2"}, "agent tweak",
+            author=("github-actions[bot]", "github-actions[bot]@users.noreply.github.com"),
+            committer=("github-actions[bot]", "github-actions[bot]@users.noreply.github.com"),
+            days_ago=5)
+
+    authorship = {"svc.py": authorship_analysis(repo, "svc.py")}
+    result = analyze_understanding(repo, authorship, _no_docs(), _stats_high("svc.py"))
+    mod = result["modules"][0]
+    # The agent commit (5 days ago) is ignored; the clock reads the human one.
+    assert 39 <= mod["days_since_comprehension_event"] <= 41


### PR DESCRIPTION
## Summary

Adds the standalone deterministic module for Signals **B4 (where understanding lives)** and **D2 (the velocity clock)** from the keyhole-readiness PRD, plus its test contract. Part of `assess-keyhole-readiness.3`.

`skills/assess/scripts/lib/understanding_analysis.py` — `analyze_understanding(repo_root, authorship_by_path, doc_staleness, complexity_stats) -> dict`.

## Changes Made

- **New module** `lib/understanding_analysis.py` computing, per module:
  - `human_anchor` / `authorship_class` — reused verbatim from `change_coupling.authorship_analysis` (never re-derived, so the conservative agent/human classification stays defined once — PRD Open Question 6).
  - `intent_source` — doc->code path-proximity association (a doc whose directory is an ancestor of the module), same edges `doc_staleness` / the C-signal join use. Presence, not freshness.
  - `days_since_comprehension_event` (D2) — days since the last **human-authored** commit on the path. Agent/bot commits don't count; `None` when indeterminate (never silently "fresh").
  - `finding` = `orphaned_understanding` when high complexity ∧ no human anchor ∧ no intent source.
- **New tests** `tests/test_understanding_analysis.py` — 12 tests: pure-logic finding/intent-source cases (mocked inputs) + git-integration cases (synthetic histories, real `authorship_analysis`, backdated velocity clock).

## Technical Details

- Standalone: consumes JSON-serialisable inputs, returns a JSON-serialisable `understanding` block. Does not import or edit `assess_core` (integration is task #5).
- "High complexity" gate mirrors the C-signal join (`max(p95, MIN_HIGH_CCN=10)`) so the threshold means one thing across findings.
- No new dependencies; deterministic core (git log + stdlib), reproducible, no AI.

## Testing

`cd skills/assess && uv run --with pytest pytest -v` — full suite 207 passed (12 new).

## Risk Assessment

Additive only — new module + new test file. No existing module touched. No plugin.json bump (single bump in the release PR #6).