### PR TITLE
feat(assess): penalize monolithic instruction files, credit skills delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ dist/standalone-skills/
 .claude/
 **/CLAUDE.md
 !/CLAUDE.md
+
+# Test fixtures intentionally named CLAUDE.md / .claude/skills to exercise the
+# instruction-bloat penalty and skills-delegation detection. Re-include them so
+# the grader tests have committed inputs on CI.
+!/skills/assess/tests/fixtures/lean_with_skills/CLAUDE.md
+!/skills/assess/tests/fixtures/lean_with_skills/.claude/

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -274,7 +274,7 @@ Layer 0 answers: *can the agent form a true picture before it acts?* It has two 
 Read the agent instruction file grades and surface integrity from `run-context.json`:
 
 ```bash
-jq '.instruction_files, .instructions_grade, .untracked_instruction_files, .broken_instruction_refs' "$REPO_ROOT/.assess/run-context.json"
+jq '.instruction_files, .instructions_grade, .untracked_instruction_files, .broken_instruction_refs, .skills_present, .skills_count, .skill_files, .instruction_file_size' "$REPO_ROOT/.assess/run-context.json"
 ```
 
 `.instruction_files` is a dict keyed by filename (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`). Only **git-tracked** files are graded - a file present on disk but uncommitted is *not* credited (it isn't part of what the repo ships). The same heuristic grader scores each tracked file. For each:
@@ -282,7 +282,11 @@ jq '.instruction_files, .instructions_grade, .untracked_instruction_files, .brok
 - `subscores.positive_directives` - count of positive directives found
 - `subscores.tradeoff_phrases` - count of reasoning phrases
 - `subscores.path_references` - count of file path references
+- `subscores.line_count` / `subscores.word_count` - file size (feeds the bloat penalty below)
+- `subscores.bloat_penalty` - points subtracted for an oversized monolith with no skills factoring (0 when lean or when the repo delegates to skills)
 - `freshness_days` - days since last edit
+
+`.skills_present` / `.skills_count` / `.skill_files` describe whether the repo factors guidance into on-demand skills (`.claude/skills/`, `skills/`). `.instruction_file_size` mirrors the per-file `line_count` / `word_count` / `bloat_penalty` for quick reference.
 
 `.instructions_grade` is the best grade across all tracked files - the starting point for the layer scoring.
 
@@ -291,6 +295,12 @@ jq '.instruction_files, .instructions_grade, .untracked_instruction_files, .brok
 - A/A-/B+ → **Present**
 - B/C → **Partial**
 - D/F → **Partial** if at least one file exists but scores low - note the grade and recommend rewriting
+
+**Size vs progressive disclosure (deterministic penalty - this LOWERS the grade, not just a flag):**
+- `skills_present: true` and/or the instruction text contains progressive-disclosure pointers → **no penalty**; the repo factors guidance into on-demand skills (loaded when relevant), which is scored positively - a lean pointer file beats a wall of text the agent must hold in full context.
+- `instruction_file_size[path].bloat_penalty > 0` → an oversized monolithic instruction file with no skills factoring. The bloat penalty **LOWERS the grade** (5-15 points by overage: 500/750/1000 lines or 3000/4500/6000 words). **This is a scoring negative, not just a flag** - the file scores **strictly below** an equivalent lean-file-plus-skills repo. Name it in the Evidence column and add the remediation action "factor guidance into `.claude/skills/` for progressive disclosure".
+- A lean instruction file that delegates to maintained skills scores **strictly above** an oversized monolith with equivalent content - the monolith is penalized, not merely annotated.
+- Conservative thresholds (500 lines / 3000 words) ensure small/legitimate instruction files are **never** penalized. This is the write-side mirror of the "modular base docs" principle in 0b: *modular + maintained, never just "more"* - an instruction file earns its grade by being navigable, not by being large.
 
 **Integrity overrides (these can pull the half *below* the grade - a single good file does not rescue a broken instruction surface):**
 - **`broken_instruction_refs` is non-empty → cap the instruction half at Partial, or Missing if it's the *primary* instruction surface that's broken.** These are advertised-but-broken instruction references: a committed `.cursorrules`/`AGENTS.md`/`CLAUDE.md` that is a **dangling symlink** (`reason: symlink target missing`), or an entry doc that **links to a missing instruction file** (`reason: link to missing instruction file`). The truth-pressure model says a broken map scores at or below absent - a repo that *advertises* `.cursorrules` but the symlink dangles is worse than one that never claimed to have it. Name each broken ref and make "fix or remove the broken instruction reference" a Top-3 action. Do **not** let an unrelated file that happens to grade B+ keep the half at Present. **But don't let the score mislead either:** if a committed instruction file still grades passing while the *advertised* surface dangles (e.g. a B+ `.github/copilot-instructions.md` while a referenced `CLAUDE.md` is missing), prefer **Partial** over Missing, and in the Evidence cell name that committed file and its grade. A human reviewer would call this Partial; reserve **Missing** for genuine absence. Either way the report must read as *the advertised surface is broken*, never *no instructions exist*.

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # Make sibling lib package importable when run as a script
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from lib.agent_instructions_grader import grade_instructions
+from lib.agent_instructions_grader import detect_skills_dir, grade_instructions
 from lib.anomaly_detector import detect_anomalies
 from lib.assess_config import load_excludes
 from lib.doc_graph import build_doc_graph, is_repo_file
@@ -95,10 +95,10 @@ def _file_freshness_days(file_path: Path) -> int:
 
 def _grade_instruction_files(
     repo_root: Path,
-) -> tuple[dict[str, dict], str | None, list[str], list[dict]]:
+) -> tuple[dict[str, dict], str | None, list[str], list[dict], dict]:
     """Scan all known instruction file locations and grade each one found.
 
-    Returns: (files_dict, best_grade, untracked, dangling_refs)
+    Returns: (files_dict, best_grade, untracked, dangling_refs, skills_info)
         files_dict: keyed by filename, e.g. {"CLAUDE.md": {grade, score, ...}}.
         best_grade: best letter grade across all *tracked, present* files; None
             if none found. None is distinct from "F": None means no committed
@@ -114,6 +114,11 @@ def _grade_instruction_files(
     """
     repo_root = repo_root.resolve()
     tracked = tracked_files(repo_root)
+    # Detect skills directories once, before grading any file. A repo that
+    # factors guidance into on-demand skills uses progressive disclosure, so a
+    # large instruction file is not penalized as bloat (see compute_bloat_penalty).
+    skills_info = detect_skills_dir(repo_root)
+    skills_present = skills_info["skills_dirs_present"]
     found: dict[str, dict] = {}
     untracked: list[str] = []
     dangling_refs: list[dict] = []
@@ -135,7 +140,9 @@ def _grade_instruction_files(
             continue
         text = candidate.read_text(encoding="utf-8")
         freshness = _file_freshness_days(candidate)
-        grade = grade_instructions(text, freshness_days=freshness)
+        grade = grade_instructions(
+            text, freshness_days=freshness, skills_present=skills_present
+        )
         found[rel_path] = {
             "grade": grade.grade,
             "score": grade.score,
@@ -147,7 +154,7 @@ def _grade_instruction_files(
 
     best = (max(found.values(), key=lambda v: GRADE_RANK.get(v["grade"], 0))["grade"]
             if found else None)
-    return found, best, untracked, dangling_refs
+    return found, best, untracked, dangling_refs, skills_info
 
 
 # Basenames (lowercased) of the known instruction files, for cross-referencing
@@ -340,7 +347,7 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
         )
 
     diff = diff_stats(prior=prior, current=current)
-    instruction_files, instructions_grade, untracked_instr, dangling_instr = \
+    instruction_files, instructions_grade, untracked_instr, dangling_instr, skills_info = \
         _grade_instruction_files(repo_root)
 
     # Load (and later update) the persistent first-flagged date map
@@ -525,6 +532,22 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # well - see the Layer 0 scoring rule in SKILL.md.
     ctx["untracked_instruction_files"] = untracked_instr
     ctx["broken_instruction_refs"] = _broken_instruction_refs(doc_graph, dangling_instr)
+    # Progressive-disclosure signals (Layer 0): does the repo factor guidance
+    # into on-demand skills, and is any instruction file an oversized monolith?
+    # An oversized instruction file with no skills factoring carries a bloat
+    # penalty (instruction_file_size[path].bloat_penalty > 0) that LOWERS its
+    # grade - it scores strictly below an equivalent lean-file-plus-skills repo.
+    ctx["skills_present"] = skills_info["skills_dirs_present"]
+    ctx["skills_count"] = skills_info["skills_count"]
+    ctx["skill_files"] = skills_info["skill_files"]
+    ctx["instruction_file_size"] = {
+        path: {
+            "line_count": meta["subscores"].get("line_count", 0),
+            "word_count": meta["subscores"].get("word_count", 0),
+            "bloat_penalty": meta["subscores"].get("bloat_penalty", 0),
+        }
+        for path, meta in instruction_files.items()
+    }
     # When the scan failed, preserve failure semantics: a failed scan must not be
     # read as "no observability" (rung 0) - that would mis-score Layer 1 Missing
     # when the truth is "not assessed". Carry the reason instead.

--- a/skills/assess/scripts/lib/agent_instructions_grader.py
+++ b/skills/assess/scripts/lib/agent_instructions_grader.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 POSITIVE_DIRECTIVE_PATTERNS = [
@@ -46,6 +47,25 @@ VERIFIABLE_PATTERNS = [
     r"\bverify:\b",
     r"\bsuccess criteria\b",
     r"\bacceptance criteria\b",
+]
+
+# Size/bloat metrics with CONSERVATIVE thresholds.
+# Conservative threshold rationale: small/legitimate instruction files must
+# never be penalized. 500 lines / 3000 words covers the common case of a
+# well-structured CLAUDE.md with sections, examples, and patterns - only
+# genuinely bloated files cross this threshold.
+SIZE_THRESHOLD_LINES = 500
+SIZE_THRESHOLD_WORDS = 3000
+
+# Skills delegation detection - text patterns that indicate progressive
+# disclosure (guidance factored into on-demand skills rather than inlined).
+SKILL_DELEGATION_PATTERNS = [
+    r"\.claude/skills/",
+    r"skills/\w+/SKILL\.md",
+    r"skill\s+\(.*?loaded\s+on\s+demand",
+    r"via\s+the\s+`?\w+-?\w*`?\s+skill",
+    r"load(?:s|ed)?\s+on\s+demand",
+    r"progressive\s+disclosure",
 ]
 
 
@@ -79,6 +99,123 @@ def count_verifiable_outcomes(text: str) -> int:
     return _count(text, VERIFIABLE_PATTERNS)
 
 
+def compute_size_metrics(text: str) -> dict:
+    """Return line_count, word_count, and threshold-exceeded flags."""
+    lines = text.splitlines()
+    words = len(text.split())
+    return {
+        "line_count": len(lines),
+        "word_count": words,
+        "exceeds_line_threshold": len(lines) > SIZE_THRESHOLD_LINES,
+        "exceeds_word_threshold": words > SIZE_THRESHOLD_WORDS,
+    }
+
+
+def detect_skills_delegation(text: str) -> dict:
+    """Detect if an instruction file delegates to skills (progressive-disclosure
+    pointers). Presence means the repo factors guidance into on-demand skills
+    rather than inlining everything into one monolithic file."""
+    matches: list[str] = []
+    for p in SKILL_DELEGATION_PATTERNS:
+        found = re.findall(p, text, re.IGNORECASE)
+        matches.extend(found)
+    return {
+        "delegates_to_skills": len(matches) > 0,
+        "delegation_pointers": len(matches),
+        "delegation_samples": matches[:5],  # first 5 for evidence
+    }
+
+
+def detect_skills_dir(repo_root: Path) -> dict:
+    """Check for the presence of skills directories in the repo.
+
+    Looks for `.claude/skills/` and `skills/` and counts the `*/SKILL.md`
+    files within. A repo with skills is using progressive disclosure, so a
+    large instruction file is not necessarily bloat.
+    """
+    skills_paths = [
+        repo_root / ".claude" / "skills",
+        repo_root / "skills",
+    ]
+    found_dirs: list[str] = []
+    skill_files: list[str] = []
+    for sp in skills_paths:
+        if sp.is_dir():
+            found_dirs.append(str(sp.relative_to(repo_root)))
+            for skill_md in sp.glob("*/SKILL.md"):
+                skill_files.append(str(skill_md.relative_to(repo_root)))
+    return {
+        "skills_dirs_present": len(found_dirs) > 0,
+        "skills_dirs": found_dirs,
+        "skills_count": len(skill_files),
+        "skill_files": skill_files,
+    }
+
+
+def compute_bloat_penalty(
+    size_metrics: dict,
+    skills_present: bool,
+    delegates_to_skills: bool,
+) -> tuple[int, str | None]:
+    """Compute the point penalty for an oversized monolithic instruction file.
+
+    Returns: (penalty_points, remediation_message)
+
+    Asymmetric scoring:
+    - Lean file (not oversized) -> no penalty
+    - Oversized file + skills factoring (dir present or delegation pointers)
+      -> no penalty; the repo uses progressive disclosure
+    - Oversized file + NO skills -> PENALTY scaled by overage
+
+    Penalty scale (conservative - only clear bloat is penalized):
+    - 500-750 lines: -5, 750-1000: -10, 1000+: -15
+    - Word count applies the same tiers at 3000/4500/6000 words
+    - Take the higher penalty of the two metrics
+    """
+    is_oversized = (
+        size_metrics["exceeds_line_threshold"]
+        or size_metrics["exceeds_word_threshold"]
+    )
+
+    if not is_oversized:
+        return 0, None
+
+    if skills_present or delegates_to_skills:
+        # Repo uses progressive disclosure - no penalty even if the
+        # instruction file is large (it may be a hub that points to skills).
+        return 0, None
+
+    lines = size_metrics["line_count"]
+    line_penalty = 0
+    if lines > 1000:
+        line_penalty = 15
+    elif lines > 750:
+        line_penalty = 10
+    elif lines > SIZE_THRESHOLD_LINES:
+        line_penalty = 5
+
+    words = size_metrics["word_count"]
+    word_penalty = 0
+    if words > 6000:
+        word_penalty = 15
+    elif words > 4500:
+        word_penalty = 10
+    elif words > SIZE_THRESHOLD_WORDS:
+        word_penalty = 5
+
+    penalty = max(line_penalty, word_penalty)
+
+    remediation = (
+        f"Instruction file exceeds size threshold ({lines} lines, {words} words) "
+        "without factoring guidance into on-demand skills. Remediation: factor "
+        "guidance into on-demand skills - extract topic-specific guidance into "
+        "`.claude/skills/*/SKILL.md` files loaded when relevant, keeping the root "
+        "instruction file lean."
+    )
+
+    return penalty, remediation
+
+
 def _letter_grade(score: int) -> str:
     if score >= 80:
         return "A"
@@ -95,7 +232,13 @@ def _letter_grade(score: int) -> str:
     return "F"
 
 
-def grade_instructions(text: str, freshness_days: int) -> Grade:
+def grade_instructions(
+    text: str,
+    freshness_days: int,
+    *,
+    skills_present: bool = False,
+    delegates_to_skills: bool | None = None,
+) -> Grade:
     """Score an agent instruction file (CLAUDE.md / AGENTS.md / GEMINI.md / etc.) and return a Grade.
 
     Scoring weights (max 100):
@@ -105,9 +248,26 @@ def grade_instructions(text: str, freshness_days: int) -> Grade:
         verifiable_outcomes:  10 points each, capped at 15
         freshness penalty:    -10 if > 365 days, -5 if > 180, 0 otherwise
                               +10 baseline if file has any content
+        bloat penalty:        -5/-10/-15 for an oversized monolithic file that
+                              does NOT factor guidance into on-demand skills
+
+    Args:
+        skills_present: whether the repo has a skills directory (auto-detected
+            by the caller via ``detect_skills_dir``).
+        delegates_to_skills: whether the text itself contains progressive-
+            disclosure pointers. ``None`` (the default) auto-detects from text.
+
+    The bloat penalty makes an oversized monolith score STRICTLY BELOW an
+    equivalent lean-file-plus-skills repo - the monolith is penalized, not
+    merely annotated. Conservative thresholds (500 lines / 3000 words) ensure
+    small/legitimate instruction files are never penalized.
     """
     if not text.strip():
         return Grade(score=0, grade="F", subscores={})
+
+    # Auto-detect delegation from text when not explicitly provided.
+    if delegates_to_skills is None:
+        delegates_to_skills = detect_skills_delegation(text)["delegates_to_skills"]
 
     sub = {
         "positive_directives": count_positive_directives(text),
@@ -115,6 +275,10 @@ def grade_instructions(text: str, freshness_days: int) -> Grade:
         "path_references": count_path_references(text),
         "verifiable_outcomes": count_verifiable_outcomes(text),
     }
+
+    size_metrics = compute_size_metrics(text)
+    sub["line_count"] = size_metrics["line_count"]
+    sub["word_count"] = size_metrics["word_count"]
 
     score = 10  # baseline for non-empty content
     score += min(sub["positive_directives"] * 3, 30)
@@ -126,6 +290,14 @@ def grade_instructions(text: str, freshness_days: int) -> Grade:
         score -= 10
     elif freshness_days > 180:
         score -= 5
+
+    # Bloat penalty - the core change. Oversized monolithic files with no
+    # skills factoring lose points, scoring strictly below lean-file-plus-skills.
+    bloat_penalty, _bloat_remediation = compute_bloat_penalty(
+        size_metrics, skills_present, delegates_to_skills
+    )
+    score -= bloat_penalty
+    sub["bloat_penalty"] = bloat_penalty
 
     score = max(0, min(score, 100))
     return Grade(score=score, grade=_letter_grade(score), subscores=sub)

--- a/skills/assess/tests/fixtures/lean_with_skills/.claude/skills/go-conventions/SKILL.md
+++ b/skills/assess/tests/fixtures/lean_with_skills/.claude/skills/go-conventions/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: go-conventions
+description: Go conventions for this repo. TRIGGER when editing any *.go file or Connect-Go handlers.
+---
+
+# Go Conventions
+
+Use the Connect-Go Content-Type negotiation defaults. Prefer protobuf JSON
+timestamps over custom formats because the wire contract stays portable.
+
+Default to table-driven tests. Run `go test ./...` before pushing.

--- a/skills/assess/tests/fixtures/lean_with_skills/.claude/skills/java-conventions/SKILL.md
+++ b/skills/assess/tests/fixtures/lean_with_skills/.claude/skills/java-conventions/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: java-conventions
+description: Java conventions for this repo. TRIGGER when editing any *.java file, JUnit tests, or Maven modules.
+---
+
+# Java Conventions
+
+Use Log4j2 for logging. Prefer constructor injection over field injection
+because it makes dependencies explicit and testable.
+
+Default to JUnit5 with AssertJ for assertions. Run `mvn verify` before pushing.

--- a/skills/assess/tests/fixtures/lean_with_skills/CLAUDE.md
+++ b/skills/assess/tests/fixtures/lean_with_skills/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+Lean in-repo contract. Topic-specific guidance is factored into on-demand
+skills so the agent only loads what is relevant - progressive disclosure
+keeps this file short and the context window focused.
+
+## Scope
+
+Repo-specific rules only. Global conventions live in the user's config and
+aren't repeated here.
+
+## Conventions by topic
+
+- Java conventions (logging, dependency injection, testing) load on demand via
+  the `java-conventions` skill.
+- Go conventions (Connect-Go Content-Type, protobuf JSON) load on demand via
+  the `go-conventions` skill.
+
+Each skill lives under `.claude/skills/<name>/SKILL.md` and is loaded when the
+router matches its trigger. Prefer adding a new skill over inlining a wall of
+text here, because a lean pointer file beats a monolith the agent must hold in
+full context.
+
+## Verifiable outcomes
+
+- Working if: `pytest` passes from the repo root.
+- Run the linter in tools/lint.sh before pushing.
+
+## Where things live
+
+- Source: src/app/
+- Tests: tests/

--- a/skills/assess/tests/fixtures/monolithic_instructions.md
+++ b/skills/assess/tests/fixtures/monolithic_instructions.md
@@ -1,0 +1,625 @@
+# Engineering Handbook
+
+This document inlines every convention the team follows. It is the
+single source of truth and must be read in full before contributing.
+
+## Authentication
+
+Use the standard authentication approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/authentication/core.py.
+Run the authentication checks in tests/authentication/ before pushing.
+
+### Authentication - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/authentication_10.yaml for the canonical example and match its structure exactly.
+
+### Authentication - Examples
+
+```
+example_authentication_1() -> applies the rule above
+example_authentication_2() -> applies the rule above
+example_authentication_3() -> applies the rule above
+example_authentication_4() -> applies the rule above
+example_authentication_5() -> applies the rule above
+example_authentication_6() -> applies the rule above
+```
+
+## Database Access
+
+Use the standard database access approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/database_access/core.py.
+Run the database access checks in tests/database_access/ before pushing.
+
+### Database Access - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/database_access_10.yaml for the canonical example and match its structure exactly.
+
+### Database Access - Examples
+
+```
+example_database_access_1() -> applies the rule above
+example_database_access_2() -> applies the rule above
+example_database_access_3() -> applies the rule above
+example_database_access_4() -> applies the rule above
+example_database_access_5() -> applies the rule above
+example_database_access_6() -> applies the rule above
+```
+
+## Caching Strategy
+
+Use the standard caching strategy approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/caching_strategy/core.py.
+Run the caching strategy checks in tests/caching_strategy/ before pushing.
+
+### Caching Strategy - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/caching_strategy_10.yaml for the canonical example and match its structure exactly.
+
+### Caching Strategy - Examples
+
+```
+example_caching_strategy_1() -> applies the rule above
+example_caching_strategy_2() -> applies the rule above
+example_caching_strategy_3() -> applies the rule above
+example_caching_strategy_4() -> applies the rule above
+example_caching_strategy_5() -> applies the rule above
+example_caching_strategy_6() -> applies the rule above
+```
+
+## Error Handling
+
+Use the standard error handling approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/error_handling/core.py.
+Run the error handling checks in tests/error_handling/ before pushing.
+
+### Error Handling - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/error_handling_10.yaml for the canonical example and match its structure exactly.
+
+### Error Handling - Examples
+
+```
+example_error_handling_1() -> applies the rule above
+example_error_handling_2() -> applies the rule above
+example_error_handling_3() -> applies the rule above
+example_error_handling_4() -> applies the rule above
+example_error_handling_5() -> applies the rule above
+example_error_handling_6() -> applies the rule above
+```
+
+## Logging
+
+Use the standard logging approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/logging/core.py.
+Run the logging checks in tests/logging/ before pushing.
+
+### Logging - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/logging_10.yaml for the canonical example and match its structure exactly.
+
+### Logging - Examples
+
+```
+example_logging_1() -> applies the rule above
+example_logging_2() -> applies the rule above
+example_logging_3() -> applies the rule above
+example_logging_4() -> applies the rule above
+example_logging_5() -> applies the rule above
+example_logging_6() -> applies the rule above
+```
+
+## Configuration
+
+Use the standard configuration approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/configuration/core.py.
+Run the configuration checks in tests/configuration/ before pushing.
+
+### Configuration - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/configuration_10.yaml for the canonical example and match its structure exactly.
+
+### Configuration - Examples
+
+```
+example_configuration_1() -> applies the rule above
+example_configuration_2() -> applies the rule above
+example_configuration_3() -> applies the rule above
+example_configuration_4() -> applies the rule above
+example_configuration_5() -> applies the rule above
+example_configuration_6() -> applies the rule above
+```
+
+## Deployment
+
+Use the standard deployment approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/deployment/core.py.
+Run the deployment checks in tests/deployment/ before pushing.
+
+### Deployment - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/deployment_10.yaml for the canonical example and match its structure exactly.
+
+### Deployment - Examples
+
+```
+example_deployment_1() -> applies the rule above
+example_deployment_2() -> applies the rule above
+example_deployment_3() -> applies the rule above
+example_deployment_4() -> applies the rule above
+example_deployment_5() -> applies the rule above
+example_deployment_6() -> applies the rule above
+```
+
+## Testing
+
+Use the standard testing approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/testing/core.py.
+Run the testing checks in tests/testing/ before pushing.
+
+### Testing - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/testing_10.yaml for the canonical example and match its structure exactly.
+
+### Testing - Examples
+
+```
+example_testing_1() -> applies the rule above
+example_testing_2() -> applies the rule above
+example_testing_3() -> applies the rule above
+example_testing_4() -> applies the rule above
+example_testing_5() -> applies the rule above
+example_testing_6() -> applies the rule above
+```
+
+## Code Style
+
+Use the standard code style approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/code_style/core.py.
+Run the code style checks in tests/code_style/ before pushing.
+
+### Code Style - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/code_style_10.yaml for the canonical example and match its structure exactly.
+
+### Code Style - Examples
+
+```
+example_code_style_1() -> applies the rule above
+example_code_style_2() -> applies the rule above
+example_code_style_3() -> applies the rule above
+example_code_style_4() -> applies the rule above
+example_code_style_5() -> applies the rule above
+example_code_style_6() -> applies the rule above
+```
+
+## Dependency Management
+
+Use the standard dependency management approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/dependency_management/core.py.
+Run the dependency management checks in tests/dependency_management/ before pushing.
+
+### Dependency Management - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/dependency_management_10.yaml for the canonical example and match its structure exactly.
+
+### Dependency Management - Examples
+
+```
+example_dependency_management_1() -> applies the rule above
+example_dependency_management_2() -> applies the rule above
+example_dependency_management_3() -> applies the rule above
+example_dependency_management_4() -> applies the rule above
+example_dependency_management_5() -> applies the rule above
+example_dependency_management_6() -> applies the rule above
+```
+
+## API Design
+
+Use the standard api design approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/api_design/core.py.
+Run the api design checks in tests/api_design/ before pushing.
+
+### API Design - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/api_design_10.yaml for the canonical example and match its structure exactly.
+
+### API Design - Examples
+
+```
+example_api_design_1() -> applies the rule above
+example_api_design_2() -> applies the rule above
+example_api_design_3() -> applies the rule above
+example_api_design_4() -> applies the rule above
+example_api_design_5() -> applies the rule above
+example_api_design_6() -> applies the rule above
+```
+
+## Concurrency
+
+Use the standard concurrency approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/concurrency/core.py.
+Run the concurrency checks in tests/concurrency/ before pushing.
+
+### Concurrency - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/concurrency_10.yaml for the canonical example and match its structure exactly.
+
+### Concurrency - Examples
+
+```
+example_concurrency_1() -> applies the rule above
+example_concurrency_2() -> applies the rule above
+example_concurrency_3() -> applies the rule above
+example_concurrency_4() -> applies the rule above
+example_concurrency_5() -> applies the rule above
+example_concurrency_6() -> applies the rule above
+```
+
+## Security
+
+Use the standard security approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/security/core.py.
+Run the security checks in tests/security/ before pushing.
+
+### Security - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/security_10.yaml for the canonical example and match its structure exactly.
+
+### Security - Examples
+
+```
+example_security_1() -> applies the rule above
+example_security_2() -> applies the rule above
+example_security_3() -> applies the rule above
+example_security_4() -> applies the rule above
+example_security_5() -> applies the rule above
+example_security_6() -> applies the rule above
+```
+
+## Performance
+
+Use the standard performance approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/performance/core.py.
+Run the performance checks in tests/performance/ before pushing.
+
+### Performance - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/performance_10.yaml for the canonical example and match its structure exactly.
+
+### Performance - Examples
+
+```
+example_performance_1() -> applies the rule above
+example_performance_2() -> applies the rule above
+example_performance_3() -> applies the rule above
+example_performance_4() -> applies the rule above
+example_performance_5() -> applies the rule above
+example_performance_6() -> applies the rule above
+```
+
+## Migrations
+
+Use the standard migrations approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/migrations/core.py.
+Run the migrations checks in tests/migrations/ before pushing.
+
+### Migrations - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/migrations_10.yaml for the canonical example and match its structure exactly.
+
+### Migrations - Examples
+
+```
+example_migrations_1() -> applies the rule above
+example_migrations_2() -> applies the rule above
+example_migrations_3() -> applies the rule above
+example_migrations_4() -> applies the rule above
+example_migrations_5() -> applies the rule above
+example_migrations_6() -> applies the rule above
+```
+
+## Monitoring
+
+Use the standard monitoring approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/monitoring/core.py.
+Run the monitoring checks in tests/monitoring/ before pushing.
+
+### Monitoring - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/monitoring_10.yaml for the canonical example and match its structure exactly.
+
+### Monitoring - Examples
+
+```
+example_monitoring_1() -> applies the rule above
+example_monitoring_2() -> applies the rule above
+example_monitoring_3() -> applies the rule above
+example_monitoring_4() -> applies the rule above
+example_monitoring_5() -> applies the rule above
+example_monitoring_6() -> applies the rule above
+```
+
+## Build System
+
+Use the standard build system approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/build_system/core.py.
+Run the build system checks in tests/build_system/ before pushing.
+
+### Build System - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/build_system_10.yaml for the canonical example and match its structure exactly.
+
+### Build System - Examples
+
+```
+example_build_system_1() -> applies the rule above
+example_build_system_2() -> applies the rule above
+example_build_system_3() -> applies the rule above
+example_build_system_4() -> applies the rule above
+example_build_system_5() -> applies the rule above
+example_build_system_6() -> applies the rule above
+```
+
+## Release Process
+
+Use the standard release process approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/release_process/core.py.
+Run the release process checks in tests/release_process/ before pushing.
+
+### Release Process - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/release_process_10.yaml for the canonical example and match its structure exactly.
+
+### Release Process - Examples
+
+```
+example_release_process_1() -> applies the rule above
+example_release_process_2() -> applies the rule above
+example_release_process_3() -> applies the rule above
+example_release_process_4() -> applies the rule above
+example_release_process_5() -> applies the rule above
+example_release_process_6() -> applies the rule above
+```
+
+## Documentation
+
+Use the standard documentation approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/documentation/core.py.
+Run the documentation checks in tests/documentation/ before pushing.
+
+### Documentation - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/documentation_10.yaml for the canonical example and match its structure exactly.
+
+### Documentation - Examples
+
+```
+example_documentation_1() -> applies the rule above
+example_documentation_2() -> applies the rule above
+example_documentation_3() -> applies the rule above
+example_documentation_4() -> applies the rule above
+example_documentation_5() -> applies the rule above
+example_documentation_6() -> applies the rule above
+```
+
+## Git Workflow
+
+Use the standard git workflow approach because consistency reduces review friction.
+Prefer explicit configuration over implicit defaults rather than relying on magic.
+Default to the patterns established in src/git_workflow/core.py.
+Run the git workflow checks in tests/git_workflow/ before pushing.
+
+### Git Workflow - Rationale
+
+Rule 1: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_1.yaml for the canonical example and match its structure exactly.
+Rule 2: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_2.yaml for the canonical example and match its structure exactly.
+Rule 3: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_3.yaml for the canonical example and match its structure exactly.
+Rule 4: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_4.yaml for the canonical example and match its structure exactly.
+Rule 5: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_5.yaml for the canonical example and match its structure exactly.
+Rule 6: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_6.yaml for the canonical example and match its structure exactly.
+Rule 7: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_7.yaml for the canonical example and match its structure exactly.
+Rule 8: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_8.yaml for the canonical example and match its structure exactly.
+Rule 9: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_9.yaml for the canonical example and match its structure exactly.
+Rule 10: choose the documented option instead of an ad-hoc one because the team has agreed on a single path. See config/git_workflow_10.yaml for the canonical example and match its structure exactly.
+
+### Git Workflow - Examples
+
+```
+example_git_workflow_1() -> applies the rule above
+example_git_workflow_2() -> applies the rule above
+example_git_workflow_3() -> applies the rule above
+example_git_workflow_4() -> applies the rule above
+example_git_workflow_5() -> applies the rule above
+example_git_workflow_6() -> applies the rule above
+```
+

--- a/skills/assess/tests/test_agent_instructions_grader.py
+++ b/skills/assess/tests/test_agent_instructions_grader.py
@@ -11,10 +11,12 @@ from pathlib import Path
 import pytest
 
 from lib.agent_instructions_grader import (
+    compute_size_metrics,
     count_positive_directives,
     count_tradeoff_phrases,
     count_path_references,
     count_verifiable_outcomes,
+    detect_skills_delegation,
     grade_instructions,
 )
 
@@ -81,3 +83,41 @@ def test_subscores_in_result(good_text: str) -> None:
     assert result.subscores["path_references"] >= 4
     assert "tradeoff_phrases" in result.subscores
     assert "verifiable_outcomes" in result.subscores
+
+
+def test_size_metrics_accurate() -> None:
+    text = "line1\nline2\nline3"
+    m = compute_size_metrics(text)
+    assert m["line_count"] == 3
+    assert m["word_count"] == 3
+    assert m["exceeds_line_threshold"] is False
+    assert m["exceeds_word_threshold"] is False
+
+
+def test_skills_delegation_detection() -> None:
+    text = "Load Java conventions via the `java-conventions` skill."
+    d = detect_skills_delegation(text)
+    assert d["delegates_to_skills"] is True
+    assert d["delegation_pointers"] >= 1
+    assert len(d["delegation_samples"]) >= 1
+
+
+def test_skills_delegation_detection_dir_pointer() -> None:
+    text = "Topic guidance lives under .claude/skills/ and loads on demand."
+    d = detect_skills_delegation(text)
+    assert d["delegates_to_skills"] is True
+
+
+def test_no_skills_delegation_in_generic_text() -> None:
+    text = "Write clean code. Follow best practices."
+    d = detect_skills_delegation(text)
+    assert d["delegates_to_skills"] is False
+    assert d["delegation_pointers"] == 0
+
+
+def test_size_subscores_in_grade(good_text: str) -> None:
+    result = grade_instructions(good_text, freshness_days=10)
+    assert "line_count" in result.subscores
+    assert "word_count" in result.subscores
+    assert "bloat_penalty" in result.subscores
+    assert result.subscores["bloat_penalty"] == 0  # good_instructions is small

--- a/skills/assess/tests/test_instruction_bloat.py
+++ b/skills/assess/tests/test_instruction_bloat.py
@@ -1,0 +1,186 @@
+"""Tests for the instruction-file bloat penalty and skills-delegation credit.
+
+The core thesis (see `test_monolith_scores_strictly_below_lean_plus_skills`):
+an oversized monolithic instruction file that is NOT factored into on-demand
+skills scores STRICTLY BELOW an equivalent lean-file-plus-skills repo. The
+monolith is penalized, not merely annotated. Conservative thresholds ensure
+small/legitimate instruction files are never penalized.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.agent_instructions_grader import (
+    SIZE_THRESHOLD_LINES,
+    SIZE_THRESHOLD_WORDS,
+    compute_bloat_penalty,
+    compute_size_metrics,
+    detect_skills_delegation,
+    detect_skills_dir,
+    grade_instructions,
+)
+
+
+def test_bloat_penalty_on_monolith(fixtures_dir: Path) -> None:
+    """Monolithic 600+ line file without skills gets a bloat penalty."""
+    text = (fixtures_dir / "monolithic_instructions.md").read_text()
+    size = compute_size_metrics(text)
+    assert size["exceeds_line_threshold"] is True
+
+    penalty, msg = compute_bloat_penalty(
+        size, skills_present=False, delegates_to_skills=False
+    )
+    assert penalty >= 5
+    assert msg is not None
+    assert "factor guidance into on-demand skills" in msg
+
+
+def test_no_bloat_penalty_with_skills(fixtures_dir: Path) -> None:
+    """Lean file with skills delegation gets no bloat penalty."""
+    repo = fixtures_dir / "lean_with_skills"
+    text = (repo / "CLAUDE.md").read_text()
+    size = compute_size_metrics(text)
+    skills = detect_skills_dir(repo)
+    delegation = detect_skills_delegation(text)
+
+    penalty, msg = compute_bloat_penalty(
+        size,
+        skills["skills_dirs_present"],
+        delegation["delegates_to_skills"],
+    )
+    assert penalty == 0
+    assert msg is None
+
+
+def test_oversized_but_factored_into_skills_no_penalty(fixtures_dir: Path) -> None:
+    """An oversized hub file is NOT penalized when skills are present - it may
+    be a hub that points to skills (progressive disclosure)."""
+    text = (fixtures_dir / "monolithic_instructions.md").read_text()
+    size = compute_size_metrics(text)
+    assert size["exceeds_line_threshold"] is True
+
+    # skills_present short-circuits the penalty even for an oversized file.
+    penalty, msg = compute_bloat_penalty(
+        size, skills_present=True, delegates_to_skills=False
+    )
+    assert penalty == 0
+    assert msg is None
+
+    # delegation pointers in the text alone also suppress the penalty.
+    penalty2, _ = compute_bloat_penalty(
+        size, skills_present=False, delegates_to_skills=True
+    )
+    assert penalty2 == 0
+
+
+def test_monolith_scores_strictly_below_lean_plus_skills(fixtures_dir: Path) -> None:
+    """REGRESSION TEST (core thesis): equivalent guidance scores STRICTLY LOWER
+    as an unfactored monolith than as a lean-file-plus-skills repo.
+
+    Grading the same guidance two ways isolates the penalty as the sole
+    difference: one repo inlines everything (no skills factoring), the other
+    factors it into on-demand skills. The monolith is penalized, not merely
+    annotated, so its score is strictly lower.
+    """
+    text = (fixtures_dir / "monolithic_instructions.md").read_text()
+
+    monolith_grade = grade_instructions(
+        text, freshness_days=10, skills_present=False, delegates_to_skills=False
+    )
+    factored_grade = grade_instructions(
+        text, freshness_days=10, skills_present=True
+    )
+
+    assert monolith_grade.subscores["bloat_penalty"] >= 5
+    assert factored_grade.subscores["bloat_penalty"] == 0
+    assert monolith_grade.score < factored_grade.score
+
+
+def test_lean_fixture_repo_detects_skills_and_avoids_penalty(fixtures_dir: Path) -> None:
+    """End-to-end on the lean fixture repo: skills dir is detected, delegation
+    pointers are present, and the graded file carries no bloat penalty."""
+    repo = fixtures_dir / "lean_with_skills"
+    text = (repo / "CLAUDE.md").read_text()
+
+    skills = detect_skills_dir(repo)
+    assert skills["skills_dirs_present"] is True
+    assert skills["skills_count"] == 2
+    assert any("java-conventions" in f for f in skills["skill_files"])
+
+    grade = grade_instructions(
+        text, freshness_days=10, skills_present=skills["skills_dirs_present"]
+    )
+    assert grade.subscores["bloat_penalty"] == 0
+
+
+def test_graceful_no_skills_dir(tmp_path: Path) -> None:
+    """Repos without any skills directory degrade gracefully."""
+    skills = detect_skills_dir(tmp_path)
+    assert skills["skills_dirs_present"] is False
+    assert skills["skills_count"] == 0
+    assert skills["skill_files"] == []
+    assert skills["skills_dirs"] == []
+
+
+def test_small_file_no_penalty() -> None:
+    """Small/legitimate instruction files are never penalized."""
+    small_text = "Use bcrypt for password hashing.\n" * 100  # 100 lines
+    size = compute_size_metrics(small_text)
+
+    assert size["exceeds_line_threshold"] is False
+    assert size["exceeds_word_threshold"] is False
+    penalty, msg = compute_bloat_penalty(
+        size, skills_present=False, delegates_to_skills=False
+    )
+    assert penalty == 0
+    assert msg is None
+
+
+def test_threshold_boundary_lines() -> None:
+    """Files at exactly the line threshold are not penalized; one more is."""
+    boundary_text = "Line\n" * SIZE_THRESHOLD_LINES
+    size = compute_size_metrics(boundary_text)
+    assert size["line_count"] == SIZE_THRESHOLD_LINES
+    assert size["exceeds_line_threshold"] is False
+
+    over_text = "Line\n" * (SIZE_THRESHOLD_LINES + 1)
+    over_size = compute_size_metrics(over_text)
+    assert over_size["exceeds_line_threshold"] is True
+    penalty, _ = compute_bloat_penalty(
+        over_size, skills_present=False, delegates_to_skills=False
+    )
+    assert penalty == 5
+
+
+def test_penalty_tiers_by_lines() -> None:
+    """Penalty escalates with overage: -5 / -10 / -15."""
+    def lines_penalty(n: int) -> int:
+        size = compute_size_metrics("x\n" * n)
+        return compute_bloat_penalty(size, False, False)[0]
+
+    assert lines_penalty(600) == 5    # 500-750
+    assert lines_penalty(800) == 10   # 750-1000
+    assert lines_penalty(1200) == 15  # 1000+
+
+
+def test_penalty_tiers_by_words() -> None:
+    """Word-count tiers mirror the line tiers at 3000/4500/6000."""
+    def words_penalty(n: int) -> int:
+        # Few lines, many words: isolates the word-count metric.
+        size = compute_size_metrics(" ".join(["word"] * n))
+        return compute_bloat_penalty(size, False, False)[0]
+
+    assert words_penalty(3500) == 5    # 3000-4500
+    assert words_penalty(5000) == 10   # 4500-6000
+    assert words_penalty(7000) == 15   # 6000+
+
+
+def test_penalty_takes_higher_of_two_metrics() -> None:
+    """When both metrics exceed, the higher penalty wins."""
+    # 600 lines (-5 by lines) but 7000 words (-15 by words) -> expect -15.
+    text = ("word " * 12 + "\n") * 600
+    size = compute_size_metrics(text)
+    assert size["line_count"] > SIZE_THRESHOLD_LINES
+    assert size["word_count"] > 6000
+    penalty, _ = compute_bloat_penalty(size, False, False)
+    assert penalty == 15


### PR DESCRIPTION
## Summary

Extends the deterministic agent-instruction grader so an oversized monolithic instruction file (CLAUDE.md / AGENTS.md / etc.) that is **not** factored into on-demand skills receives a real scoring penalty in `grade_instructions()`. The core thesis: such a monolith scores **strictly below** an equivalent lean-file-plus-skills repo. Skills delegation suppresses the penalty (and the lean form keeps its full grade). Conservative thresholds ensure small/legitimate instruction files are never penalized.

## Changes Made

- **`lib/agent_instructions_grader.py`**: new `compute_size_metrics`, `SKILL_DELEGATION_PATTERNS` + `detect_skills_delegation`, `detect_skills_dir`, `compute_bloat_penalty`. `grade_instructions(text, freshness_days, *, skills_present=False, delegates_to_skills=None)` - `None` auto-detects delegation from the text. Records `line_count`, `word_count`, `bloat_penalty` in subscores.
- **`scripts/assess_core.py`**: detect the skills directory once before the file loop, pass `skills_present` to each grade call. Additive `run-context.json` keys: `skills_present`, `skills_count`, `skill_files`, `instruction_file_size` (per-path line/word/penalty). The `test_pressure` block is untouched.
- **`SKILL.md` Layer 0 (0a)**: documents the size-vs-progressive-disclosure penalty as a grade-lowering rule (not just a flag), extends the jq command with the new fields, and cross-references the modular-base-docs principle in 0b.
- **Fixtures + tests**: `monolithic_instructions.md` (625 lines, no skills refs), `lean_with_skills/` (lean CLAUDE.md + `.claude/skills/*/SKILL.md`), `test_instruction_bloat.py` (regression test + penalty/threshold/tier/graceful-degradation), grader-signal unit tests in `test_agent_instructions_grader.py`.
- **`.gitignore`**: scoped exceptions so the fixture `CLAUDE.md` / `.claude/` (which the repo's broad `**/CLAUDE.md` and `.claude/` rules would otherwise hide) are committed for CI.

## Technical Details

Penalty thresholds: 500 lines / 3000 words. Tiers: 500-750/750-1000/1000+ lines -> -5/-10/-15; words at 3000/4500/6000 mirror this; the higher of the two metrics wins. No penalty when the file is not oversized, or when `skills_present` or text delegation pointers are detected.

Worked example (regression test): the monolithic fixture scores **70 (A-)** as an unfactored monolith vs **85 (A)** when graded as the same content factored into skills - a strict 15-point drop, crossing a letter grade.

## Testing

- `skills/assess`: 328 passed (11 new bloat tests + extended grader signals).
- `scripts`: 69 passed.
- Standalone `assess` ZIP builds clean with no orphan markers.

## Risk Assessment

Low. Grader changes are additive and keyword-only; existing call sites keep their behaviour (penalty defaults off). `run-context.json` gains keys, none removed. No version bump (consolidated in task 8).