### PR TITLE
feat(assess): release write-side truth-pressure (v1.14.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands (Task Master orchestration, autonomous PR/branch fix loops) that may need adaptation outside the author's setup.",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"


### PR DESCRIPTION
## Summary

Final integration PR for the `/assess` write-side truth-pressure feature line ("covered ≠ pinned"). Bumps the plugin to **v1.14.0** (MINOR), which triggers the standalone-skills build/publish workflow. Carries the single consolidated version bump for the whole feature (tasks 1-7, 9 landed dormant/additive across PRs #71-75 per the repo's split-feature-bumps-once-at-integration convention).

## Changes Made

- `.claude-plugin/plugin.json`: `1.13.3` → `1.14.0`

## Technical Details

The feature was delivered across five prior PRs, all merged to `main`:

| PR | Tasks | Contribution |
|----|-------|--------------|
| #71 | 1 | Layer 6 rubric reframed to behaviour-constraint + asymmetry rule (hollow-high-coverage ≤ honest-low-coverage) |
| #72 | 2+3 | `lib/test_pressure.py`: mutation-config detection, bounded mutation runs, cheap hollow-test heuristics |
| #73 | 4+7 | wired `scan_test_pressure` into `assess_core.py`/`run-context.json` + hollow-vs-honest fixtures and thesis tests |
| #74 | 5+6 | survivor-density treemap overlay (SVG pattern, one encoding) + cross-layer Lying Signals report section |
| #75 | 9 | instruction-file bloat penalty + skills-delegation credit (monolith scores strictly below lean+skills) |

## Testing

- `skills/assess`: 328 passed
- `scripts/`: 69 passed
- Standalone ZIP rebuilt (416 KB), validated: no orphan `chat-skip`/`chat-replace` markers, no `SKILL_DIR`/namespaced-command leaks; Lying Signals section and Layer 6 `covered ≠ pinned` framing both present in the built `SKILL.md`.

## Risk Assessment

Low. One-line version bump; all functional changes already merged and CI-green individually. The version bump activates the rolling standalone-skills release.