### PR TITLE
feat(assess): wire test_pressure into deterministic core with fixtures

### DIFF
--- a/skills/assess/pyproject.toml
+++ b/skills/assess/pyproject.toml
@@ -17,3 +17,8 @@ dev = [
 testpaths = ["tests"]
 pythonpath = ["scripts"]
 addopts = "-v --tb=short"
+# Fixture repos under tests/fixtures/ contain test_*.py files that are scanned
+# as *data* by the test_pressure heuristics, not run as pytest tests. They
+# import from their own `src/` package which isn't on the path, so collecting
+# them errors. Exclude the whole fixtures tree from collection.
+norecursedirs = ["tests/fixtures"]

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -43,6 +43,7 @@ from lib.doc_staleness import analyze_doc_staleness
 from lib.git_churn import tracked_files
 from lib.liveness_scan import scan_liveness
 from lib.stats_diff import diff_stats, hotspot_commits, load_stats
+from lib.test_pressure import scan_test_pressure
 from lib.wiki_writer import (
     HotspotEntry,
     LogEntry,
@@ -542,6 +543,41 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
               "discoverable": {"present": False, "signals": []},
               "reachable": {"present": False, "signals": []}}
     )
+
+    # Layer 1 write-side truth pressure: does the suite pin behaviour down, or
+    # merely visit it? Best-effort like every other read-side scan. opt_in=False
+    # keeps the (mutating, code-running) bounded mutation pass OFF by default, so
+    # /assess stays read-only and fast - the cheap hollow-test heuristics and
+    # mutation-config detection still run. hot_files come from the current top
+    # hotspots so an opt-in mutation run would target the files that matter most.
+    hot_files = [h.get("path") for h in current.get("top_hotspots", [])
+                 if h.get("path")]
+    test_pressure = _safe(
+        "test_pressure",
+        lambda: scan_test_pressure(repo_root, hot_files=hot_files, opt_in=False),
+    )
+    # A failed (or malformed) scan must not read as "no mutation setup": that
+    # would mis-score Layer 1 just as a failed liveness scan would mis-score
+    # observability. Carry an explicit unavailable marker with a null
+    # mutation_config_present and empty heuristic buckets so the LLM sees
+    # "not assessed", never a false negative. Keys mirror the real block's
+    # `cheap_heuristics` schema (assertion_on_internal / untested_boundaries /
+    # duplicate_truth) so the consumer's shape doesn't change on the failure path.
+    tp_ok = (isinstance(test_pressure, dict)
+             and "mutation_config_present" in test_pressure
+             and "cheap_heuristics" in test_pressure)
+    ctx["test_pressure"] = test_pressure if tp_ok else {
+        "available": False,
+        "reason": (test_pressure.get("reason")
+                   if isinstance(test_pressure, dict)
+                   else "test_pressure scan unavailable"),
+        "mutation_config_present": None,
+        "cheap_heuristics": {
+            "assertion_on_internal": [],
+            "untested_boundaries": [],
+            "duplicate_truth": [],
+        },
+    }
 
     ctx["plugin_version"] = _read_plugin_version()
     ctx["anomalies"] = [

--- a/skills/assess/tests/fixtures/hollow_test_repo/src/processor.py
+++ b/skills/assess/tests/fixtures/hollow_test_repo/src/processor.py
@@ -1,0 +1,20 @@
+"""Tiny line processor shared verbatim by the hollow and honest fixture repos.
+
+The two repos differ ONLY in their test file: the hollow repo asserts on the
+private `_last_processed_line` cursor (implementation detail); the honest repo
+asserts on the public `process` return value (the contract). Same source, same
+coverage - the only variable is what the test pins.
+"""
+from __future__ import annotations
+
+
+class Processor:
+    def __init__(self) -> None:
+        self._last_processed_line = 0
+        self.results: list[str] = []
+
+    def process(self, lines: list[str]) -> list[str]:
+        for i, line in enumerate(lines, start=1):
+            self._last_processed_line = i
+            self.results.append(line.upper())
+        return self.results

--- a/skills/assess/tests/fixtures/hollow_test_repo/tests/test_processor.py
+++ b/skills/assess/tests/fixtures/hollow_test_repo/tests/test_processor.py
@@ -1,0 +1,14 @@
+"""Hollow test: pins the implementation, not the contract.
+
+It asserts only on the private `_last_processed_line` cursor. A correct refactor
+that renames or removes the cursor breaks this test; a behavioural regression in
+the public output (wrong case, dropped lines) sails straight past it. This is the
+meridian resume-guard fingerprint that detect_assertion_on_internal flags.
+"""
+from src.processor import Processor
+
+
+def test_process_advances_cursor():
+    p = Processor()
+    p.process(["a", "b", "c", "d", "e"])
+    assert p._last_processed_line == 5

--- a/skills/assess/tests/fixtures/honest_test_repo/src/processor.py
+++ b/skills/assess/tests/fixtures/honest_test_repo/src/processor.py
@@ -1,0 +1,20 @@
+"""Tiny line processor shared verbatim by the hollow and honest fixture repos.
+
+The two repos differ ONLY in their test file: the hollow repo asserts on the
+private `_last_processed_line` cursor (implementation detail); the honest repo
+asserts on the public `process` return value (the contract). Same source, same
+coverage - the only variable is what the test pins.
+"""
+from __future__ import annotations
+
+
+class Processor:
+    def __init__(self) -> None:
+        self._last_processed_line = 0
+        self.results: list[str] = []
+
+    def process(self, lines: list[str]) -> list[str]:
+        for i, line in enumerate(lines, start=1):
+            self._last_processed_line = i
+            self.results.append(line.upper())
+        return self.results

--- a/skills/assess/tests/fixtures/honest_test_repo/tests/test_processor.py
+++ b/skills/assess/tests/fixtures/honest_test_repo/tests/test_processor.py
@@ -1,0 +1,14 @@
+"""Honest test: pins the contract, not the implementation.
+
+It asserts on the public `process` return value - the observable behaviour the
+caller depends on. A regression in the output is caught; a refactor that keeps
+the output stable is free to change internals. detect_assertion_on_internal must
+NOT flag this: there is no private-field assertion here.
+"""
+from src.processor import Processor
+
+
+def test_process_uppercases_lines():
+    p = Processor()
+    out = p.process(["a", "b", "c", "d", "e"])
+    assert out == ["A", "B", "C", "D", "E"]

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -806,3 +806,101 @@ def test_config_excludes_apply_to_all_scans(tmp_path: Path) -> None:
     # via --exclude or get post-filtered).
     for c in ctx["dead_code"].get("candidates", []):
         assert "regulatory-raw" not in c.get("path", "")
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Task 4 - test_pressure wiring into build_run_context / run-context.json
+# ════════════════════════════════════════════════════════════════════════════
+
+def test_test_pressure_block_present_in_ctx(tmp_path: Path) -> None:
+    """run-context.json carries a test_pressure block with the required fields.
+
+    A hollow test (asserts on a private field, no public assertion) must surface
+    as an assertion_on_internal candidate so the LLM can fold it into Layer 1."""
+    repo = _minimal_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "guard.py").write_text("class Guard:\n    pass\n", encoding="utf-8")
+    (repo / "test_guard.py").write_text(
+        "def test_resume():\n"
+        "    g = Guard()\n"
+        "    assert g._resume_count == 1\n",
+        encoding="utf-8",
+    )
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-29")
+    assert "test_pressure" in ctx
+    tp = ctx["test_pressure"]
+    assert "mutation_config_present" in tp
+    assert "cheap_heuristics" in tp
+    # opt_in defaults off: /assess stays read-only, no mutation run.
+    assert tp["mutation_run"] is False
+    assert tp["cheap_heuristics"]["assertion_on_internal"]
+
+
+def test_test_pressure_mutation_not_run_by_default(tmp_path: Path) -> None:
+    """The bounded mutation pass is opt-in - a default run must never invoke it.
+
+    scan_test_pressure is called with opt_in=False, so even a repo whose language
+    is present and whose tool is on PATH does not get mutated by /assess."""
+    repo = _minimal_repo(tmp_path)
+    (repo / "app.py").write_text("def f(): return 1\n", encoding="utf-8")
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-29")
+    tp = ctx["test_pressure"]
+    assert tp["mutation_run"] is False
+    assert tp["per_file"] == []
+
+
+def test_test_pressure_passes_hotspots_as_hot_files(tmp_path: Path, monkeypatch) -> None:
+    """The wiring threads the current top-hotspot paths into scan_test_pressure
+    as hot_files, so an opt-in mutation run would target the files that matter."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 10, "loc": {"p50": 10, "p95": 30, "max": 50},
+        "ccn": {"p50": 1, "p95": 3, "max": 5},
+        "top_hotspots": [
+            {"path": "src/hot.py", "loc": 500, "ccn": 20, "commits": 5},
+        ],
+        "top_complex": [{"path": "src/hot.py", "ccn": 20}],
+        "top_large": [{"path": "src/hot.py", "loc": 500}],
+    }))
+    captured = {}
+
+    def fake_scan(repo_root, hot_files=None, opt_in=False, coverage_data=None):
+        captured["hot_files"] = hot_files
+        captured["opt_in"] = opt_in
+        return {"mutation_config_present": False, "cheap_heuristics": {}}
+
+    monkeypatch.setattr(assess_core, "scan_test_pressure", fake_scan)
+    build_run_context(repo_root=repo, run_date="2026-05-29")
+    assert captured["hot_files"] == ["src/hot.py"]
+    assert captured["opt_in"] is False  # read-only by default
+
+
+def test_test_pressure_scan_failure_degrades_not_crashes(tmp_path: Path, monkeypatch) -> None:
+    """A raising test_pressure scan must degrade to an unavailable marker that
+    preserves failure semantics: mutation_config_present is None (not False) so
+    the LLM never reads a failed scan as 'no mutation setup', and the cheap
+    heuristic buckets are present-but-empty so the consumer's shape is stable."""
+    repo = _minimal_repo(tmp_path)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated test_pressure failure")
+
+    monkeypatch.setattr(assess_core, "scan_test_pressure", boom)
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-29")
+    tp = ctx["test_pressure"]
+    assert tp["available"] is False
+    assert "reason" in tp
+    assert tp["mutation_config_present"] is None  # NOT False - "not assessed"
+    assert tp["cheap_heuristics"] == {
+        "assertion_on_internal": [],
+        "untested_boundaries": [],
+        "duplicate_truth": [],
+    }
+    # downstream blocks still present - one failed scan never blocks the run.
+    assert "anomalies" in ctx
+    assert "plugin_version" in ctx

--- a/skills/assess/tests/test_test_pressure.py
+++ b/skills/assess/tests/test_test_pressure.py
@@ -460,3 +460,46 @@ def test_scan_test_pressure_never_raises_on_empty(tmp_path: Path) -> None:
     assert block["mutation_config_present"] is False
     assert block["per_file"] == []
     assert block["survivor_clusters"] == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Thesis integration test - hollow vs honest fixture repos
+#
+# The two fixture repos under tests/fixtures/ carry an IDENTICAL source file
+# (src/processor.py) and differ ONLY in what their test asserts on: the hollow
+# repo pins the private `_last_processed_line` cursor; the honest repo pins the
+# public `process` return value. This is the load-bearing claim of the whole
+# module - a suite can have full line coverage yet pin the implementation, and
+# the assertion-on-internal heuristic is what tells those two apart.
+# ════════════════════════════════════════════════════════════════════════════
+
+def test_thesis_hollow_repo_flags_internal_assertion(fixtures_dir: Path) -> None:
+    """The hollow fixture asserts only on a private field -> flagged."""
+    findings = detect_assertion_on_internal(fixtures_dir / "hollow_test_repo")
+    assert len(findings) == 1
+    assert findings[0]["internal_field"] == "_last_processed_line"
+    assert findings[0]["test_file"] == "tests/test_processor.py"
+    assert findings[0]["confidence"] == "medium"
+
+
+def test_thesis_honest_repo_yields_no_findings(fixtures_dir: Path) -> None:
+    """The honest fixture asserts on the public return value -> not flagged.
+
+    Same source, same coverage as the hollow repo. The only variable is what the
+    test pins, so a finding here would mean the heuristic flags honest tests."""
+    assert detect_assertion_on_internal(fixtures_dir / "honest_test_repo") == []
+
+
+def test_thesis_full_scan_separates_hollow_from_honest(fixtures_dir: Path) -> None:
+    """End-to-end via the public scan_test_pressure entry point: the hollow repo
+    surfaces an assertion_on_internal candidate in its test_pressure block; the
+    honest repo's identical-source block carries none. This is the signal the
+    LLM consumes from run-context.json."""
+    hollow = scan_test_pressure(fixtures_dir / "hollow_test_repo")
+    honest = scan_test_pressure(fixtures_dir / "honest_test_repo")
+    assert hollow["cheap_heuristics"]["assertion_on_internal"]
+    assert honest["cheap_heuristics"]["assertion_on_internal"] == []
+    # The thesis is about test-pinning, not mutation setup: neither fixture
+    # configures mutation testing, so that signal stays identical across both.
+    assert hollow["mutation_config_present"] is False
+    assert honest["mutation_config_present"] is False


### PR DESCRIPTION
## Summary

Wires the `test_pressure` module (merged in #72) into the deterministic core so the write-side truth-pressure signal actually reaches the LLM, and adds the hollow-vs-honest fixtures plus the thesis integration test. Combines task 4 (wiring) and task 7 (fixtures + thesis test) of `assess-write-side-truth-pressure`.

Coverage says a line *ran*; it never says an assertion would *fail* if that line were wrong. This PR makes that distinction observable in `run-context.json`.

## Changes Made

**Task 4 - wiring (`scripts/assess_core.py`):**
- Import `scan_test_pressure` and emit `ctx["test_pressure"]` in `build_run_context()` using the same best-effort `_safe(...)` degrade-don't-block pattern as the liveness scan.
- `opt_in=False` by default - the mutating, code-running bounded mutation pass stays off, so `/assess` remains read-only and fast. The cheap hollow-test heuristics and mutation-config detection still run.
- `hot_files` threaded from `current["top_hotspots"]` so an opt-in mutation run would target the files that matter most.
- Failed/malformed scans degrade to an explicit unavailable marker: `mutation_config_present: None` (not `False`) and present-but-empty `cheap_heuristics` buckets, so the LLM never mis-reads a failed scan as "no mutation setup" (mirrors the failed-liveness → not-rung-0 semantics).

**Task 7 - fixtures + tests:**
- `tests/fixtures/hollow_test_repo/` and `honest_test_repo/` share an identical `src/processor.py`; the only variable is what the test asserts on (private `_last_processed_line` cursor vs public `process` return value).
- Thesis integration tests in `test_test_pressure.py`: hollow yields an `assertion_on_internal` finding, honest yields none, both via the real `scan_test_pressure` / `detect_assertion_on_internal` API.
- Wiring tests in `test_assess_core.py`: block present with required fields, mutation not run by default, hotspots threaded as `hot_files`, graceful degradation on a raising scan.
- `pyproject.toml`: exclude `tests/fixtures` from pytest collection (the fixture `test_*.py` files are scanned as *data* by the heuristics, not run as tests, and import from their own `src/` package).

## Technical Details

The PRD referenced a `build_test_pressure_block(...)` entry point that does not exist; the real public API is `scan_test_pressure(repo_root, hot_files=None, opt_in=False, coverage_data=None)`. The wiring uses the real signature. The failure-path fallback uses the real `cheap_heuristics` key names (`assertion_on_internal` / `untested_boundaries` / `duplicate_truth`) so the consumer's block shape is identical on success and failure - the PRD's `duplicate_truth_fields` was a placeholder name.

## Testing

`cd skills/assess && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q` → **298 passed** (was 291; +7 new).
Coverage: `lib/test_pressure.py` **93%**, `assess_core.py` 92%.

## Risk Assessment

Low. Additive: one new key in `run-context.json`, no behaviour change to existing signals. The scan is best-effort and degrades to an unavailable marker rather than blocking. Mutation testing is opt-in only, so `/assess` stays read-only by default.

## Deployment Notes

No `plugin.json` bump here - the single MINOR bump for this feature line is consolidated in task 8 per the agreed plan.