### PR TITLE
feat(assess): document keyhole-readiness findings and release v1.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -656,6 +656,25 @@ rg -i 'retrospective|retro|feedback loop|learnings|post.?mortem' "$REPO_ROOT"/{C
 - Partial: Some orchestration tooling exists but no systematic feedback loop, or ad-hoc retro notes without structured process
 - Missing: No AI-aware project management
 
+### Cross-layer derived findings (keyhole readiness)
+
+The layers above each measure one axis. The deterministic core also crosses those axes against each other and emits six named findings - the "where to look" signals no single layer surfaces. Read them once, after the per-layer scans:
+
+```bash
+jq '.derived_findings, .attention' "$REPO_ROOT/.assess/run-context.json"
+```
+
+`derived_findings` is a fixed-order list of six `{name, paths, action}` objects - all six always present, `paths` may be empty. Omit a finding from the report when its `paths` is empty. Each pairs an axis-crossing with the action it implies:
+
+- **`hidden_coupling`** - modular statically but bleeds across boundaries historically (files that keep changing together). The static map says "isolated"; git says "coupled." Action: investigate the seam before trusting the boundary.
+- **`lying_map`** - high complexity under a stale doc: the map exists but no longer matches the territory. Action: fix or delete the doc - a wrong map is worse than none.
+- **`unexplained_complexity`** - high complexity with no doc and no recorded intent. Action: write the missing contract. Do **not** auto-generate it - a guessed contract is just another lying map.
+- **`orphaned_understanding`** - high complexity with no human anchor and no intent: nobody owns the knowledge. Action: assign a human anchor before further change.
+- **`candidate_dead_weight`** - high complexity with no runtime evidence it is live. The bias is to **keep** (static reachability can't see external callers - Layer 1's caveat applies). Action: verify liveness, then delete only if confirmed dead.
+- **`refactor_boundary`** (positive) - high containment: edits stay local. A safe zone, never an attention row. Action: safe to hand an agent in isolation; cite these paths in Strengths.
+
+`attention` ranks the few units landing in the most *negative* findings (`refactor_boundary` never counts) - the "look here first" list, each row carrying its `findings` and `score`. Lead the report's findings with the top of this list.
+
 ## Step 3.5: Read Cross-Run Context
 
 Before scoring, check what changed since the last run:


### PR DESCRIPTION
## Summary

The release PR for the keyhole-readiness feature (assess task #6). Tasks #1-#5 wired the deterministic core (`keyhole_signals.py` + five signal modules) so `assess_core.py` now emits a `derived_findings` block in `run-context.json`. This PR makes the feature reachable to the report writer and carries the version bump.

## Changes Made

- **`skills/assess/SKILL.md`** - new "Cross-layer derived findings (keyhole readiness)" subsection at the end of Step 3, documenting how the report reads the six derived findings (`hidden_coupling`, `lying_map`, `unexplained_complexity`, `orphaned_understanding`, `candidate_dead_weight`, `refactor_boundary`) and the companion `attention` list from `run-context.json`, each paired with its implied action.
- **`.claude-plugin/plugin.json`** - version bumped `1.15.0` -> `1.16.0` (MINOR; new feature on an existing skill).

## Technical Details

- The new section is portable prose (references only `$REPO_ROOT`/`jq`/`run-context.json`), so it needs no standalone-ZIP markers - verified against the integration test's forbidden-strings list (no `SKILL_DIR`, `CLAUDE_PLUGIN_ROOT`, `$ARGUMENTS`, namespaced commands, or Claude-Code-only tools).
- Documents the keep-bias on `candidate_dead_weight` (static reachability can't see external callers) and that `refactor_boundary` is a positive/Strengths signal, never an attention row.

## Testing

- `scripts/` pipeline tests: 69 passed (transform + integration, including ZIP forbidden-strings/expected-files validation).
- `skills/assess/` suite: 347 passed.
- Standalone ZIP rebuilt (`assess.zip`, 412 KB); confirmed the new section is present and no markers/plugin-only strings leaked.
- Dogfood: ran `assess_core.py` against this repo; `.assess/run-context.json` `derived_findings` populated with all six findings in fixed order (5 `hidden_coupling` paths, 1 `refactor_boundary`). Generated `.assess/` removed - not committed.

## Risk Assessment

Low. Docs + version bump only; no deterministic-core code changed. The version bump triggers the standalone-skills build workflow, which is expected.

## Deployment Notes

Merging this cuts the v1.16.0 release.