### PR TITLE
docs: showcase before/after /assess SVG comparison in README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -10,17 +10,34 @@ The headline pieces are three **skills**:
 
 ## What `/assess` produces
 
-Two paired views from a single run, on a real ~650k-LOC private monorepo (file paths sanitized). The first asks _can an agent find its way?_ The second asks _what's risky to change?_
+Two paired SVG views from a single run, on a real ~650k-LOC monorepo (file paths sanitized). The first asks _can an agent find its way?_ The second asks _what's risky to change?_
 
-[![Example doc navigability map from a real codebase](docs/example-doc-graph.svg)](docs/example-doc-graph.svg)
+Here is the same repo twice: an already-good AI-native codebase **before**, then the **same repo after** its maintainers worked through the Top 3 Actions from the `/assess` report. The story is that it gets measurably cleaner. Click any image for the full interactive SVG; hover any node or block for its underlying numbers.
 
-> Doc-navigability graph: 254 docs, 622 links, 43 islands, 30% reachable from the entry point. Structure encodes reachability (centre = entry, rings = link-distance from entry, rim = unreachable, dashed ring = orphan); colour encodes staleness (vivid red = a frozen doc beside churning code = a *lying map*); size encodes file length. The rim of orphans, the disconnected islands, the vivid-red hubs all become visible at a glance - this is the docs an agent would consult before changing anything, and whether they're still true. Hover any node for its in/out degree, reachability state, and staleness.
+<table>
+  <tr>
+    <th width="50%">Before</th>
+    <th width="50%">After applying the Top 3 Actions</th>
+  </tr>
+  <tr>
+    <td colspan="2" align="center"><b>Doc-navigability graph</b> - can an agent traverse the docs to the right place, and is what it finds still true?</td>
+  </tr>
+  <tr>
+    <td><a href="docs/example-doc-graph.svg"><img alt="Doc-navigability graph before the action sweep: 254 docs, 30% reachable from the entry point, 43 islands, 15 broken links" title="Before: 30% reachable, 24% orphaned, 43 islands, 15 broken links" src="docs/example-doc-graph.svg"></a></td>
+    <td><a href="docs/example-doc-graph-after.svg"><img alt="Doc-navigability graph after the action sweep: 247 docs, 89% reachable from the entry point, 20 islands, 0 broken links" title="After: 89% reachable, 11% orphaned, 20 islands, 0 broken links" src="docs/example-doc-graph-after.svg"></a></td>
+  </tr>
+  <tr>
+    <td colspan="2" align="center"><b>Complexity hotspot heatmap</b> - which files are riskiest to change next week?</td>
+  </tr>
+  <tr>
+    <td><a href="docs/example-heatmap.svg"><img alt="Complexity hotspot heatmap before the action sweep" title="Before: complexity hotspots, size = LOC, hue = complexity, saturation = churn" src="docs/example-heatmap.svg"></a></td>
+    <td><a href="docs/example-heatmap-after.svg"><img alt="Complexity hotspot heatmap for the same repo after the action sweep" title="After: same repo, complexity hotspots, size = LOC, hue = complexity, saturation = churn" src="docs/example-heatmap-after.svg"></a></td>
+  </tr>
+</table>
 
-[![Example complexity hotspot from the same codebase](docs/example-heatmap.svg)](docs/example-heatmap.svg)
+> **The measurable win.** In the doc-navigability graph, reachability from the entry point climbs from **30% to 89%**, orphaned docs fall from **24% to 11%**, disconnected islands drop from **43 to 20**, and the **15 broken links are gone**. The rim of orphans thins, the islands reconnect, and the lying-map reds cool - the map an agent consults before changing anything becomes honest. The heatmap stays the same repo's complexity profile throughout: it tells you which territory is dangerous, while the graph tells you whether the map is honest.
 
-> Codecov-style complexity heatmap from the same run. Size encodes lines of code, hue encodes cyclomatic complexity (red = high), saturation encodes recent git churn (vivid = active). Vivid red blocks are the migration risk an agent (or human) is most likely to break next week. Hover any block for its LOC, CCN, and recent commit count. Read alongside the graph above: the graph tells you whether the map is honest; the heatmap tells you which territory is dangerous.
-
-Both SVGs are colour-blind-safe (OrRd ramp, no red-green).
+> **How to read them.** *Doc graph* - structure encodes reachability (centre = entry, rings = link-distance from entry, rim = unreachable, dashed ring = orphan); colour encodes staleness (vivid red = a frozen doc beside churning code, a *lying map*); size encodes file length. *Heatmap* - size encodes lines of code, hue encodes cyclomatic complexity (red = high), saturation encodes recent git churn (vivid = active); the vivid-red blocks are the migration risk an agent (or human) is most likely to break next week. Both SVGs are colour-blind-safe (OrRd ramp, no red-green).
 
 ### Why this matters for an AI-driven codebase
 
@@ -308,7 +325,10 @@ ai-native-toolkit/
 │       └── test_integration.py        # Full-build ZIP content validation
 ├── dist/                              # Generated ZIPs (gitignored; published via CI)
 └── docs/
-    └── example-heatmap.svg            # Sanitized real-world /assess output (README hero)
+    ├── example-doc-graph.svg          # Real /assess doc-navigability SVG, before the action sweep (README hero)
+    ├── example-doc-graph-after.svg    # Same repo, doc-navigability after the action sweep
+    ├── example-heatmap.svg            # Real /assess complexity heatmap, before the action sweep (README hero)
+    └── example-heatmap-after.svg      # Same repo, complexity heatmap after the action sweep
 ```
 
 ## Contributors

--- a/docs/example-doc-graph-after.svg
+++ b/docs/example-doc-graph-after.svg
@@ -1,0 +1,1176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 1230" width="1180" height="1230" preserveAspectRatio="xMidYMid meet">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1a1a1a; }
+  circle:hover { stroke: #000; stroke-width: 2; }
+</style>
+<rect x="0" y="0" width="1180" height="1230" fill="#ffffff"/>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9aa0a6"/></marker></defs>
+<line x1="655.9" y1="629.4" x2="554.2" y2="652.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="307.0" y1="911.1" x2="314.7" y2="649.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="307.0" y1="911.1" x2="391.2" y2="697.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="307.0" y1="911.1" x2="764.5" y2="812.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="307.0" y1="911.1" x2="415.6" y2="842.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="480.2" y2="666.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="512.1" y2="510.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="466.2" y2="584.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="596.9" y2="482.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="678.1" y2="518.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="539.4" y1="655.9" x2="620.8" y2="735.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="238.4" y1="827.6" x2="602.7" y2="949.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="703.9" y1="686.9" x2="717.2" y2="763.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="703.9" y1="686.9" x2="461.4" y2="462.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="703.9" y1="686.9" x2="643.6" y2="798.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="574.7" y1="541.7" x2="709.9" y2="589.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="574.7" y1="541.7" x2="535.2" y2="724.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="574.7" y1="541.7" x2="691.8" y2="673.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="614.4" y1="953.1" x2="614.7" y2="830.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="614.4" y1="953.1" x2="569.3" y2="893.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="614.4" y1="953.1" x2="524.6" y2="882.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="700.1" y1="784.3" x2="675.0" y2="796.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="176.2" y1="622.5" x2="309.6" y2="547.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="176.2" y1="622.5" x2="349.1" y2="465.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="572.3" y2="553.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="476.2" y2="679.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="511.0" y2="510.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="462.3" y2="587.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="679.8" y2="520.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="483.4" y2="762.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="457.5" y2="755.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="448.8" y2="740.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="436.9" y2="725.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="421.6" y2="707.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="411.3" y2="688.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="585.1" y2="806.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="398.2" y2="557.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="526.6" y2="789.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="511.5" y2="780.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="496.9" y2="772.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="731.2" y2="479.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="597.6" y2="482.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="659.8" y2="431.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="425.9" y2="496.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="416.6" y2="519.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="393.2" y2="578.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="455.9" y2="465.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="640.8" y2="419.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="491.5" y2="440.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="680.9" y2="438.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="770.0" y2="531.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="472.7" y2="450.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="440.8" y2="482.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="717.2" y2="462.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="544.4" y2="798.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="511.3" y2="431.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="617.9" y2="420.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="531.9" y2="424.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="553.3" y2="417.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="574.8" y2="416.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="597.2" y2="413.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="395.1" y2="645.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="391.2" y2="623.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="393.4" y2="603.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="701.0" y2="447.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="564.1" y2="803.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="746.7" y2="494.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="758.9" y2="513.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="406.5" y2="538.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="533.0" y1="734.7" x2="397.9" y2="665.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="583.3" y2="876.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="679.1" y2="855.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="446.5" y2="831.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="486.1" y2="775.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="541.1" y2="804.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="436.3" y2="728.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="457.7" y2="760.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="421.2" y2="709.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="448.5" y2="745.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="680.1" y1="795.4" x2="339.7" y2="696.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="678.9" y1="870.3" x2="682.6" y2="869.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="678.9" y1="870.3" x2="446.9" y2="750.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="678.9" y1="870.3" x2="664.1" y2="821.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="678.9" y1="870.3" x2="536.2" y2="424.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="678.9" y1="870.3" x2="568.0" y2="880.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="659.1" y1="804.1" x2="665.6" y2="858.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="659.1" y1="804.1" x2="436.0" y2="729.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="659.1" y1="804.1" x2="665.6" y2="801.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="659.1" y1="804.1" x2="541.1" y2="805.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="667.5" y1="873.9" x2="661.2" y2="821.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="667.5" y1="873.9" x2="665.2" y2="874.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="656.1" y1="877.0" x2="699.4" y2="704.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="656.1" y1="877.0" x2="681.1" y2="869.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="614.7" y1="814.5" x2="668.0" y2="860.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="621.0" y1="883.3" x2="651.4" y2="820.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="621.0" y1="883.3" x2="652.0" y2="877.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="609.2" y1="884.3" x2="446.0" y2="838.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="609.2" y1="884.3" x2="651.9" y2="876.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="597.3" y1="884.9" x2="601.7" y2="884.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="597.3" y1="884.9" x2="664.7" y2="872.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="597.3" y1="884.9" x2="651.9" y2="876.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="585.4" y1="885.0" x2="581.2" y2="885.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="585.4" y1="885.0" x2="664.7" y2="872.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="585.4" y1="885.0" x2="651.8" y2="876.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="573.6" y1="884.5" x2="668.1" y2="805.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="573.6" y1="884.5" x2="651.8" y2="875.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="549.9" y1="882.1" x2="581.2" y2="883.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="549.9" y1="882.1" x2="569.3" y2="883.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="549.9" y1="882.1" x2="549.3" y2="882.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="549.9" y1="882.1" x2="555.3" y2="883.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="538.2" y1="880.1" x2="644.0" y2="813.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="538.2" y1="880.1" x2="581.3" y2="883.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="538.2" y1="880.1" x2="569.3" y2="883.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="538.2" y1="880.1" x2="549.3" y2="881.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="538.2" y1="880.1" x2="532.0" y2="879.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="526.6" y1="877.6" x2="666.3" y2="802.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="526.6" y1="877.6" x2="619.9" y2="881.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="515.1" y1="874.6" x2="666.0" y2="802.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="515.1" y1="874.6" x2="600.9" y2="822.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="515.1" y1="874.6" x2="414.7" y2="717.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.8" y1="871.2" x2="665.7" y2="801.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.8" y1="871.2" x2="642.8" y2="811.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.8" y1="871.2" x2="651.7" y2="873.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.8" y1="871.2" x2="600.3" y2="821.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.8" y1="871.2" x2="514.1" y2="874.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="492.6" y1="867.2" x2="569.5" y2="881.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="492.6" y1="867.2" x2="549.5" y2="880.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="492.6" y1="867.2" x2="532.4" y2="877.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="481.5" y1="862.8" x2="665.2" y2="800.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="481.5" y1="862.8" x2="514.2" y2="873.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="481.5" y1="862.8" x2="468.5" y2="795.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="481.5" y1="862.8" x2="710.6" y2="851.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="481.5" y1="862.8" x2="750.0" y2="826.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="470.7" y1="857.9" x2="665.1" y2="799.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="470.7" y1="857.9" x2="581.6" y2="881.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="470.7" y1="857.9" x2="471.1" y2="858.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="460.1" y1="852.5" x2="459.4" y2="852.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="460.1" y1="852.5" x2="774.0" y2="685.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="449.8" y1="846.7" x2="651.8" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="449.8" y1="846.7" x2="428.6" y2="406.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="439.7" y1="840.5" x2="664.7" y2="798.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="439.7" y1="840.5" x2="439.3" y2="840.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="664.6" y2="797.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="596.2" y2="880.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="570.0" y2="879.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="446.6" y2="394.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="466.7" y2="380.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="437.0" y2="398.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="322.7" y2="647.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="400.2" y2="698.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="429.9" y1="833.8" x2="581.9" y2="880.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="420.3" y1="826.7" x2="522.5" y2="873.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="411.1" y1="819.2" x2="489.2" y2="863.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="411.1" y1="819.2" x2="652.0" y2="870.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="411.1" y1="819.2" x2="515.0" y2="871.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="402.2" y1="811.3" x2="472.0" y2="856.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="402.2" y1="811.3" x2="460.2" y2="850.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="393.7" y1="803.0" x2="664.4" y2="795.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="393.7" y1="803.0" x2="620.6" y2="877.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="417.3" y2="822.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="570.7" y2="878.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="786.2" y2="594.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="641.3" y2="803.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="326.4" y2="554.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="385.6" y1="794.4" x2="363.0" y2="470.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="377.8" y1="785.4" x2="398.6" y2="435.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="360.4" y2="749.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="681.7" y2="862.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="664.8" y2="798.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="666.7" y2="862.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="641.6" y2="807.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="654.9" y2="864.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="644.3" y2="865.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="637.0" y2="870.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="623.8" y2="812.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="598.6" y2="815.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="626.0" y2="870.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="615.8" y2="871.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="605.9" y2="871.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="596.1" y2="868.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="587.0" y2="868.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="576.8" y2="872.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="566.8" y2="872.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="559.7" y2="866.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="549.4" y2="866.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="536.1" y2="868.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="524.7" y2="867.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="517.9" y2="862.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="505.3" y2="860.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="492.1" y2="858.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="482.7" y2="853.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="471.4" y2="849.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="461.8" y2="844.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="452.9" y2="838.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="446.6" y2="832.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="431.0" y2="826.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="422.2" y2="819.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="412.3" y2="811.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="405.4" y2="803.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="398.5" y2="795.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="388.9" y2="787.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="381.0" y2="778.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="374.3" y2="768.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="591.9" y1="816.0" x2="368.5" y2="759.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="483.7" y2="783.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="418.2" y2="714.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="488.4" y2="853.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="749.9" y2="824.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="501.2" y2="794.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="524.6" y1="805.4" x2="520.9" y2="803.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.4" y1="797.0" x2="483.1" y2="784.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.4" y1="797.0" x2="417.7" y2="715.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.4" y1="797.0" x2="509.3" y2="799.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="503.4" y1="797.0" x2="500.7" y2="795.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="483.3" y1="786.4" x2="482.5" y2="785.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="483.3" y1="786.4" x2="417.0" y2="715.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="483.3" y1="786.4" x2="481.8" y2="851.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="483.3" y1="786.4" x2="509.7" y2="798.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="483.3" y1="786.4" x2="486.8" y2="788.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="464.4" y1="773.5" x2="664.5" y2="793.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="464.4" y1="773.5" x2="416.4" y2="716.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="464.4" y1="773.5" x2="479.4" y2="851.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="464.4" y1="773.5" x2="641.5" y2="801.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="464.4" y1="773.5" x2="653.3" y2="866.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.1" y1="758.7" x2="415.7" y2="716.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.1" y1="758.7" x2="447.8" y2="759.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.1" y1="758.7" x2="430.1" y2="738.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.1" y1="758.7" x2="664.6" y2="792.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="664.8" y2="792.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="666.1" y2="863.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="553.2" y2="874.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="448.6" y2="758.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="527.6" y2="424.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="538.2" y2="868.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="431.5" y1="742.1" x2="387.7" y2="606.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="417.8" y1="723.8" x2="642.2" y2="798.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="417.8" y1="723.8" x2="449.5" y2="757.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="417.8" y1="723.8" x2="653.9" y2="865.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="417.8" y1="723.8" x2="414.2" y2="717.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="406.2" y1="704.2" x2="665.2" y2="790.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="406.2" y1="704.2" x2="642.6" y2="797.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="406.2" y1="704.2" x2="654.2" y2="865.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="406.2" y1="704.2" x2="622.7" y2="873.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="396.8" y1="683.4" x2="727.5" y2="475.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="396.8" y1="683.4" x2="328.2" y2="642.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="396.8" y1="683.4" x2="426.2" y2="817.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="396.8" y1="683.4" x2="764.9" y2="804.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="465.6" y1="668.7" x2="419.8" y2="696.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="465.6" y1="668.7" x2="709.5" y2="600.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="465.6" y1="668.7" x2="464.6" y2="751.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="465.6" y1="668.7" x2="430.4" y2="709.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="465.6" y1="668.7" x2="412.0" y2="680.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="327.1" y2="648.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="336.0" y2="677.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="330.4" y2="658.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="344.1" y2="705.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="334.6" y2="667.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="338.9" y2="686.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="351.8" y2="724.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="346.8" y2="716.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="389.8" y1="661.7" x2="343.0" y2="694.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="330.7" y1="703.5" x2="605.1" y2="945.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.8" y1="692.2" x2="665.0" y2="791.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.8" y1="692.2" x2="666.0" y2="863.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.8" y1="692.2" x2="817.4" y2="742.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.8" y1="692.2" x2="831.3" y2="711.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="456.2" y2="657.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="498.0" y2="503.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="442.5" y2="574.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="589.9" y2="476.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="674.9" y2="512.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="619.9" y2="736.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="584.4" y2="807.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="751.9" y2="818.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="742.9" y2="825.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="732.8" y2="831.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="723.7" y2="838.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="713.3" y2="843.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="386.5" y1="571.2" x2="702.9" y2="849.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="391.9" y1="549.1" x2="761.2" y2="810.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="391.9" y1="549.1" x2="668.2" y2="785.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="399.7" y1="527.6" x2="646.5" y2="863.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="399.7" y1="527.6" x2="348.3" y2="723.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="399.7" y1="527.6" x2="343.1" y2="714.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.8" y1="507.2" x2="480.7" y2="436.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.8" y1="507.2" x2="605.7" y2="801.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.8" y1="507.2" x2="692.8" y2="851.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.8" y1="507.2" x2="670.3" y2="858.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="323.1" y2="579.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="322.0" y2="601.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="340.3" y2="522.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="349.4" y2="510.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="322.5" y2="590.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="378.4" y2="452.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="330.6" y2="544.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="325.1" y2="567.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="344.2" y2="503.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="356.4" y2="485.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="376.7" y2="462.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="369.6" y2="468.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="360.3" y2="476.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="323.5" y2="610.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="324.1" y2="621.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="327.6" y2="556.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="336.2" y2="532.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="351.6" y2="494.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="384.4" y2="444.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="569.1" y2="872.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="422.1" y1="488.0" x2="691.4" y2="775.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="315.1" y1="634.1" x2="383.6" y2="675.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="315.1" y1="634.1" x2="421.5" y2="819.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="315.1" y1="634.1" x2="765.1" y2="803.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.3" y1="622.3" x2="564.7" y2="875.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.3" y1="622.3" x2="366.7" y2="766.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.0" y1="610.4" x2="255.9" y2="630.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.0" y1="610.4" x2="389.2" y2="792.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.0" y1="610.4" x2="773.6" y2="547.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.0" y1="610.4" x2="688.5" y2="779.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.9" y1="586.6" x2="789.2" y2="777.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.9" y1="586.6" x2="444.1" y2="835.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.9" y1="586.6" x2="340.3" y2="496.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="314.9" y1="586.6" x2="356.1" y2="469.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="320.1" y1="551.4" x2="644.8" y2="793.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="320.1" y1="551.4" x2="655.9" y2="863.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="322.8" y1="539.9" x2="354.7" y2="469.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="322.8" y1="539.9" x2="339.3" y2="496.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="322.8" y1="539.9" x2="922.7" y2="583.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="322.8" y1="539.9" x2="382.4" y2="781.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="587.6" y2="872.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="575.9" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="725.0" y2="750.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="713.2" y2="843.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="742.9" y2="825.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="326.0" y1="528.4" x2="751.9" y2="818.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="566.6" y2="874.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="320.9" y2="551.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="333.7" y2="507.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="369.8" y2="445.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="424.3" y2="726.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="645.7" y2="792.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="603.5" y2="802.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="667.8" y2="785.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="668.7" y2="860.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="656.6" y2="862.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="645.2" y2="865.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="317.0" y2="619.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="316.4" y2="586.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="329.7" y1="517.1" x2="362.8" y2="455.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="338.6" y1="495.1" x2="567.0" y2="873.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="338.6" y1="495.1" x2="362.3" y2="454.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="343.7" y1="484.4" x2="784.3" y2="784.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="343.7" y1="484.4" x2="353.1" y2="468.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="343.7" y1="484.4" x2="347.9" y2="476.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="343.7" y1="484.4" x2="778.3" y2="794.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="349.3" y1="473.9" x2="567.5" y2="873.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="349.3" y1="473.9" x2="338.2" y2="498.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="355.4" y1="463.7" x2="352.5" y2="468.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="355.4" y1="463.7" x2="328.8" y2="525.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="355.4" y1="463.7" x2="650.0" y2="418.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="361.8" y1="453.7" x2="350.2" y2="473.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="361.8" y1="453.7" x2="650.0" y2="418.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="361.8" y1="453.7" x2="426.9" y2="817.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="376.0" y1="434.7" x2="590.2" y2="870.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="470.5" y1="440.0" x2="394.8" y2="427.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="470.5" y1="440.0" x2="401.8" y2="419.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="489.8" y1="427.9" x2="609.7" y2="799.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="489.8" y1="427.9" x2="514.4" y2="862.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="489.8" y1="427.9" x2="695.3" y2="850.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="489.8" y1="427.9" x2="820.9" y2="735.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="400.2" y1="408.6" x2="591.2" y2="870.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="400.2" y1="408.6" x2="579.6" y2="869.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.0" y1="400.6" x2="671.2" y2="782.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.0" y1="400.6" x2="591.5" y2="869.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.0" y1="400.6" x2="579.9" y2="869.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.0" y1="400.6" x2="569.5" y2="872.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="409.0" y1="400.6" x2="558.0" y2="871.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="418.2" y1="393.0" x2="671.5" y2="782.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="418.2" y1="393.0" x2="660.2" y2="859.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="418.2" y1="393.0" x2="420.6" y2="390.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="671.9" y2="782.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="660.5" y2="859.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="592.1" y2="869.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="580.6" y2="869.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="570.0" y2="872.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="558.5" y2="871.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="545.6" y2="864.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="427.6" y1="385.8" x2="449.2" y2="834.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="437.4" y1="379.0" x2="429.0" y2="384.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="437.4" y1="379.0" x2="430.1" y2="817.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="437.4" y1="379.0" x2="580.9" y2="869.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.4" y1="372.7" x2="430.5" y2="817.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.4" y1="372.7" x2="454.0" y2="368.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="447.4" y1="372.7" x2="581.2" y2="869.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="473.1" y2="358.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="322.6" y2="620.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="400.2" y2="668.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="770.8" y2="796.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="431.2" y2="817.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="468.2" y1="361.3" x2="525.2" y2="864.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="479.0" y1="356.3" x2="485.7" y2="353.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="479.0" y1="356.3" x2="431.6" y2="817.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="432.3" y2="817.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="594.5" y2="869.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="582.9" y2="868.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="423.4" y2="394.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="446.0" y2="376.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="501.1" y1="347.7" x2="467.1" y2="363.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="523.9" y1="341.0" x2="549.1" y2="863.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="523.9" y1="341.0" x2="537.8" y2="862.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="535.5" y1="338.4" x2="455.5" y2="371.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="535.5" y1="338.4" x2="467.7" y2="364.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="535.5" y1="338.4" x2="486.5" y2="355.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="547.2" y1="336.3" x2="553.7" y2="335.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="547.2" y1="336.3" x2="542.3" y2="337.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="547.2" y1="336.3" x2="542.4" y2="337.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="547.2" y1="336.3" x2="664.1" y2="858.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="547.2" y1="336.3" x2="573.0" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="582.7" y1="333.1" x2="676.9" y2="780.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="582.7" y1="333.1" x2="573.8" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="582.7" y1="333.1" x2="585.5" y2="333.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="594.6" y1="333.0" x2="677.2" y2="779.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="594.6" y1="333.0" x2="574.1" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="594.6" y1="333.0" x2="425.3" y2="394.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="594.6" y1="333.0" x2="585.5" y2="333.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="606.4" y1="333.5" x2="677.6" y2="779.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="606.4" y1="333.5" x2="574.3" y2="871.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="606.4" y1="333.5" x2="585.5" y2="333.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="630.1" y1="335.9" x2="678.4" y2="779.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="630.1" y1="335.9" x2="598.3" y2="868.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="630.1" y1="335.9" x2="436.1" y2="818.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="630.1" y1="335.9" x2="425.6" y2="395.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="630.1" y1="335.9" x2="468.7" y2="368.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="687.4" y1="350.8" x2="553.9" y2="339.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="687.4" y1="350.8" x2="469.1" y2="370.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="687.4" y1="350.8" x2="437.8" y2="818.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="698.5" y1="355.2" x2="426.1" y2="397.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="698.5" y1="355.2" x2="426.8" y2="403.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="698.5" y1="355.2" x2="659.5" y2="343.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="719.9" y1="365.5" x2="661.5" y2="786.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="719.9" y1="365.5" x2="669.1" y2="858.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="719.9" y1="365.5" x2="680.5" y2="349.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="730.2" y1="371.3" x2="681.9" y2="779.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="730.2" y1="371.3" x2="577.3" y2="872.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="730.2" y1="371.3" x2="619.4" y2="337.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="730.2" y1="371.3" x2="349.1" y2="510.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="740.3" y1="377.5" x2="734.1" y2="373.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="740.3" y1="377.5" x2="469.1" y2="373.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="740.3" y1="377.5" x2="525.7" y2="350.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="740.3" y1="377.5" x2="662.4" y2="786.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="740.3" y1="377.5" x2="456.3" y2="836.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="786.3" y1="415.0" x2="427.2" y2="409.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="786.3" y1="415.0" x2="603.3" y2="869.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="786.3" y1="415.0" x2="591.8" y2="870.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="794.4" y1="423.6" x2="788.8" y2="417.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="794.4" y1="423.6" x2="553.1" y2="344.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="794.4" y1="423.6" x2="780.2" y2="409.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="835.0" y1="481.9" x2="741.0" y2="382.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="835.0" y1="481.9" x2="701.2" y2="363.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="835.0" y1="481.9" x2="759.0" y2="394.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="849.3" y1="514.5" x2="848.9" y2="513.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="853.2" y1="525.8" x2="840.3" y2="494.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="853.2" y1="525.8" x2="834.8" y2="484.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="865.1" y1="631.4" x2="864.9" y2="599.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="865.1" y1="631.4" x2="865.5" y2="607.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="865.1" y1="631.4" x2="691.8" y2="785.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="850.3" y1="700.9" x2="836.0" y2="495.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="850.3" y1="700.9" x2="864.0" y2="607.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="850.3" y1="700.9" x2="860.8" y2="571.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="512.1" y2="358.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="454.7" y2="388.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="426.1" y2="403.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="446.9" y2="393.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="550.5" y2="349.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="487.1" y2="372.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="520.7" y2="359.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="562.2" y2="345.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="465.1" y2="385.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="470.1" y2="378.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="539.6" y2="353.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="427.1" y2="410.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="479.7" y2="376.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="494.4" y2="366.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="638.0" y2="348.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="504.4" y2="372.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="607.0" y2="343.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="574.7" y2="342.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="586.0" y2="341.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="596.2" y2="342.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="670.2" y2="357.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="689.4" y2="365.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="530.0" y2="356.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="846.0" y2="533.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="831.3" y2="500.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="840.4" y2="521.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="838.0" y2="511.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="844.8" y2="543.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="686.5" y2="359.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="714.9" y2="374.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="431.5" y2="396.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="703.8" y2="369.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="723.0" y2="380.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="736.8" y2="386.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="744.1" y2="393.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="753.1" y2="400.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="762.1" y2="407.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="774.3" y2="415.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="779.5" y2="423.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="781.8" y2="431.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="617.1" y2="344.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="626.0" y2="347.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="654.7" y2="356.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="795.5" y2="440.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="802.2" y2="449.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="807.9" y2="459.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="815.9" y2="469.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="821.4" y2="479.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="824.0" y2="488.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="851.4" y2="566.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="851.2" y2="556.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="851.0" y2="577.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="855.1" y2="590.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="855.6" y2="602.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="856.0" y2="614.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="853.1" y2="624.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="852.7" y2="636.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="851.3" y2="647.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="849.2" y2="659.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="846.5" y2="670.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="843.8" y2="681.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="840.3" y2="692.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="649.7" y2="350.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="589.6" y2="804.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="510.3" y1="418.0" x2="392.8" y2="563.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="797.7" y2="768.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="824.2" y2="732.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="837.9" y2="699.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="791.0" y2="778.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="784.0" y2="789.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="817.2" y2="740.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="812.0" y2="751.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="774.8" y2="794.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="829.2" y2="721.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="835.6" y2="713.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="805.8" y2="761.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="593.4" y2="804.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="644.4" y1="409.3" x2="523.7" y2="417.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="836.3" y1="733.6" x2="398.5" y2="792.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="836.3" y1="733.6" x2="804.4" y2="780.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="836.3" y1="733.6" x2="799.1" y2="600.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="836.3" y1="733.6" x2="376.6" y2="462.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="824.7" y1="754.3" x2="823.9" y2="755.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="824.7" y1="754.3" x2="839.4" y2="725.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="824.7" y1="754.3" x2="805.0" y2="780.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="824.7" y1="754.3" x2="448.9" y2="742.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="818.2" y1="764.3" x2="452.8" y2="837.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="804.0" y1="783.3" x2="838.6" y2="724.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="804.0" y1="783.3" x2="823.2" y2="755.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="804.0" y1="783.3" x2="805.7" y2="781.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="804.0" y1="783.3" x2="734.3" y2="612.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="796.3" y1="792.4" x2="680.9" y2="865.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="788.2" y1="801.1" x2="354.0" y2="491.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="788.2" y1="801.1" x2="375.1" y2="464.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="788.2" y1="801.1" x2="786.4" y2="803.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="779.8" y1="809.4" x2="329.4" y2="639.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="779.8" y1="809.4" x2="411.5" y2="688.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="779.8" y1="809.4" x2="786.2" y2="802.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="779.8" y1="809.4" x2="446.6" y2="832.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="686.5" y1="510.4" x2="477.6" y2="660.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="741.0" y1="467.4" x2="409.9" y2="675.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="778.8" y1="524.1" x2="661.4" y2="861.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="245.9" y1="633.4" x2="302.5" y2="614.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="245.9" y1="633.4" x2="773.6" y2="547.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="771.0" y1="817.4" x2="695.4" y2="799.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="771.0" y1="817.4" x2="681.4" y2="866.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="873.0" y1="306.9" x2="661.8" y2="861.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="873.0" y1="306.9" x2="348.8" y2="718.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="873.0" y1="306.9" x2="711.3" y2="670.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="622.1" y2="800.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="776.6" y2="554.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="735.1" y2="743.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="785.0" y2="590.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="785.9" y2="610.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="761.0" y2="709.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="782.5" y2="649.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="770.0" y2="688.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="777.8" y2="669.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="749.2" y2="727.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="785.7" y2="629.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="782.0" y2="572.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="701.9" y2="771.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="683.7" y2="780.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="727.3" y1="595.5" x2="664.6" y2="787.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="787.0" y1="545.4" x2="479.4" y2="663.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="787.0" y1="545.4" x2="403.5" y2="796.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="787.0" y1="545.4" x2="523.1" y2="499.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="787.0" y1="545.4" x2="697.7" y2="514.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="787.0" y1="545.4" x2="741.5" y2="583.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="469.1" y2="654.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="460.9" y2="561.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="613.3" y2="798.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="516.1" y2="862.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="698.1" y2="849.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="565.6" y1="264.9" x2="512.8" y2="483.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="792.8" y1="567.4" x2="479.7" y2="664.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="792.8" y1="567.4" x2="411.7" y2="679.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="761.8" y1="825.0" x2="478.7" y2="675.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="761.8" y1="825.0" x2="492.9" y2="861.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="761.8" y1="825.0" x2="381.1" y2="777.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="761.8" y1="825.0" x2="421.2" y2="709.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="796.1" y1="590.0" x2="480.0" y2="665.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="796.1" y1="590.0" x2="435.9" y2="717.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="752.4" y1="832.2" x2="478.4" y2="676.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="752.4" y1="832.2" x2="492.9" y2="861.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="752.4" y1="832.2" x2="381.1" y2="777.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="752.4" y1="832.2" x2="421.1" y2="709.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="797.0" y1="612.8" x2="480.2" y2="666.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="797.0" y1="612.8" x2="522.3" y2="501.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="797.0" y1="612.8" x2="470.0" y2="576.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="797.0" y1="612.8" x2="695.2" y2="518.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="797.0" y1="612.8" x2="745.3" y2="599.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="795.3" y1="635.5" x2="480.3" y2="667.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="795.3" y1="635.5" x2="521.9" y2="502.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="791.1" y1="657.9" x2="480.4" y2="668.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="784.5" y1="679.8" x2="480.4" y2="669.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="784.5" y1="679.8" x2="491.3" y2="856.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="784.5" y1="679.8" x2="380.9" y2="773.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="784.5" y1="679.8" x2="422.0" y2="703.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="993.2" y1="703.1" x2="480.4" y2="669.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="775.6" y1="700.7" x2="480.3" y2="670.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="775.6" y1="700.7" x2="520.4" y2="505.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="775.6" y1="700.7" x2="691.5" y2="521.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="775.6" y1="700.7" x2="791.3" y2="579.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="775.6" y1="700.7" x2="735.0" y2="612.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="764.4" y1="720.6" x2="480.2" y2="671.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="764.4" y1="720.6" x2="519.9" y2="505.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="764.4" y1="720.6" x2="690.6" y2="521.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="764.4" y1="720.6" x2="732.6" y2="613.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="742.6" y1="839.0" x2="478.2" y2="676.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="732.6" y1="845.3" x2="466.2" y2="584.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="732.6" y1="845.3" x2="517.0" y2="508.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="722.3" y1="851.2" x2="477.7" y2="677.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="722.3" y1="851.2" x2="493.0" y2="862.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="722.3" y1="851.2" x2="485.3" y2="779.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="722.3" y1="851.2" x2="420.6" y2="710.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="751.0" y1="739.1" x2="480.0" y2="672.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="751.0" y1="739.1" x2="486.1" y2="770.9" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="751.0" y1="739.1" x2="519.2" y2="506.5" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="735.7" y1="756.0" x2="479.7" y2="673.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="711.8" y1="856.7" x2="477.4" y2="677.7" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="603.5" y1="1022.8" x2="598.0" y2="901.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="701.0" y1="861.7" x2="628.9" y2="822.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="701.0" y1="861.7" x2="568.1" y2="276.0" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="701.0" y1="861.7" x2="527.1" y2="873.8" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="701.0" y1="861.7" x2="495.3" y2="439.3" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="701.0" y1="861.7" x2="418.8" y2="518.2" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="346.2" y1="1025.9" x2="176.0" y2="376.4" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="1006.9" y1="852.8" x2="695.6" y2="798.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="1006.9" y1="852.8" x2="527.2" y2="874.1" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<line x1="1006.9" y1="852.8" x2="477.3" y2="221.6" stroke="#9aa0a6" stroke-width="1.2" opacity="0.6" marker-end="url(#arrow)"/>
+<circle cx="495.9" cy="1012.2" r="7.3" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>.githooks/README.md
+108 lines · in 0 · out 0 · orphan · 0d stale, subject churn 2</title></circle>
+<circle cx="394.8" cy="974.1" r="13.1" fill="#fff7ec" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>.github/claude-review-instructions.md
+800 lines · in 0 · out 0 · orphan · 0d stale, subject churn 8647</title></circle>
+<circle cx="655.9" cy="629.4" r="5.0" fill="#fff7ec" stroke="#0072B2" stroke-width="3.5"><title>AGENTS.md
+10 lines · in 0 · out 1 · entry · 0d stale, subject churn 8647</title></circle>
+<circle cx="307.0" cy="911.1" r="7.8" fill="#f26e4b" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>CHANGELOG.md
+141 lines · in 0 · out 4 · orphan · 114d stale, subject churn 8647</title></circle>
+<circle cx="718.7" cy="771.1" r="5.2" fill="#f67a51" stroke="#b8b8b8" stroke-width="1.0"><title>CLA.md
+15 lines · in 1 · out 0 · reachable · 106d stale, subject churn 8647</title></circle>
+<circle cx="539.4" cy="655.9" r="12.2" fill="#fff7ec" stroke="#0072B2" stroke-width="3.5"><title>CLAUDE.md
+648 lines · in 1 · out 6 · entry · 0d stale, subject churn 8647</title></circle>
+<circle cx="238.4" cy="827.6" r="6.9" fill="#800000" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>CODE_OF_CONDUCT.md
+81 lines · in 0 · out 1 · orphan · 190d stale, subject churn 8647</title></circle>
+<circle cx="703.9" cy="686.9" r="15.3" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>CONTRIBUTING.md
+1225 lines · in 3 · out 3 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="574.7" cy="541.7" r="8.6" fill="#d3d3d7" stroke="#0072B2" stroke-width="3.5"><title>README.md
+204 lines · in 1 · out 3 · entry · 0d stale, subject churn 525</title></circle>
+<circle cx="614.4" cy="953.1" r="9.4" fill="#f2704c" stroke="#b8b8b8" stroke-width="1.0"><title>SECURITY.md
+280 lines · in 2 · out 3 · reachable · 112d stale, subject churn 8647</title></circle>
+<circle cx="700.1" cy="784.3" r="9.6" fill="#d0cdd2" stroke="#b8b8b8" stroke-width="1.0"><title>api/proto/README.md
+307 lines · in 3 · out 1 · reachable · 168d stale, subject churn 157</title></circle>
+<circle cx="627.2" cy="741.9" r="6.0" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>cookbook/README.md
+37 lines · in 2 · out 0 · reachable · 18d stale, subject churn 14</title></circle>
+<circle cx="193.8" cy="729.1" r="9.5" fill="#fca16c" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>cookbook/docs/authoring-components.md
+288 lines · in 0 · out 0 · orphan · 85d stale, subject churn 8647</title></circle>
+<circle cx="176.2" cy="622.5" r="11.2" fill="#fcae78" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>cookbook/docs/authoring-patterns.md
+495 lines · in 0 · out 2 · orphan · 78d stale, subject churn 8647</title></circle>
+<circle cx="186.8" cy="514.9" r="9.5" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>deploy/demo/README.md
+290 lines · in 0 · out 0 · orphan · 73d stale, subject churn 10</title></circle>
+<circle cx="224.9" cy="413.8" r="9.6" fill="#fc905c" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>deploy/demo/cloudflare-setup-checklist.md
+300 lines · in 0 · out 0 · orphan · 94d stale, subject churn 8647</title></circle>
+<circle cx="287.9" cy="326.0" r="7.2" fill="#fca973" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>deploy/demo/dex-identity-migration-plan.md
+97 lines · in 0 · out 0 · orphan · 81d stale, subject churn 8647</title></circle>
+<circle cx="371.4" cy="257.4" r="9.5" fill="#fc935f" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>deploy/demo/pg-migration-compatibility-report.md
+290 lines · in 0 · out 0 · orphan · 92d stale, subject churn 8647</title></circle>
+<circle cx="469.9" cy="212.8" r="8.5" fill="#c1130c" stroke="#b8b8b8" stroke-width="1.0"><title>deployments/k8s/audit-consumer/README.md
+197 lines · in 1 · out 0 · island · 157d stale, subject churn 8647</title></circle>
+<circle cx="576.5" cy="195.2" r="8.2" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>deployments/k8s/policies/tests/README.md
+174 lines · in 0 · out 0 · orphan · 149d stale, subject churn 1</title></circle>
+<circle cx="533.0" cy="734.7" r="7.1" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/README.md
+93 lines · in 1 · out 46 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="690.0" cy="866.2" r="6.4" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0001-record-architecture-decisions.md
+54 lines · in 2 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="680.1" cy="795.4" r="12.7" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0002-microservices-per-bian-domain.md
+731 lines · in 30 · out 10 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="678.9" cy="870.3" r="11.4" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0003-database-schema-migrations.md
+525 lines · in 10 · out 5 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="659.1" cy="804.1" r="14.7" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0004-event-schema-evolution.md
+1115 lines · in 16 · out 4 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="667.5" cy="873.9" r="12.8" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0005-adapter-pattern-layer-translation.md
+757 lines · in 22 · out 2 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="656.1" cy="877.0" r="13.2" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0006-tilt-local-development.md
+812 lines · in 5 · out 2 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="644.5" cy="879.6" r="8.7" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0007-raw-yaml-over-helm-for-initial-development.md
+216 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="637.2" cy="810.6" r="10.4" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0008-defensive-testing-standards.md
+402 lines · in 2 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="614.7" cy="814.5" r="13.2" fill="#c2150d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0009-application-level-audit-logging.md
+813 lines · in 10 · out 1 · reachable · 156d stale, subject churn 8647</title></circle>
+<circle cx="632.8" cy="881.7" r="9.9" fill="#bc0c07" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0010-grpc-client-side-load-balancing.md
+331 lines · in 4 · out 0 · reachable · 161d stale, subject churn 8647</title></circle>
+<circle cx="621.0" cy="883.3" r="10.2" fill="#fca36d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0011-iso-20022-compliance-via-adapter-layer.md
+368 lines · in 1 · out 2 · reachable · 84d stale, subject churn 8647</title></circle>
+<circle cx="609.2" cy="884.3" r="10.5" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0012-lien-based-fund-reservation.md
+411 lines · in 2 · out 2 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="597.3" cy="884.9" r="13.1" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0013-generic-asset-quantity-types.md
+804 lines · in 15 · out 3 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="585.4" cy="885.0" r="13.2" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0014-financial-instrument-reference-data.md
+821 lines · in 15 · out 3 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="573.6" cy="884.5" r="9.6" fill="#d02719" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0015-standard-service-directory-structure.md
+306 lines · in 14 · out 2 · reachable · 147d stale, subject churn 8647</title></circle>
+<circle cx="561.7" cy="883.5" r="9.5" fill="#b40101" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0016-tenant-id-naming-strategy.md
+295 lines · in 8 · out 0 · reachable · 166d stale, subject churn 8647</title></circle>
+<circle cx="549.9" cy="882.1" r="15.2" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0017-temporal-quality-ladder.md
+1203 lines · in 7 · out 4 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="538.2" cy="880.1" r="14.3" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0018-settlement-reconciliation.md
+1027 lines · in 4 · out 5 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="526.6" cy="877.6" r="10.1" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0019-resilient-client-patterns.md
+355 lines · in 5 · out 2 · reachable · 163d stale, subject churn 10</title></circle>
+<circle cx="515.1" cy="874.6" r="9.0" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0020-per-service-audit-workers.md
+246 lines · in 6 · out 3 · reachable · 0d stale, subject churn 6</title></circle>
+<circle cx="503.8" cy="871.2" r="13.7" fill="#cf2518" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0021-kyc-aml-verification-provider-architecture.md
+906 lines · in 2 · out 5 · reachable · 148d stale, subject churn 8647</title></circle>
+<circle cx="492.6" cy="867.2" r="11.3" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0022-instrument-successor-lineage.md
+520 lines · in 1 · out 3 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="481.5" cy="862.8" r="8.4" fill="#da3724" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0023-balance-delegation-to-position-keeping.md
+190 lines · in 10 · out 5 · reachable · 140d stale, subject churn 8647</title></circle>
+<circle cx="470.7" cy="857.9" r="9.7" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0024-internal-bank-account-service.md
+315 lines · in 3 · out 3 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="460.1" cy="852.5" r="8.7" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0025-clearing-purpose-specialization.md
+212 lines · in 1 · out 2 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="449.8" cy="846.7" r="9.3" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0026-canonical-ingestion-contract.md
+275 lines · in 5 · out 2 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="439.7" cy="840.5" r="10.4" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0027-market-information-management.md
+401 lines · in 2 · out 2 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="429.9" cy="833.8" r="13.8" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0028-starlark-saga-cel-valuation.md
+932 lines · in 16 · out 9 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="420.3" cy="826.7" r="7.7" fill="#f57850" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0029-settlement-scheduler-architecture.md
+129 lines · in 1 · out 1 · reachable · 108d stale, subject churn 8647</title></circle>
+<circle cx="411.1" cy="819.2" r="8.1" fill="#f67d52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0030-kyc-aml-provider-selection.md
+162 lines · in 1 · out 3 · reachable · 105d stale, subject churn 8647</title></circle>
+<circle cx="402.2" cy="811.3" r="7.1" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0031-getbalance-nil-guard-retention.md
+91 lines · in 1 · out 2 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="393.7" cy="803.0" r="8.7" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0032-vanguard-json-transcoding-gateway.md
+217 lines · in 3 · out 2 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="385.6" cy="794.4" r="10.1" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0033-event-triggered-sagas.md
+355 lines · in 3 · out 6 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="377.8" cy="785.4" r="8.2" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0034-position-compaction-strategy.md
+174 lines · in 1 · out 1 · reachable · 84d stale, subject churn 7</title></circle>
+<circle cx="370.4" cy="776.1" r="7.8" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0035-multi-asset-purity.md
+140 lines · in 5 · out 0 · reachable · 83d stale, subject churn 2</title></circle>
+<circle cx="363.4" cy="766.5" r="8.2" fill="#fcb37c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0036-embedded-dex-identity.md
+171 lines · in 1 · out 0 · reachable · 76d stale, subject churn 8647</title></circle>
+<circle cx="356.8" cy="756.6" r="9.1" fill="#fdcf99" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/0037-scheduler-attribution-design.md
+250 lines · in 1 · out 0 · reachable · 52d stale, subject churn 8647</title></circle>
+<circle cx="591.9" cy="816.0" r="8.7" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/README.md
+211 lines · in 4 · out 38 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="350.7" cy="746.5" r="7.1" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/adr/template.md
+92 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="569.2" cy="814.9" r="9.3" fill="#fcba83" stroke="#b8b8b8" stroke-width="1.0"><title>docs/analysis/cmd-coverage-assessment.md
+267 lines · in 1 · out 0 · reachable · 72d stale, subject churn 8647</title></circle>
+<circle cx="546.6" cy="811.4" r="9.7" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/api/saga-validation.md
+314 lines · in 1 · out 0 · reachable · 60d stale, subject churn 104</title></circle>
+<circle cx="524.6" cy="805.4" r="13.5" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/api-contracts/current-account-contract.md
+864 lines · in 5 · out 6 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="503.4" cy="797.0" r="15.8" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/api-contracts/financial-accounting-contract.md
+1341 lines · in 3 · out 4 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="483.3" cy="786.4" r="16.7" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/api-contracts/position-keeping-contract.md
+1563 lines · in 3 · out 5 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="464.4" cy="773.5" r="18.8" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/bian-service-boundaries.md
+2132 lines · in 12 · out 5 · reachable · 89d stale, subject churn 44</title></circle>
+<circle cx="447.1" cy="758.7" r="7.8" fill="#d0d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/boundary-migration-plan.md
+139 lines · in 2 · out 4 · reachable · 164d stale, subject churn 44</title></circle>
+<circle cx="431.5" cy="742.1" r="14.4" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/data-model.md
+1048 lines · in 5 · out 7 · reachable · 0d stale, subject churn 44</title></circle>
+<circle cx="417.8" cy="723.8" r="16.2" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/event-driven-architecture.md
+1444 lines · in 6 · out 4 · reachable · 89d stale, subject churn 44</title></circle>
+<circle cx="406.2" cy="704.2" r="12.8" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/service-coupling-analysis.md
+757 lines · in 14 · out 4 · reachable · 147d stale, subject churn 44</title></circle>
+<circle cx="396.8" cy="683.4" r="12.5" fill="#d1d1d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture/starlark-saga-architecture.md
+695 lines · in 9 · out 4 · reachable · 59d stale, subject churn 44</title></circle>
+<circle cx="465.6" cy="668.7" r="11.8" fill="#feebd0" stroke="#b8b8b8" stroke-width="1.0"><title>docs/architecture-layers.md
+592 lines · in 22 · out 5 · reachable · 18d stale, subject churn 8647</title></circle>
+<circle cx="345.0" cy="736.1" r="10.2" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/ARCHITECTURE.md
+371 lines · in 2 · out 0 · reachable · 85d stale, subject churn 44</title></circle>
+<circle cx="339.7" cy="725.4" r="8.5" fill="#fca16c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/DEMO_GUIDE.md
+195 lines · in 3 · out 0 · reachable · 85d stale, subject churn 8647</title></circle>
+<circle cx="389.8" cy="661.7" r="6.0" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/README.md
+40 lines · in 1 · out 9 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="335.0" cy="714.5" r="9.7" fill="#fca16c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/audit-analysis-findings.md
+315 lines · in 1 · out 0 · reachable · 85d stale, subject churn 8647</title></circle>
+<circle cx="330.7" cy="703.5" r="12.1" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/authentication-integration.md
+636 lines · in 1 · out 1 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="326.8" cy="692.2" r="10.4" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/database-per-service-migration.md
+395 lines · in 2 · out 4 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="323.5" cy="680.8" r="10.0" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/immutability-audit.md
+352 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="320.7" cy="669.3" r="11.1" fill="#fca16c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/panic-audit-inventory.md
+481 lines · in 1 · out 0 · reachable · 85d stale, subject churn 8647</title></circle>
+<circle cx="318.3" cy="657.6" r="9.1" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/rbac-testing-guide.md
+254 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="316.5" cy="645.9" r="7.9" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/archive/task-8-service-integration.md
+147 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="385.2" cy="639.4" r="8.8" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/audit/frontend-backend-gaps.md
+222 lines · in 1 · out 0 · reachable · 92d stale, subject churn 55</title></circle>
+<circle cx="383.1" cy="616.7" r="7.2" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>docs/audit/multi-asset-purity.md
+101 lines · in 1 · out 0 · reachable · 84d stale, subject churn 55</title></circle>
+<circle cx="383.6" cy="593.8" r="10.5" fill="#fdcc96" stroke="#b8b8b8" stroke-width="1.0"><title>docs/audits/tenant-isolation-audit-2026-04-04.md
+405 lines · in 2 · out 0 · reachable · 55d stale, subject churn 8647</title></circle>
+<circle cx="386.5" cy="571.2" r="7.1" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/claude-code-skills.md
+92 lines · in 2 · out 13 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="391.9" cy="549.1" r="7.5" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/coupling-visualization-example.md
+116 lines · in 1 · out 2 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="456.3" cy="574.7" r="10.8" fill="#feebd0" stroke="#b8b8b8" stroke-width="1.0"><title>docs/data-flows.md
+448 lines · in 6 · out 0 · reachable · 18d stale, subject churn 8647</title></circle>
+<circle cx="399.7" cy="527.6" r="9.7" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/demos/multi-organization-settlement.md
+313 lines · in 1 · out 3 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="409.8" cy="507.2" r="11.2" fill="#c5180f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/development/audit-adding-new-service.md
+508 lines · in 2 · out 4 · reachable · 155d stale, subject churn 8647</title></circle>
+<circle cx="422.1" cy="488.0" r="6.5" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/README.md
+59 lines · in 1 · out 21 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="315.1" cy="634.1" r="12.2" fill="#f26e4b" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/adding-starlark-service-bindings.md
+653 lines · in 7 · out 3 · reachable · 114d stale, subject churn 8647</title></circle>
+<circle cx="314.3" cy="622.3" r="11.6" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/ai-native-codebase-architecture.md
+559 lines · in 1 · out 2 · reachable · 70d stale, subject churn 4</title></circle>
+<circle cx="314.0" cy="610.4" r="9.1" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/calling-meridian-apis.md
+256 lines · in 2 · out 4 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="314.2" cy="598.5" r="8.9" fill="#d02719" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/circuit-breaker-usage.md
+230 lines · in 2 · out 0 · reachable · 147d stale, subject churn 8647</title></circle>
+<circle cx="314.9" cy="586.6" r="8.2" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/cli-tools.md
+171 lines · in 1 · out 4 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="316.1" cy="574.8" r="8.6" fill="#a70000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/coupling-analysis.md
+201 lines · in 1 · out 0 · reachable · 172d stale, subject churn 8647</title></circle>
+<circle cx="317.8" cy="563.1" r="9.0" fill="#fdbb84" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/error-conventions.md
+245 lines · in 2 · out 0 · reachable · 71d stale, subject churn 8647</title></circle>
+<circle cx="320.1" cy="551.4" r="9.4" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/financial-accounting-proto.md
+285 lines · in 1 · out 2 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="322.8" cy="539.9" r="12.1" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/manifest-design-patterns.md
+641 lines · in 4 · out 4 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="326.0" cy="528.4" r="12.5" fill="#d52d1d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/multi-asset-integration.md
+696 lines · in 1 · out 6 · reachable · 144d stale, subject churn 8647</title></circle>
+<circle cx="329.7" cy="517.1" r="17.6" fill="#fdd09a" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/new-bian-service-checklist.md
+1790 lines · in 3 · out 14 · reachable · 51d stale, subject churn 8647</title></circle>
+<circle cx="333.9" cy="506.0" r="7.5" fill="#fdbb84" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/proto-conventions.md
+117 lines · in 1 · out 0 · reachable · 71d stale, subject churn 8647</title></circle>
+<circle cx="338.6" cy="495.1" r="10.1" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/repository-conventions.md
+359 lines · in 2 · out 2 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="343.7" cy="484.4" r="9.7" fill="#f3734e" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/saga-validation.md
+309 lines · in 5 · out 4 · reachable · 111d stale, subject churn 8647</title></circle>
+<circle cx="349.3" cy="473.9" r="8.1" fill="#fdbb84" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/service-file-conventions.md
+166 lines · in 1 · out 2 · reachable · 71d stale, subject churn 8647</title></circle>
+<circle cx="355.4" cy="463.7" r="12.1" fill="#fca16c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/starlark-built-ins-reference.md
+642 lines · in 2 · out 3 · reachable · 85d stale, subject churn 8647</title></circle>
+<circle cx="361.8" cy="453.7" r="14.2" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/starlark-style-guide.md
+999 lines · in 9 · out 3 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="368.7" cy="444.1" r="9.5" fill="#fca36d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/testcontainers-usage.md
+297 lines · in 3 · out 0 · reachable · 84d stale, subject churn 8647</title></circle>
+<circle cx="376.0" cy="434.7" r="9.8" fill="#fdbb84" stroke="#b8b8b8" stroke-width="1.0"><title>docs/guides/value-types.md
+321 lines · in 2 · out 1 · reachable · 71d stale, subject churn 8647</title></circle>
+<circle cx="436.4" cy="470.2" r="9.7" fill="#cf2518" stroke="#b8b8b8" stroke-width="1.0"><title>docs/integrations/kyc-aml-providers.md
+315 lines · in 1 · out 0 · reachable · 148d stale, subject churn 8647</title></circle>
+<circle cx="452.6" cy="454.2" r="9.1" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/local-documentation.md
+249 lines · in 2 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="470.5" cy="440.0" r="8.0" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/mapping-layer/README.md
+151 lines · in 1 · out 2 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="383.7" cy="425.6" r="8.3" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/mapping-layer/examples.md
+177 lines · in 1 · out 0 · reachable · 96d stale, subject churn 8</title></circle>
+<circle cx="391.8" cy="416.9" r="7.4" fill="#fb8c58" stroke="#b8b8b8" stroke-width="1.0"><title>docs/mapping-layer/troubleshooting.md
+114 lines · in 1 · out 0 · reachable · 96d stale, subject churn 8647</title></circle>
+<circle cx="489.8" cy="427.9" r="9.7" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/operations/audit-monitoring.md
+315 lines · in 3 · out 4 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="509.6" cy="496.8" r="10.6" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/patterns.md
+426 lines · in 11 · out 0 · reachable · 18d stale, subject churn 8</title></circle>
+<circle cx="400.2" cy="408.6" r="24.0" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/001-universal-asset-system.md
+3868 lines · in 6 · out 2 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="409.0" cy="400.6" r="14.3" fill="#fc9964" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/002-internal-bank-account.md
+1025 lines · in 4 · out 5 · reachable · 89d stale, subject churn 8647</title></circle>
+<circle cx="418.2" cy="393.0" r="10.9" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/003-meridian-edge.md
+455 lines · in 1 · out 3 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="427.6" cy="385.8" r="17.7" fill="#fc9964" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/004-market-information-management.md
+1824 lines · in 3 · out 8 · reachable · 89d stale, subject churn 8647</title></circle>
+<circle cx="437.4" cy="379.0" r="16.6" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/005-durable-execution-engine.md
+1542 lines · in 4 · out 3 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="447.4" cy="372.7" r="18.7" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/006-starlark-saga-orchestration-core.md
+2103 lines · in 8 · out 3 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="457.7" cy="366.8" r="14.3" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/007-starlark-typed-service-clients.md
+1031 lines · in 2 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="468.2" cy="361.3" r="16.3" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/008-starlark-service-bindings.md
+1462 lines · in 4 · out 6 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="479.0" cy="356.3" r="14.8" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/009-production-readiness-review.md
+1122 lines · in 1 · out 2 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="490.0" cy="351.8" r="11.9" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/010-starlark-testing-framework.md
+610 lines · in 1 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="501.1" cy="347.7" r="21.8" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/011-valuation-service.md
+3060 lines · in 2 · out 6 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="512.5" cy="344.1" r="11.2" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/012-codebase-health-audit.md
+503 lines · in 1 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="523.9" cy="341.0" r="15.8" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/013-reconciliation-service.md
+1341 lines · in 2 · out 2 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="535.5" cy="338.4" r="15.5" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/014-control-plane.md
+1269 lines · in 4 · out 3 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="547.2" cy="336.3" r="15.5" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/015-stripe-connect.md
+1281 lines · in 1 · out 5 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="559.0" cy="334.7" r="13.7" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/016-market-data-dynamic-pricing.md
+916 lines · in 2 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="570.8" cy="333.7" r="11.7" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/017-reconciliation-grpc-wiring.md
+575 lines · in 4 · out 0 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="582.7" cy="333.1" r="9.2" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/018-current-account-withdrawal-persistence.md
+266 lines · in 1 · out 3 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="594.6" cy="333.0" r="9.1" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/019-internal-bank-account-position-keeping-client.md
+254 lines · in 1 · out 4 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="606.4" cy="333.5" r="10.6" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/020-party-kyc-aml-provider-integration.md
+417 lines · in 2 · out 3 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="618.3" cy="334.5" r="11.2" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/021-platform-scheduler.md
+508 lines · in 1 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="630.1" cy="335.9" r="12.7" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/022-org-scoped-accounts.md
+740 lines · in 1 · out 5 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="641.8" cy="337.9" r="15.5" fill="#fc9964" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/023-product-directory.md
+1279 lines · in 2 · out 0 · reachable · 89d stale, subject churn 8647</title></circle>
+<circle cx="653.4" cy="340.4" r="14.4" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/024-structured-inbound-mapping.md
+1055 lines · in 1 · out 0 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="664.9" cy="343.4" r="13.8" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/025-real-time-event-streaming.md
+929 lines · in 2 · out 0 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="676.2" cy="346.8" r="20.5" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/026-operations-console-ui.md
+2621 lines · in 1 · out 0 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="687.4" cy="350.8" r="15.4" fill="#fc925d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/027-mcp-server.md
+1258 lines · in 2 · out 3 · reachable · 93d stale, subject churn 8647</title></circle>
+<circle cx="698.5" cy="355.2" r="9.6" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/028-asset-agnostic-accounts.md
+298 lines · in 1 · out 3 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="709.3" cy="360.1" r="17.7" fill="#fc9964" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/029-operational-gateway.md
+1826 lines · in 1 · out 0 · reachable · 89d stale, subject churn 8647</title></circle>
+<circle cx="719.9" cy="365.5" r="13.6" fill="#fc9964" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/030-asyncapi-specification.md
+883 lines · in 2 · out 3 · reachable · 89d stale, subject churn 8647</title></circle>
+<circle cx="730.2" cy="371.3" r="12.6" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/031-identity-access-management.md
+719 lines · in 2 · out 4 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="740.3" cy="377.5" r="14.6" fill="#fc9d68" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/032-event-driven-valuation-saga.md
+1089 lines · in 1 · out 5 · reachable · 87d stale, subject churn 8647</title></circle>
+<circle cx="750.1" cy="384.2" r="10.5" fill="#fc9d68" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/033-gateway-architecture.md
+412 lines · in 2 · out 0 · reachable · 87d stale, subject churn 8647</title></circle>
+<circle cx="759.7" cy="391.3" r="12.6" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/034-frontend-service-alignment.md
+720 lines · in 1 · out 0 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="768.9" cy="398.8" r="12.8" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/035-economy-cookbook.md
+747 lines · in 2 · out 0 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="777.8" cy="406.7" r="12.7" fill="#fca36d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/036-cookbook-browser.md
+733 lines · in 2 · out 0 · reachable · 84d stale, subject churn 8647</title></circle>
+<circle cx="786.3" cy="415.0" r="8.9" fill="#fca36d" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/037-multi-asset-purity.md
+236 lines · in 1 · out 3 · reachable · 84d stale, subject churn 8647</title></circle>
+<circle cx="794.4" cy="423.6" r="12.0" fill="#fca46f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/038-manifest-business-model-visualization.md
+618 lines · in 1 · out 3 · reachable · 83d stale, subject churn 8647</title></circle>
+<circle cx="802.2" cy="432.6" r="17.5" fill="#fca771" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/039-meridian-vm.md
+1755 lines · in 1 · out 0 · reachable · 82d stale, subject churn 8647</title></circle>
+<circle cx="809.6" cy="441.9" r="11.2" fill="#fca973" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/040-handler-schema-alignment.md
+498 lines · in 1 · out 0 · reachable · 81d stale, subject churn 8647</title></circle>
+<circle cx="816.6" cy="451.5" r="11.5" fill="#fcaa74" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/041-economy-generator.md
+544 lines · in 1 · out 0 · reachable · 80d stale, subject churn 8647</title></circle>
+<circle cx="823.2" cy="461.4" r="12.4" fill="#fcaa74" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/042-economy-ide.md
+684 lines · in 1 · out 0 · reachable · 80d stale, subject churn 8647</title></circle>
+<circle cx="829.3" cy="471.5" r="10.6" fill="#fcae78" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/043-mcp-manifest-tenant-isolation.md
+425 lines · in 2 · out 0 · reachable · 78d stale, subject churn 8647</title></circle>
+<circle cx="835.0" cy="481.9" r="10.9" fill="#fcb47e" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/044-auth-flow-architecture.md
+463 lines · in 3 · out 3 · reachable · 75d stale, subject churn 8647</title></circle>
+<circle cx="840.3" cy="492.6" r="13.6" fill="#fcb67f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/045-manifest-as-sole-source-of-truth.md
+894 lines · in 1 · out 0 · reachable · 74d stale, subject churn 8647</title></circle>
+<circle cx="845.0" cy="503.5" r="11.1" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/046-economy-visualization-completeness.md
+493 lines · in 1 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="849.3" cy="514.5" r="8.8" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/047-security-audit-status.md
+220 lines · in 1 · out 1 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="853.2" cy="525.8" r="10.4" fill="#fcb982" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/047-security-audit.md
+391 lines · in 2 · out 2 · reachable · 73d stale, subject churn 8647</title></circle>
+<circle cx="856.5" cy="537.2" r="8.1" fill="#fcba83" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/048-test-coverage-80.md
+164 lines · in 1 · out 0 · reachable · 72d stale, subject churn 8647</title></circle>
+<circle cx="859.3" cy="548.7" r="12.5" fill="#fdbb84" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/049-codebase-consistency.md
+700 lines · in 1 · out 0 · reachable · 71d stale, subject churn 8647</title></circle>
+<circle cx="861.7" cy="560.4" r="8.4" fill="#fdc089" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/050-demo-sandbox.md
+184 lines · in 2 · out 0 · reachable · 67d stale, subject churn 8647</title></circle>
+<circle cx="863.5" cy="572.1" r="10.2" fill="#fdc089" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/051-party-navigation.md
+371 lines · in 1 · out 0 · reachable · 67d stale, subject churn 8647</title></circle>
+<circle cx="864.9" cy="583.9" r="12.3" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/052-email-platform.md
+672 lines · in 2 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="865.7" cy="595.7" r="8.8" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/053-auth-email-flows.md
+226 lines · in 3 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="866.0" cy="607.6" r="8.8" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/054-billing-ui.md
+220 lines · in 1 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="865.8" cy="619.5" r="8.2" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/055-tenant-branding.md
+172 lines · in 1 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="865.1" cy="631.4" r="11.1" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/056-correspondence-service.md
+481 lines · in 1 · out 3 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="863.9" cy="643.2" r="10.2" fill="#fdc993" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/057-convergent-manifest-apply.md
+371 lines · in 1 · out 0 · reachable · 58d stale, subject churn 8647</title></circle>
+<circle cx="862.2" cy="654.9" r="10.1" fill="#fdc993" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/058-full-economy-visibility.md
+357 lines · in 1 · out 0 · reachable · 58d stale, subject churn 8647</title></circle>
+<circle cx="859.9" cy="666.6" r="10.1" fill="#fdcb94" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/059-asset-agnostic-posting-layer.md
+360 lines · in 1 · out 0 · reachable · 56d stale, subject churn 8647</title></circle>
+<circle cx="857.2" cy="678.1" r="10.4" fill="#fdce98" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/060-per-tenant-scheduled-execution.md
+399 lines · in 1 · out 0 · reachable · 53d stale, subject churn 8647</title></circle>
+<circle cx="854.0" cy="689.6" r="10.0" fill="#fdce98" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/061-mcp-auth-session-unification.md
+350 lines · in 1 · out 0 · reachable · 53d stale, subject churn 8647</title></circle>
+<circle cx="850.3" cy="700.9" r="9.9" fill="#fddfb6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/062-self-service-onboarding-readiness.md
+339 lines · in 1 · out 3 · reachable · 34d stale, subject churn 8647</title></circle>
+<circle cx="510.3" cy="418.0" r="10.4" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/prd/README.md
+393 lines · in 2 · out 65 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="531.8" cy="410.3" r="11.3" fill="#fc905c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/reports/cockroachdb-migration-audit.md
+522 lines · in 3 · out 0 · reachable · 94d stale, subject churn 8647</title></circle>
+<circle cx="554.0" cy="405.2" r="8.8" fill="#e65139" stroke="#b8b8b8" stroke-width="1.0"><title>docs/reports/market-information-go-live-readiness.md
+226 lines · in 1 · out 0 · reachable · 128d stale, subject churn 8647</title></circle>
+<circle cx="576.7" cy="402.4" r="11.5" fill="#e65139" stroke="#b8b8b8" stroke-width="1.0"><title>docs/reports/market-information-integration.md
+539 lines · in 1 · out 0 · reachable · 128d stale, subject churn 8647</title></circle>
+<circle cx="599.5" cy="402.2" r="8.6" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/reports/market-information-traceability.md
+206 lines · in 1 · out 0 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="622.1" cy="404.5" r="13.2" fill="#fc935f" stroke="#b8b8b8" stroke-width="1.0"><title>docs/reports/saga-handler-audit.md
+817 lines · in 1 · out 0 · reachable · 92d stale, subject churn 8647</title></circle>
+<circle cx="644.4" cy="409.3" r="8.2" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/README.md
+171 lines · in 1 · out 13 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="846.1" cy="712.0" r="11.7" fill="#bc0c07" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/disaster-recovery.md
+579 lines · in 4 · out 0 · reachable · 161d stale, subject churn 8647</title></circle>
+<circle cx="841.4" cy="722.9" r="7.9" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/email-infrastructure.md
+146 lines · in 1 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="836.3" cy="733.6" r="11.0" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/event-router.md
+470 lines · in 1 · out 4 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="830.7" cy="744.1" r="10.4" fill="#800000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/incident-response.md
+390 lines · in 5 · out 0 · reachable · 190d stale, subject churn 8647</title></circle>
+<circle cx="824.7" cy="754.3" r="13.1" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/internal-account-operations.md
+806 lines · in 1 · out 4 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="818.2" cy="764.3" r="11.1" fill="#e55037" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/market-information-operations.md
+492 lines · in 1 · out 1 · reachable · 129d stale, subject churn 8647</title></circle>
+<circle cx="811.3" cy="773.9" r="10.2" fill="#f77e52" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/party-kyc-verification.md
+377 lines · in 1 · out 0 · reachable · 104d stale, subject churn 8647</title></circle>
+<circle cx="804.0" cy="783.3" r="12.9" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/production-deployment.md
+772 lines · in 2 · out 4 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="796.3" cy="792.4" r="11.5" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/saga-failure-recovery.md
+543 lines · in 7 · out 1 · reachable · 0d stale, subject churn 33</title></circle>
+<circle cx="788.2" cy="801.1" r="9.2" fill="#fca16c" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/saga-validation-failure.md
+264 lines · in 2 · out 3 · reachable · 85d stale, subject churn 8647</title></circle>
+<circle cx="779.8" cy="809.4" r="12.6" fill="#f26e4b" stroke="#b8b8b8" stroke-width="1.0"><title>docs/runbooks/troubleshooting-saga-handlers.md
+721 lines · in 5 · out 4 · reachable · 114d stale, subject churn 8647</title></circle>
+<circle cx="600.5" cy="471.4" r="8.7" fill="#feebd0" stroke="#b8b8b8" stroke-width="1.0"><title>docs/saga-handler-loading.md
+213 lines · in 3 · out 0 · reachable · 18d stale, subject churn 8647</title></circle>
+<circle cx="666.1" cy="416.5" r="13.2" fill="#fdcd97" stroke="#b8b8b8" stroke-width="1.0"><title>docs/saga-service-catalog.md
+823 lines · in 3 · out 0 · reachable · 54d stale, subject churn 8647</title></circle>
+<circle cx="686.8" cy="426.0" r="10.3" fill="#b80704" stroke="#b8b8b8" stroke-width="1.0"><title>docs/secrets-management.md
+388 lines · in 1 · out 0 · reachable · 163d stale, subject churn 8647</title></circle>
+<circle cx="706.3" cy="437.8" r="7.6" fill="#fcb982" stroke="#b8b8b8" stroke-width="1.0"><title>docs/security/pgx-tenant-audit.md
+126 lines · in 1 · out 0 · reachable · 73d stale, subject churn 8647</title></circle>
+<circle cx="686.5" cy="510.4" r="8.9" fill="#feebd0" stroke="#b8b8b8" stroke-width="1.0"><title>docs/service-readme-template.md
+230 lines · in 7 · out 1 · reachable · 18d stale, subject churn 8647</title></circle>
+<circle cx="724.5" cy="451.6" r="9.9" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>docs/services/party/verification-guide.md
+339 lines · in 1 · out 0 · reachable · 104d stale, subject churn 1</title></circle>
+<circle cx="741.0" cy="467.4" r="12.9" fill="#fff7ec" stroke="#b8b8b8" stroke-width="1.0"><title>docs/spec/saga-contract.md
+767 lines · in 2 · out 1 · reachable · 0d stale, subject churn 8647</title></circle>
+<circle cx="755.6" cy="484.8" r="10.4" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/testing/CHAOS_TESTING.md
+399 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="768.3" cy="503.8" r="10.2" fill="#7f0000" stroke="#b8b8b8" stroke-width="1.0"><title>docs/testing/COVERAGE_ANALYSIS.md
+373 lines · in 1 · out 0 · reachable · 191d stale, subject churn 8647</title></circle>
+<circle cx="778.8" cy="524.1" r="8.5" fill="#fdc790" stroke="#b8b8b8" stroke-width="1.0"><title>docs/tilt-fast-startup.md
+198 lines · in 1 · out 1 · reachable · 60d stale, subject churn 8647</title></circle>
+<circle cx="684.1" cy="205.8" r="5.8" fill="#d8c5c0" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>frontend/README.md
+31 lines · in 0 · out 0 · orphan · 96d stale, subject churn 1478</title></circle>
+<circle cx="785.2" cy="243.9" r="8.8" fill="#fcaa74" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>frontend/docs/tenant-subdomain-routing.md
+227 lines · in 0 · out 0 · orphan · 80d stale, subject churn 8647</title></circle>
+<circle cx="245.9" cy="633.4" r="7.6" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>http/README.md
+124 lines · in 1 · out 2 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="771.0" cy="817.4" r="9.0" fill="#d0ced3" stroke="#b8b8b8" stroke-width="1.0"><title>scripts/README.md
+244 lines · in 1 · out 2 · reachable · 191d stale, subject churn 94</title></circle>
+<circle cx="873.0" cy="306.9" r="8.4" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>scripts/kafka-tests/README.md
+189 lines · in 0 · out 3 · orphan · 60d stale, subject churn 3</title></circle>
+<circle cx="727.3" cy="595.5" r="15.5" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/README.md
+1276 lines · in 7 · out 15 · reachable · 0d stale, subject churn 1</title></circle>
+<circle cx="787.0" cy="545.4" r="10.5" fill="#d2d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/api-gateway/README.md
+413 lines · in 3 · out 5 · reachable · 18d stale, subject churn 225</title></circle>
+<circle cx="565.6" cy="264.9" r="8.4" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/audit-worker/README.md
+188 lines · in 1 · out 6 · reachable · 17d stale, subject churn 50</title></circle>
+<circle cx="792.8" cy="567.4" r="8.7" fill="#d3d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/control-plane/README.md
+217 lines · in 2 · out 2 · reachable · 15d stale, subject churn 546</title></circle>
+<circle cx="934.1" cy="584.6" r="8.5" fill="#fc9f69" stroke="#b8b8b8" stroke-width="1.0"><title>services/control-plane/internal/applier/testdata/tenant-saga-examples/README.md
+197 lines · in 1 · out 0 · reachable · 86d stale, subject churn 8647</title></circle>
+<circle cx="761.8" cy="825.0" r="9.0" fill="#d4d3d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/current-account/README.md
+239 lines · in 4 · out 4 · reachable · 15d stale, subject churn 706</title></circle>
+<circle cx="796.1" cy="590.0" r="8.1" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/event-router/README.md
+164 lines · in 3 · out 2 · reachable · 17d stale, subject churn 69</title></circle>
+<circle cx="941.6" cy="390.4" r="7.1" fill="#fca16c" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/event-router/k8s/README.md
+91 lines · in 0 · out 0 · orphan · 85d stale, subject churn 8647</title></circle>
+<circle cx="752.4" cy="832.2" r="8.6" fill="#d3d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/financial-accounting/README.md
+207 lines · in 2 · out 4 · reachable · 15d stale, subject churn 365</title></circle>
+<circle cx="797.0" cy="612.8" r="8.4" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/financial-gateway/README.md
+189 lines · in 1 · out 5 · reachable · 18d stale, subject churn 74</title></circle>
+<circle cx="795.3" cy="635.5" r="8.1" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/forecasting/README.md
+166 lines · in 1 · out 2 · reachable · 17d stale, subject churn 72</title></circle>
+<circle cx="791.1" cy="657.9" r="9.1" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/identity/README.md
+250 lines · in 1 · out 1 · reachable · 17d stale, subject churn 156</title></circle>
+<circle cx="784.5" cy="679.8" r="8.9" fill="#d2d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/internal-account/README.md
+235 lines · in 2 · out 4 · reachable · 15d stale, subject churn 192</title></circle>
+<circle cx="986.2" cy="488.9" r="8.1" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/internal-account/benchmarks/README.md
+165 lines · in 0 · out 0 · orphan · 92d stale, subject churn 10</title></circle>
+<circle cx="1003.8" cy="595.5" r="8.7" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/internal-account/examples/README.md
+212 lines · in 0 · out 0 · orphan · 92d stale, subject churn 8</title></circle>
+<circle cx="993.2" cy="703.1" r="8.9" fill="#d2d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/market-information/README.md
+234 lines · in 0 · out 1 · orphan · 17d stale, subject churn 204</title></circle>
+<circle cx="775.6" cy="700.7" r="10.3" fill="#d2d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/mcp-server/README.md
+384 lines · in 1 · out 5 · reachable · 18d stale, subject churn 222</title></circle>
+<circle cx="955.1" cy="804.2" r="7.8" fill="#fc925d" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/mcp-server/internal/resources/docs/cel-reference.md
+139 lines · in 0 · out 0 · orphan · 93d stale, subject churn 8647</title></circle>
+<circle cx="892.1" cy="892.0" r="7.3" fill="#fc925d" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/mcp-server/internal/resources/docs/starlark-guide.md
+104 lines · in 0 · out 0 · orphan · 93d stale, subject churn 8647</title></circle>
+<circle cx="764.4" cy="720.6" r="8.9" fill="#d1d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/operational-gateway/README.md
+235 lines · in 1 · out 4 · reachable · 18d stale, subject churn 125</title></circle>
+<circle cx="742.6" cy="839.0" r="9.3" fill="#d2d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/party/README.md
+272 lines · in 1 · out 1 · reachable · 17d stale, subject churn 280</title></circle>
+<circle cx="732.6" cy="845.3" r="8.4" fill="#d3d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/payment-order/README.md
+184 lines · in 1 · out 2 · reachable · 15d stale, subject churn 429</title></circle>
+<circle cx="808.6" cy="960.6" r="7.1" fill="#ee6347" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>services/payment-order/service/HANDLER_ARCHITECTURE.md
+90 lines · in 0 · out 0 · orphan · 120d stale, subject churn 8647</title></circle>
+<circle cx="722.3" cy="851.2" r="8.7" fill="#d3d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/position-keeping/README.md
+213 lines · in 3 · out 4 · reachable · 17d stale, subject churn 428</title></circle>
+<circle cx="751.0" cy="739.1" r="8.4" fill="#d2d1d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/reconciliation/README.md
+186 lines · in 1 · out 3 · reachable · 17d stale, subject churn 280</title></circle>
+<circle cx="735.7" cy="756.0" r="9.3" fill="#d3d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/reference-data/README.md
+268 lines · in 2 · out 1 · reachable · 17d stale, subject churn 368</title></circle>
+<circle cx="711.8" cy="856.7" r="8.7" fill="#d2d2d6" stroke="#b8b8b8" stroke-width="1.0"><title>services/tenant/README.md
+215 lines · in 1 · out 1 · reachable · 15d stale, subject churn 295</title></circle>
+<circle cx="710.1" cy="1005.2" r="7.0" fill="#d6d0ce" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>shared/README.md
+87 lines · in 0 · out 0 · orphan · 54d stale, subject churn 1123</title></circle>
+<circle cx="603.5" cy="1022.8" r="12.2" fill="#fdc790" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>shared/domain/money/PRECISION_GUARANTEES.md
+647 lines · in 0 · out 1 · orphan · 60d stale, subject churn 8647</title></circle>
+<circle cx="701.0" cy="861.7" r="10.0" fill="#d1d0d5" stroke="#b8b8b8" stroke-width="1.0"><title>shared/platform/audit/README.md
+344 lines · in 3 · out 5 · reachable · 130d stale, subject churn 55</title></circle>
+<circle cx="346.2" cy="1025.9" r="6.6" fill="#d1d0d5" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>shared/platform/bootstrap/README.md
+65 lines · in 0 · out 1 · orphan · 130d stale, subject churn 33</title></circle>
+<circle cx="173.1" cy="365.2" r="8.6" fill="#cf2518" stroke="#b8b8b8" stroke-width="1.0"><title>shared/platform/bootstrap/SHUTDOWN_USAGE.md
+205 lines · in 1 · out 0 · island · 148d stale, subject churn 8647</title></circle>
+<circle cx="833.8" cy="192.1" r="9.7" fill="#d1d0d5" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>shared/platform/observability/README.md
+318 lines · in 0 · out 0 · orphan · 130d stale, subject churn 43</title></circle>
+<circle cx="1006.9" cy="852.8" r="9.1" fill="#d1d1d6" stroke="#1a1a1a" stroke-width="1.8" stroke-dasharray="3,2"><title>tests/audit-e2e/README.md
+255 lines · in 0 · out 3 · orphan · 92d stale, subject churn 4</title></circle>
+
+<text x="590" y="40" font-size="24" font-weight="600" text-anchor="middle">Doc map — 247 docs, 659 links, 20 islands</text>
+<text x="590" y="66" font-size="14" fill="#555" text-anchor="middle">11% orphaned · 89% reachable from the entry point</text>
+<defs><linearGradient id="stalegrad" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#fff7ec"/><stop offset="0.5" stop-color="#fc8d59"/><stop offset="1" stop-color="#7f0000"/></linearGradient></defs>
+<text x="334" y="1162" font-size="12" fill="#555" text-anchor="end">stable</text>
+<rect x="340" y="1151" width="110" height="12" rx="3" fill="url(#stalegrad)"/>
+<text x="456" y="1162" font-size="12" fill="#555">lying map</text>
+<circle cx="600" cy="1158" r="8" fill="#dddddd" stroke="#0072B2" stroke-width="3"/>
+<text x="614" y="1162" font-size="13">entry</text>
+<circle cx="695" cy="1158" r="8" fill="#dddddd" stroke="#1a1a1a" stroke-width="2" stroke-dasharray="3,2"/>
+<text x="709" y="1162" font-size="13">orphan</text>
+<circle cx="795" cy="1158" r="8" fill="#ffffff" stroke="#CC79A7" stroke-width="1.8" stroke-dasharray="3,2"/>
+<text x="809" y="1162" font-size="13">ghost (broken link)</text>
+<text x="590" y="1198" font-size="12" fill="#555" text-anchor="middle">colour = staleness · size = file length (lines) · rings = link-distance from entry · rim = unreachable</text>
+</svg>

--- a/docs/example-heatmap-after.svg
+++ b/docs/example-heatmap-after.svg
@@ -1,0 +1,8067 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" width="1600" height="1000" preserveAspectRatio="xMidYMid meet">
+<style>
+  rect:hover { stroke: #000; stroke-width: 1.5; }
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1a1a1a; pointer-events: none; text-anchor: middle; dominant-baseline: middle; }
+</style>
+<rect x="0.00" y="0.00" width="59.82" height="37.71" fill="#fdbf88" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler_test.go
+1129 loc · ccn 89 · commits (last 12mo) 15</title></rect>
+<rect x="59.82" y="0.00" width="43.76" height="37.71" fill="#fdc68f" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/handlers_test.go
+826 loc · ccn 76 · commits (last 12mo) 8</title></rect>
+<rect x="103.58" y="0.00" width="37.99" height="37.71" fill="#ecc5a4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/reference_data_client_test.go
+717 loc · ccn 92 · commits (last 12mo) 5</title></rect>
+<rect x="0.00" y="37.71" width="37.94" height="33.60" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/resource_patcher_test.go
+638 loc · ccn 55 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="71.30" width="37.94" height="32.86" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
+624 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="104.17" width="37.94" height="29.28" fill="#e7ceb6" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/market_information_client_test.go
+556 loc · ccn 64 · commits (last 12mo) 4</title></rect>
+<rect x="0.00" y="133.45" width="37.94" height="27.65" fill="#fdc891" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler.go
+525 loc · ccn 73 · commits (last 12mo) 19</title></rect>
+<rect x="37.94" y="37.71" width="35.14" height="29.22" fill="#ecc5a4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler_mappers.go
+514 loc · ccn 92 · commits (last 12mo) 5</title></rect>
+<rect x="73.07" y="37.71" width="34.73" height="29.22" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/apply_resource_test.go
+508 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="107.80" y="37.71" width="33.77" height="29.22" fill="#fddfb5" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/executor_test.go
+494 loc · ccn 23 · commits (last 12mo) 10</title></rect>
+<rect x="37.94" y="66.93" width="29.09" height="27.47" fill="#fdcf98" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/handlers.go
+400 loc · ccn 59 · commits (last 12mo) 10</title></rect>
+<rect x="37.94" y="94.40" width="29.09" height="24.25" fill="#fdddb2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/executor.go
+353 loc · ccn 27 · commits (last 12mo) 11</title></rect>
+<rect x="37.94" y="118.65" width="29.09" height="21.50" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/operational_gateway_client_test.go
+313 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="37.94" y="140.15" width="29.09" height="20.95" fill="#f2d0a9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/reference_data_client.go
+305 loc · ccn 57 · commits (last 12mo) 6</title></rect>
+<rect x="67.02" y="66.93" width="29.51" height="20.58" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler_convergent_test.go
+304 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="96.53" y="66.93" width="22.81" height="20.58" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/operational_gateway_client.go
+235 loc · ccn 61 · commits (last 12mo) 2</title></rect>
+<rect x="119.34" y="66.93" width="22.23" height="20.58" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/resource_patcher.go
+229 loc · ccn 72 · commits (last 12mo) 2</title></rect>
+<rect x="67.02" y="87.51" width="22.24" height="19.59" fill="#e7d7c4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/party_client_test.go
+218 loc · ccn 27 · commits (last 12mo) 4</title></rect>
+<rect x="67.02" y="107.10" width="22.24" height="18.96" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/internal_account_client_test.go
+211 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="67.02" y="126.05" width="22.24" height="18.42" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/apply_resource.go
+205 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="67.02" y="144.47" width="22.24" height="16.62" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/executor_convert.go
+185 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="89.26" y="87.51" width="18.55" height="19.82" fill="#ecd5b7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/market_information_client.go
+184 loc · ccn 41 · commits (last 12mo) 5</title></rect>
+<rect x="107.80" y="87.51" width="17.14" height="19.82" fill="#fde1b9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/bootstrap_test.go
+170 loc · ccn 19 · commits (last 12mo) 9</title></rect>
+<rect x="124.94" y="87.51" width="16.63" height="19.82" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/apply_job_integration_test.go
+165 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="89.26" y="107.33" width="17.52" height="16.99" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/apply_job.go
+149 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="106.77" y="107.33" width="17.40" height="16.99" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/saga_definition_repository.go
+148 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="124.17" y="107.33" width="17.40" height="16.99" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/testdata/tenant-saga-examples/README.md
+148 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="89.26" y="124.32" width="13.58" height="18.68" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/bootstrap.go
+127 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="89.26" y="143.00" width="13.58" height="18.09" fill="#f2dbbc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/party_client.go
+123 loc · ccn 25 · commits (last 12mo) 6</title></rect>
+<rect x="102.84" y="124.32" width="16.30" height="14.83" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/grpc_handler_phase.go
+121 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="102.84" y="139.15" width="16.30" height="11.52" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/manifest_apply_integration_test.go
+94 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="102.84" y="150.68" width="16.30" height="10.42" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/executor_coverage_test.go
+85 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="119.14" y="124.32" width="11.36" height="14.42" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/saga_integration_test.go
+82 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="130.49" y="124.32" width="11.08" height="14.42" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/saga_definition_repository_test.go
+80 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="119.14" y="138.75" width="11.98" height="11.67" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/validate_examples_test.go
+70 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="119.14" y="150.42" width="11.98" height="10.67" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/internal_account_client.go
+64 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="131.11" y="138.75" width="10.46" height="11.46" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/executor_pinning_test.go
+60 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="131.11" y="150.21" width="10.46" height="10.89" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/applier/apply_job_test.go
+57 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="161.10" width="47.14" height="45.69" fill="#d6c9c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/manifest_validator_triggers_rails_test.go
+1078 loc · ccn 140 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="206.78" width="47.14" height="44.67" fill="#e24932" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/manifest_validator_test.go
+1054 loc · ccn 218 · commits (last 12mo) 17</title></rect>
+<rect x="0.00" y="251.46" width="47.14" height="32.80" fill="#d6cbc9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/manifest_validator_orphans_destructive_test.go
+774 loc · ccn 119 · commits (last 12mo) 1</title></rect>
+<rect x="47.14" y="161.10" width="34.30" height="34.19" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/handler_schema_integration_test.go
+587 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="81.44" y="161.10" width="30.68" height="34.19" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/crossref_validator.go
+525 loc · ccn 92 · commits (last 12mo) 2</title></rect>
+<rect x="112.12" y="161.10" width="29.45" height="34.19" fill="#e1cab8" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/domain_validator.go
+504 loc · ccn 90 · commits (last 12mo) 3</title></rect>
+<rect x="47.14" y="195.28" width="30.22" height="31.80" fill="#d6cdcb" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/manifest_validator_mappings_test.go
+481 loc · ccn 102 · commits (last 12mo) 1</title></rect>
+<rect x="47.14" y="227.08" width="30.22" height="29.28" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/cel_validator.go
+443 loc · ccn 91 · commits (last 12mo) 2</title></rect>
+<rect x="47.14" y="256.36" width="30.22" height="27.90" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/domain_validator_test.go
+422 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="77.36" y="195.28" width="32.79" height="24.86" fill="#fdc58f" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/manifest_validator.go
+408 loc · ccn 77 · commits (last 12mo) 22</title></rect>
+<rect x="110.15" y="195.28" width="31.42" height="24.86" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/semantic_validator_test.go
+391 loc · ccn 44 · commits (last 12mo) 1</title></rect>
+<rect x="77.36" y="220.14" width="26.39" height="24.53" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/starlark_validator.go
+324 loc · ccn 64 · commits (last 12mo) 2</title></rect>
+<rect x="77.36" y="244.67" width="26.39" height="20.59" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/relationship_graph_test.go
+272 loc · ccn 41 · commits (last 12mo) 2</title></rect>
+<rect x="77.36" y="265.26" width="26.39" height="19.00" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/semantic_validator.go
+251 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="103.75" y="220.14" width="20.30" height="23.71" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/relationship_graph.go
+241 loc · ccn 42 · commits (last 12mo) 4</title></rect>
+<rect x="124.05" y="220.14" width="17.52" height="23.71" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/crossref_validator_test.go
+208 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="103.75" y="243.85" width="20.41" height="19.38" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/lifecycle_validator_test.go
+198 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="124.15" y="243.85" width="17.42" height="19.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/starlark_validator_test.go
+169 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="103.75" y="263.24" width="15.78" height="21.02" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/lifecycle_validator.go
+166 loc · ccn 32 · commits (last 12mo) 3</title></rect>
+<rect x="119.52" y="263.24" width="14.83" height="21.02" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/cel_validator_test.go
+156 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="134.35" y="263.24" width="7.22" height="21.02" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/validator/example_manifests_test.go
+76 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="141.57" y="0.00" width="58.05" height="35.69" fill="#f7c293" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_test.go
+1037 loc · ccn 86 · commits (last 12mo) 7</title></rect>
+<rect x="199.62" y="0.00" width="31.91" height="35.69" fill="#e6bda4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/grpc_live_state_adapters.go
+570 loc · ccn 116 · commits (last 12mo) 4</title></rect>
+<rect x="141.57" y="35.69" width="31.62" height="31.85" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_resources.go
+504 loc · ccn 73 · commits (last 12mo) 1</title></rect>
+<rect x="173.19" y="35.69" width="30.74" height="31.85" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_live_test.go
+490 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="203.93" y="35.69" width="27.60" height="31.85" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_live.go
+440 loc · ccn 71 · commits (last 12mo) 3</title></rect>
+<rect x="141.57" y="67.53" width="23.69" height="35.17" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+417 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="141.57" y="102.70" width="23.69" height="28.92" fill="#d6cdcb" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_helpers.go
+343 loc · ccn 104 · commits (last 12mo) 1</title></rect>
+<rect x="165.26" y="67.53" width="26.99" height="24.05" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/live_state_provider_test.go
+325 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="165.26" y="91.58" width="26.99" height="20.35" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_resources_test.go
+275 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="165.26" y="111.94" width="14.41" height="19.69" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/persistence/manifest_version_store_test.go
+142 loc · ccn 14 · commits (last 12mo) 4</title></rect>
+<rect x="179.67" y="111.94" width="12.58" height="19.69" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/persistence/manifest_version_store.go
+124 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="192.26" y="67.53" width="20.67" height="21.26" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_helpers_test.go
+220 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="212.93" y="67.53" width="18.60" height="21.26" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/live_state_filter_test.go
+198 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="192.26" y="88.79" width="23.76" height="16.23" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/live_state_provider.go
+193 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="216.02" y="88.79" width="15.51" height="16.23" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ_mappings_test.go
+126 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="192.26" y="105.02" width="16.15" height="15.47" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/manifest_differ.go
+125 loc · ccn 29 · commits (last 12mo) 12</title></rect>
+<rect x="192.26" y="120.49" width="16.15" height="11.14" fill="#f8e3c6" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/types.go
+90 loc · ccn 7 · commits (last 12mo) 7</title></rect>
+<rect x="208.40" y="105.02" width="12.60" height="12.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/safety_test.go
+79 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="221.01" y="105.02" width="10.53" height="12.52" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/store_test.go
+66 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="208.40" y="117.54" width="8.94" height="14.08" fill="#ecdbc5" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/live_state.go
+63 loc · ccn 16 · commits (last 12mo) 5</title></rect>
+<rect x="217.34" y="117.54" width="7.66" height="14.08" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/drift_test.go
+54 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="225.01" y="117.54" width="6.53" height="5.20" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/store.go
+17 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="225.01" y="122.75" width="6.53" height="5.20" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/safety.go
+17 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="225.01" y="127.95" width="6.53" height="3.67" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/differ/drift.go
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="231.53" y="0.00" width="56.81" height="33.48" fill="#e7ccb3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/service_test.go
+952 loc · ccn 73 · commits (last 12mo) 4</title></rect>
+<rect x="288.34" y="0.00" width="22.26" height="33.48" fill="#eccbab" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/service.go
+373 loc · ccn 72 · commits (last 12mo) 5</title></rect>
+<rect x="231.53" y="33.48" width="28.49" height="25.52" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/pattern_matcher.go
+364 loc · ccn 89 · commits (last 12mo) 1</title></rect>
+<rect x="260.03" y="33.48" width="27.63" height="25.52" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/validate_fix_test.go
+353 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="287.66" y="33.48" width="22.94" height="25.52" fill="#d6cbc9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/validate_fix_parse.go
+293 loc · ccn 119 · commits (last 12mo) 1</title></rect>
+<rect x="231.53" y="59.00" width="20.93" height="27.48" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/pattern_matcher_test.go
+288 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="231.53" y="86.48" width="20.93" height="23.09" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/validate_fix_coverage_test.go
+242 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="231.53" y="109.58" width="20.93" height="22.04" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/context_assembler_test.go
+231 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="252.47" y="59.00" width="20.89" height="20.17" fill="#e7d3bc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/validate_fix.go
+211 loc · ccn 44 · commits (last 12mo) 4</title></rect>
+<rect x="273.36" y="59.00" width="20.10" height="20.17" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/golden_test.go
+203 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="293.47" y="59.00" width="17.13" height="20.17" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/handler_reference_test.go
+173 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="252.47" y="79.18" width="18.40" height="18.03" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/context_assembler.go
+166 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="252.47" y="97.20" width="18.40" height="17.48" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/amend.go
+161 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="252.47" y="114.68" width="18.40" height="16.94" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/validate_fix_enrich.go
+156 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="270.87" y="79.18" width="21.03" height="14.53" fill="#e7d8c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/llm_client.go
+153 loc · ccn 21 · commits (last 12mo) 4</title></rect>
+<rect x="291.90" y="79.18" width="18.70" height="14.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/cached_context_test.go
+136 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="270.87" y="93.71" width="18.34" height="13.18" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/handler_reference.go
+121 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="270.87" y="106.89" width="18.34" height="12.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/amend_test.go
+117 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="270.87" y="119.64" width="18.34" height="11.98" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/schema_summary.go
+110 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="289.20" y="93.71" width="10.81" height="18.12" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/topic_list_test.go
+98 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="300.01" y="93.71" width="10.59" height="18.12" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/llm_client_test.go
+96 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="289.20" y="111.82" width="13.02" height="10.59" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/cached_context.go
+69 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="289.20" y="122.41" width="13.02" height="9.21" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/topic_list.go
+60 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="302.22" y="111.82" width="8.38" height="10.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/schema_summary_test.go
+44 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="302.22" y="122.32" width="8.38" height="9.30" fill="#f2e1c9" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/generator/export_test.go
+39 loc · ccn 5 · commits (last 12mo) 6</title></rect>
+<rect x="141.57" y="131.62" width="32.69" height="43.39" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/export_test.go
+710 loc · ccn 67 · commits (last 12mo) 2</title></rect>
+<rect x="141.57" y="175.01" width="32.69" height="25.97" fill="#fdd8a8" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/history_test.go
+425 loc · ccn 38 · commits (last 12mo) 8</title></rect>
+<rect x="141.57" y="200.98" width="32.69" height="25.24" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/export.go
+413 loc · ccn 86 · commits (last 12mo) 2</title></rect>
+<rect x="174.27" y="131.62" width="23.80" height="30.81" fill="#fdc28b" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/history.go
+367 loc · ccn 83 · commits (last 12mo) 8</title></rect>
+<rect x="198.07" y="131.62" width="22.83" height="30.81" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/repository_test.go
+352 loc · ccn 27 · commits (last 12mo) 5</title></rect>
+<rect x="220.89" y="131.62" width="22.18" height="30.81" fill="#f7ce9f" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/grpc_handler.go
+342 loc · ccn 61 · commits (last 12mo) 7</title></rect>
+<rect x="174.27" y="162.43" width="26.34" height="23.51" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/reconcile_test.go
+310 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="174.27" y="185.94" width="26.34" height="20.86" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/grpc_handler_integration_test.go
+275 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="174.27" y="206.80" width="26.34" height="19.42" fill="#f2d1aa" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/repository.go
+256 loc · ccn 53 · commits (last 12mo) 6</title></rect>
+<rect x="200.61" y="162.43" width="22.15" height="21.73" fill="#e7d8c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/history_integration_test.go
+241 loc · ccn 20 · commits (last 12mo) 4</title></rect>
+<rect x="222.76" y="162.43" width="20.32" height="21.73" fill="#e7d8c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/grpc_handler_test.go
+221 loc · ccn 20 · commits (last 12mo) 4</title></rect>
+<rect x="200.61" y="184.16" width="20.85" height="21.17" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/reconcile.go
+221 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="200.61" y="205.33" width="20.85" height="20.88" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/export_coverage_test.go
+218 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="221.46" y="184.16" width="21.61" height="15.44" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/history_coverage_test.go
+167 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="221.46" y="199.60" width="21.61" height="13.96" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/grpc_handler_coverage_test.go
+151 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="221.46" y="213.55" width="21.61" height="12.66" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/manifest/rollback_integration_test.go
+137 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="141.57" y="226.22" width="33.97" height="32.52" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/balance_sheet_test.go
+553 loc · ccn 53 · commits (last 12mo) 2</title></rect>
+<rect x="141.57" y="258.74" width="33.97" height="25.52" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/balance_sheet.go
+434 loc · ccn 84 · commits (last 12mo) 2</title></rect>
+<rect x="175.54" y="226.22" width="22.89" height="33.08" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/integration_test.go
+379 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="175.54" y="259.30" width="22.89" height="24.96" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/causation_visualizer.go
+286 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="198.43" y="226.22" width="23.03" height="22.47" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/export_test.go
+259 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="221.46" y="226.22" width="21.61" height="22.47" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/balance_sheet_handler_test.go
+243 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="198.43" y="248.68" width="21.79" height="20.91" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/handler_test.go
+228 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="198.43" y="269.59" width="21.79" height="14.67" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/balance_sheet_handler.go
+160 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="220.22" y="248.68" width="22.85" height="13.20" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/handler.go
+151 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="220.22" y="261.88" width="11.61" height="22.38" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/export.go
+130 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="231.83" y="261.88" width="11.25" height="12.97" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/causation_visualizer_coverage_test.go
+73 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="231.83" y="274.85" width="11.25" height="9.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/admin/causation_visualizer_test.go
+53 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="243.07" y="131.62" width="22.07" height="35.12" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/webhook_test.go
+388 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="243.07" y="166.74" width="22.07" height="28.96" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/webhook.go
+320 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="265.14" y="131.62" width="22.82" height="21.45" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/reconciliation_test.go
+245 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="287.96" y="131.62" width="22.63" height="21.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/webhook_coverage_test.go
+243 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="265.14" y="153.07" width="16.45" height="23.08" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/reconciliation.go
+190 loc · ccn 28 · commits (last 12mo) 3</title></rect>
+<rect x="265.14" y="176.15" width="16.45" height="19.56" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/consumer_test.go
+161 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="281.59" y="153.07" width="14.50" height="18.18" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/idempotency_test.go
+132 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="296.09" y="153.07" width="14.50" height="18.18" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/preflight_test.go
+132 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="281.59" y="171.26" width="15.93" height="12.66" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/consumer.go
+101 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="281.59" y="183.92" width="15.93" height="11.79" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/publisher_test.go
+94 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="297.52" y="171.26" width="13.07" height="13.30" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/publisher.go
+87 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="297.52" y="184.55" width="13.07" height="11.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/stripe/preflight.go
+73 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="243.07" y="195.71" width="38.22" height="35.91" fill="#f7cd9f" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/planner/manifest_planner_test.go
+687 loc · ccn 62 · commits (last 12mo) 7</title></rect>
+<rect x="243.07" y="231.62" width="16.83" height="21.01" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/planner/types.go
+177 loc · ccn 33 · commits (last 12mo) 11</title></rect>
+<rect x="259.90" y="231.62" width="14.83" height="21.01" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/planner/manifest_planner.go
+156 loc · ccn 30 · commits (last 12mo) 10</title></rect>
+<rect x="274.73" y="231.62" width="6.56" height="21.01" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/planner/manifest_planner_mappings_test.go
+69 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="281.29" y="195.71" width="29.30" height="27.88" fill="#e7c9b1" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/staff/service.go
+409 loc · ccn 83 · commits (last 12mo) 4</title></rect>
+<rect x="281.29" y="223.59" width="26.90" height="29.04" fill="#ecd3b3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/staff/service_test.go
+391 loc · ccn 49 · commits (last 12mo) 5</title></rect>
+<rect x="308.19" y="223.59" width="2.41" height="29.04" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/staff/entity.go
+35 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="243.07" y="252.63" width="29.69" height="22.27" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/server/interceptors_test.go
+331 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="243.07" y="274.91" width="29.69" height="9.35" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/server/interceptors.go
+139 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="272.76" y="252.63" width="21.03" height="14.06" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/scheduling/provider_test.go
+148 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="272.76" y="266.69" width="14.89" height="17.57" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/scheduling/provider.go
+131 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="287.66" y="266.69" width="6.14" height="11.39" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/scheduling/entity_test.go
+35 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="287.66" y="278.08" width="6.14" height="6.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/scheduling/entity.go
+19 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="293.79" y="252.63" width="16.80" height="25.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/apiauth/service_test.go
+214 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="293.79" y="278.08" width="16.80" height="6.18" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/internal/apiauth/service.go
+52 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="0.00" width="22.96" height="56.99" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/validate/starlark_test.go
+655 loc · ccn 95 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="56.99" width="22.96" height="35.41" fill="#e1c5b4" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/validate/starlark.go
+407 loc · ccn 105 · commits (last 12mo) 3</title></rect>
+<rect x="310.60" y="92.40" width="22.96" height="22.10" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/validate/main_test.go
+254 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="114.50" width="22.96" height="18.10" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/validate/main.go
+208 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="310.60" y="132.60" width="16.94" height="17.92" fill="#f7dcb7" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/main.go
+152 loc · ccn 26 · commits (last 12mo) 7</title></rect>
+<rect x="327.54" y="132.60" width="6.02" height="9.96" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/main_test.go
+30 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="327.54" y="142.56" width="6.02" height="7.97" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/control-plane/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="310.60" y="150.53" width="22.96" height="20.53" fill="#e7d7c5" stroke="white" stroke-width="0.5"><title>services/control-plane/service/bootstrap_test.go
+236 loc · ccn 25 · commits (last 12mo) 4</title></rect>
+<rect x="310.60" y="171.06" width="12.62" height="19.32" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/service/economy_generator_test.go
+122 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="323.21" y="171.06" width="10.34" height="19.32" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/service/manifest_history_test.go
+100 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="190.38" width="13.69" height="11.39" fill="#f2ddc2" stroke="white" stroke-width="0.5"><title>services/control-plane/service/manifest_history.go
+78 loc · ccn 16 · commits (last 12mo) 6</title></rect>
+<rect x="310.60" y="201.76" width="13.69" height="10.80" fill="#f2e0c7" stroke="white" stroke-width="0.5"><title>services/control-plane/service/apply_manifest.go
+74 loc · ccn 9 · commits (last 12mo) 6</title></rect>
+<rect x="324.28" y="190.38" width="9.27" height="9.91" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/control-plane/service/bootstrap.go
+46 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="324.28" y="200.29" width="9.27" height="7.11" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/service/economy_generator.go
+33 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="324.28" y="207.39" width="9.27" height="5.17" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/control-plane/service/apply_manifest_test.go
+24 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="212.56" width="12.61" height="21.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/deployment.yaml
+134 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="323.21" y="212.56" width="10.35" height="11.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/networkpolicy.yaml
+57 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="323.21" y="223.56" width="7.23" height="5.53" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/configmap.yaml
+20 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="323.21" y="229.09" width="7.23" height="4.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="330.43" y="223.56" width="3.12" height="5.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="330.43" y="229.32" width="3.12" height="4.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="233.79" width="19.65" height="16.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/rbac/method_permissions.go
+160 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="330.24" y="233.79" width="3.32" height="16.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/control-plane/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="250.06" width="22.96" height="15.66" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/control-plane/README.md
+180 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="310.60" y="265.73" width="11.48" height="6.96" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260209000001_staff_identity.sql
+40 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="322.07" y="265.73" width="6.31" height="6.96" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260317000001_platform_saga_definition.sql
+22 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="272.69" width="5.87" height="6.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260209000004_manifest_apply_jobs.sql
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="310.60" y="278.81" width="5.87" height="5.44" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260209000002_create_manifest_versions.sql
+16 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="316.47" y="272.69" width="4.84" height="5.78" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260406000001_create_tenant_schedule.sql
+14 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="316.47" y="278.47" width="4.84" height="5.78" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260330000002_align_platform_saga_definition_constraints.sql
+14 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="321.30" y="272.69" width="4.05" height="5.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260516000001_saga_definitions.sql
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="325.35" y="272.69" width="3.03" height="5.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260330000001_align_platform_saga_definition_columns.sql
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="321.30" y="278.62" width="3.54" height="2.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260401000002_migrate_version_to_varchar.sql
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="321.30" y="281.44" width="3.54" height="2.82" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260316000001_add_sequence_number_columns.sql
+5 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="324.84" y="278.62" width="2.12" height="2.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260401000003_rename_version_column.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="326.97" y="278.62" width="1.42" height="2.82" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260316000004_add_partial_apply_status_constraint.sql
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="324.84" y="281.44" width="1.42" height="2.82" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260316000002_add_phase_status.sql
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="326.26" y="281.44" width="1.06" height="1.88" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260316000003_add_partial_apply_status.sql
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="327.32" y="281.44" width="1.06" height="1.88" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260308000001_add_relationship_graph.sql
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="326.26" y="283.32" width="2.12" height="0.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/control-plane/migrations/20260401000001_add_version_varchar_column.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="328.38" y="265.73" width="5.17" height="18.53" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/control-plane/atlas/atlas.hcl
+48 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="333.56" y="0.00" width="55.85" height="55.01" fill="#fdbe87" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_service_test.go
+1538 loc · ccn 90 · commits (last 12mo) 22</title></rect>
+<rect x="333.56" y="55.01" width="55.85" height="51.04" fill="#fc935f" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_service_test.go
+1427 loc · ccn 138 · commits (last 12mo) 27</title></rect>
+<rect x="333.56" y="106.05" width="55.85" height="38.24" fill="#fcba83" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_service_integration_test.go
+1069 loc · ccn 98 · commits (last 12mo) 33</title></rect>
+<rect x="333.56" y="144.29" width="55.85" height="37.02" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_account_db_test.go
+1035 loc · ccn 54 · commits (last 12mo) 1</title></rect>
+<rect x="389.41" y="0.00" width="43.02" height="48.07" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_withdrawal_lien_test.go
+1035 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="389.41" y="48.07" width="43.02" height="44.96" fill="#d6cfcc" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_orchestrator_test.go
+968 loc · ccn 84 · commits (last 12mo) 1</title></rect>
+<rect x="389.41" y="93.02" width="43.02" height="44.54" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_posting_handler_test.go
+959 loc · ccn 59 · commits (last 12mo) 1</title></rect>
+<rect x="389.41" y="137.56" width="43.02" height="43.75" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_valuation_health_test.go
+942 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="432.43" y="0.00" width="46.33" height="39.71" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>services/current-account/service/coverage_saga_handler_test.go
+921 loc · ccn 90 · commits (last 12mo) 1</title></rect>
+<rect x="478.76" y="0.00" width="44.32" height="39.71" fill="#fdd49e" stroke="white" stroke-width="0.5"><title>services/current-account/service/withdrawal_test.go
+881 loc · ccn 49 · commits (last 12mo) 13</title></rect>
+<rect x="523.08" y="0.00" width="42.05" height="39.71" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_lifecycle_unit_test.go
+836 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="565.13" y="0.00" width="39.69" height="39.71" fill="#fddaaa" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_service_product_type_test.go
+789 loc · ccn 35 · commits (last 12mo) 9</title></rect>
+<rect x="432.43" y="39.71" width="30.17" height="40.07" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_lifecycle_coverage_test.go
+605 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="432.43" y="79.78" width="30.17" height="35.56" fill="#f7d4a5" stroke="white" stroke-width="0.5"><title>services/current-account/service/health_test.go
+537 loc · ccn 49 · commits (last 12mo) 7</title></rect>
+<rect x="432.43" y="115.35" width="30.17" height="34.84" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/current-account/service/valuation_engine_test.go
+526 loc · ccn 33 · commits (last 12mo) 8</title></rect>
+<rect x="432.43" y="150.18" width="30.17" height="31.13" fill="#fddaaa" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_service_party_integration_test.go
+470 loc · ccn 36 · commits (last 12mo) 13</title></rect>
+<rect x="462.60" y="39.71" width="30.32" height="30.57" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_execute_unit_test.go
+464 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="462.60" y="70.29" width="30.32" height="29.85" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/current-account/service/validators_test.go
+453 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="462.60" y="100.13" width="30.32" height="27.80" fill="#f7c192" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_lifecycle.go
+422 loc · ccn 89 · commits (last 12mo) 7</title></rect>
+<rect x="462.60" y="127.94" width="30.32" height="26.88" fill="#fde0b8" stroke="white" stroke-width="0.5"><title>services/current-account/service/valuation_feature_service_test.go
+408 loc · ccn 20 · commits (last 12mo) 8</title></rect>
+<rect x="462.60" y="154.82" width="30.32" height="26.49" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>services/current-account/service/validators.go
+402 loc · ccn 72 · commits (last 12mo) 3</title></rect>
+<rect x="492.92" y="39.71" width="29.18" height="25.19" fill="#e7cab1" stroke="white" stroke-width="0.5"><title>services/current-account/service/valuation_feature_service.go
+368 loc · ccn 80 · commits (last 12mo) 4</title></rect>
+<rect x="522.10" y="39.71" width="28.63" height="25.19" fill="#f7cd9f" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_control_endpoints.go
+361 loc · ccn 63 · commits (last 12mo) 7</title></rect>
+<rect x="550.73" y="39.71" width="27.84" height="25.19" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/current-account/service/server.go
+351 loc · ccn 49 · commits (last 12mo) 3</title></rect>
+<rect x="578.57" y="39.71" width="26.25" height="25.19" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/current-account/service/valuation_engine.go
+331 loc · ccn 41 · commits (last 12mo) 4</title></rect>
+<rect x="492.92" y="64.91" width="28.33" height="22.49" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_helpers.go
+319 loc · ccn 54 · commits (last 12mo) 3</title></rect>
+<rect x="521.25" y="64.91" width="28.15" height="22.49" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/current-account/service/account_resolver_test.go
+317 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="549.40" y="64.91" width="27.89" height="22.49" fill="#fdca94" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_execute.go
+314 loc · ccn 69 · commits (last 12mo) 12</title></rect>
+<rect x="577.29" y="64.91" width="27.53" height="22.49" fill="#ecd2b2" stroke="white" stroke-width="0.5"><title>services/current-account/service/health.go
+310 loc · ccn 50 · commits (last 12mo) 5</title></rect>
+<rect x="492.92" y="87.40" width="24.85" height="24.44" fill="#fdd5a1" stroke="white" stroke-width="0.5"><title>services/current-account/service/saga_handlers.go
+304 loc · ccn 46 · commits (last 12mo) 23</title></rect>
+<rect x="492.92" y="111.84" width="24.85" height="24.12" fill="#f2d0a8" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_manage.go
+300 loc · ccn 58 · commits (last 12mo) 6</title></rect>
+<rect x="492.92" y="135.96" width="24.85" height="22.75" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/current-account/service/saga_handler_financial_accounting.go
+283 loc · ccn 42 · commits (last 12mo) 3</title></rect>
+<rect x="492.92" y="158.71" width="24.85" height="22.59" fill="#fde1ba" stroke="white" stroke-width="0.5"><title>services/current-account/service/account_control_integration_test.go
+281 loc · ccn 17 · commits (last 12mo) 12</title></rect>
+<rect x="517.76" y="87.40" width="22.75" height="24.33" fill="#fdcd97" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_account_endpoints.go
+277 loc · ccn 62 · commits (last 12mo) 20</title></rect>
+<rect x="540.51" y="87.40" width="21.76" height="24.33" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_execute_integration_test.go
+265 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="562.28" y="87.40" width="21.43" height="24.33" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_manage_integration_test.go
+261 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="583.71" y="87.40" width="21.11" height="24.33" fill="#fddaac" stroke="white" stroke-width="0.5"><title>services/current-account/service/deposit_orchestrator.go
+257 loc · ccn 34 · commits (last 12mo) 18</title></rect>
+<rect x="517.76" y="111.73" width="20.47" height="24.79" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_lifecycle_helpers.go
+254 loc · ccn 67 · commits (last 12mo) 1</title></rect>
+<rect x="517.76" y="136.51" width="20.47" height="23.52" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>services/current-account/service/withdrawal_orchestrator.go
+241 loc · ccn 30 · commits (last 12mo) 17</title></rect>
+<rect x="517.76" y="160.03" width="20.47" height="21.27" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/control_outbox_integration_test.go
+218 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="538.24" y="111.73" width="23.25" height="18.30" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/current-account/service/saga_handler_position_keeping.go
+213 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="561.49" y="111.73" width="23.25" height="18.30" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/fungibility_validator_test.go
+213 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="584.73" y="111.73" width="20.08" height="18.30" fill="#fdd5a1" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_deposit_endpoints.go
+184 loc · ccn 46 · commits (last 12mo) 8</title></rect>
+<rect x="538.24" y="130.03" width="19.29" height="18.23" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>services/current-account/service/account_resolver.go
+176 loc · ccn 25 · commits (last 12mo) 5</title></rect>
+<rect x="538.24" y="148.26" width="19.29" height="18.02" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_withdrawal_tenant_isolation_test.go
+174 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="538.24" y="166.29" width="19.29" height="15.02" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_mappers.go
+145 loc · ccn 30 · commits (last 12mo) 10</title></rect>
+<rect x="557.52" y="130.03" width="15.89" height="15.46" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>services/current-account/service/saga_handlers_test.go
+123 loc · ccn 10 · commits (last 12mo) 4</title></rect>
+<rect x="573.42" y="130.03" width="15.77" height="15.46" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/current-account/service/fungibility_validator.go
+122 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="589.18" y="130.03" width="15.64" height="15.46" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/saga_valuation_analysis_test.go
+121 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="557.52" y="145.49" width="12.49" height="18.87" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_mappers_test.go
+118 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="557.52" y="164.36" width="12.49" height="16.95" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/deposit_orchestrator_test.go
+106 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="570.01" y="145.49" width="13.60" height="14.98" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/current-account/service/health_example_test.go
+102 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="583.62" y="145.49" width="10.67" height="14.98" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/withdrawal_orchestrator_test.go
+80 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="594.28" y="145.49" width="10.53" height="14.98" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_queries.go
+79 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="570.01" y="160.47" width="13.52" height="11.23" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/service/grpc_account_endpoints_test.go
+76 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="570.01" y="171.70" width="13.52" height="9.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/service/server_coverage_test.go
+65 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="583.53" y="160.47" width="9.11" height="11.41" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>services/current-account/service/lien_service.go
+52 loc · ccn 1 · commits (last 12mo) 23</title></rect>
+<rect x="583.53" y="171.88" width="9.11" height="9.43" fill="#f2e2cc" stroke="white" stroke-width="0.5"><title>services/current-account/service/client_interfaces.go
+43 loc · ccn 1 · commits (last 12mo) 6</title></rect>
+<rect x="592.64" y="160.47" width="6.18" height="11.32" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/testmain_test.go
+35 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="598.82" y="160.47" width="6.00" height="11.32" fill="#f8e5ca" stroke="white" stroke-width="0.5"><title>services/current-account/service/errors.go
+34 loc · ccn 1 · commits (last 12mo) 7</title></rect>
+<rect x="592.64" y="171.79" width="6.72" height="9.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/contract_test.go
+32 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="599.36" y="171.79" width="5.46" height="9.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/service/server_test.go
+26 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="333.56" y="181.31" width="45.75" height="40.91" fill="#fdc18b" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/repository_test.go
+937 loc · ccn 84 · commits (last 12mo) 22</title></rect>
+<rect x="379.31" y="181.31" width="41.36" height="40.91" fill="#fdd49e" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/lien_repository_test.go
+847 loc · ccn 49 · commits (last 12mo) 14</title></rect>
+<rect x="333.56" y="222.22" width="25.28" height="32.24" fill="#fdbd86" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/repository.go
+408 loc · ccn 92 · commits (last 12mo) 24</title></rect>
+<rect x="333.56" y="254.47" width="25.28" height="29.79" fill="#f2dabb" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/withdrawal_repository_test.go
+377 loc · ccn 26 · commits (last 12mo) 6</title></rect>
+<rect x="358.84" y="222.22" width="21.88" height="27.76" fill="#fdce98" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/lien_repository.go
+304 loc · ccn 61 · commits (last 12mo) 13</title></rect>
+<rect x="380.72" y="222.22" width="20.23" height="27.76" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/org_scoped_migration_test.go
+281 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="400.94" y="222.22" width="19.72" height="27.76" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/valuation_feature_repository_test.go
+274 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="358.84" y="249.98" width="25.64" height="20.34" fill="#fde2bd" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/org_scoped_account_test.go
+261 loc · ccn 15 · commits (last 12mo) 8</title></rect>
+<rect x="358.84" y="270.31" width="25.64" height="13.95" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/multi_asset_repository_test.go
+179 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="384.48" y="249.98" width="17.19" height="17.55" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/withdrawal_repository.go
+151 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="384.48" y="267.52" width="17.19" height="16.73" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/repository_mapping.go
+144 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="401.67" y="249.98" width="19.00" height="9.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/lien_entity_test.go
+92 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="401.67" y="259.65" width="9.91" height="14.72" fill="#fde6c3" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/account_entity.go
+73 loc · ccn 7 · commits (last 12mo) 12</title></rect>
+<rect x="411.57" y="259.65" width="9.09" height="14.72" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/repository_contract_test.go
+67 loc · ccn 3 · commits (last 12mo) 5</title></rect>
+<rect x="401.67" y="274.37" width="10.91" height="9.89" fill="#f8e3c7" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/lien_entity.go
+54 loc · ccn 6 · commits (last 12mo) 7</title></rect>
+<rect x="412.58" y="274.37" width="8.08" height="5.19" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/withdrawal_entity.go
+21 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="412.58" y="279.56" width="5.96" height="4.70" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/valuation_feature_repository.go
+14 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="418.54" y="279.56" width="2.13" height="4.70" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/current-account/adapters/persistence/valuation_feature_entity.go
+5 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="420.67" y="181.31" width="53.01" height="42.47" fill="#fcb982" stroke="white" stroke-width="0.5"><title>services/current-account/domain/account_test.go
+1127 loc · ccn 99 · commits (last 12mo) 14</title></rect>
+<rect x="420.67" y="223.78" width="27.05" height="27.47" fill="#fdc790" stroke="white" stroke-width="0.5"><title>services/current-account/domain/account.go
+372 loc · ccn 74 · commits (last 12mo) 18</title></rect>
+<rect x="447.72" y="223.78" width="25.96" height="27.47" fill="#f2d3ab" stroke="white" stroke-width="0.5"><title>services/current-account/domain/lien_test.go
+357 loc · ccn 51 · commits (last 12mo) 6</title></rect>
+<rect x="420.67" y="251.25" width="22.94" height="18.90" fill="#ecd6ba" stroke="white" stroke-width="0.5"><title>services/current-account/domain/quantity_test.go
+217 loc · ccn 37 · commits (last 12mo) 5</title></rect>
+<rect x="420.67" y="270.15" width="22.94" height="14.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/domain/valuation_feature_test.go
+162 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="443.60" y="251.25" width="16.23" height="16.74" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/current-account/domain/lien.go
+136 loc · ccn 29 · commits (last 12mo) 3</title></rect>
+<rect x="459.83" y="251.25" width="13.85" height="16.74" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/domain/withdrawal_test.go
+116 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="443.60" y="267.99" width="11.66" height="16.27" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/current-account/domain/account_builder.go
+95 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="455.27" y="267.99" width="10.68" height="16.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/domain/withdrawal.go
+87 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="465.95" y="267.99" width="7.73" height="11.37" fill="#f2e1c9" stroke="white" stroke-width="0.5"><title>services/current-account/domain/quantity.go
+44 loc · ccn 5 · commits (last 12mo) 6</title></rect>
+<rect x="465.95" y="279.35" width="7.73" height="4.91" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/current-account/domain/valuation_feature.go
+19 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="473.68" y="181.31" width="30.74" height="59.15" fill="#eccdad" stroke="white" stroke-width="0.5"><title>services/current-account/client/starlark_test.go
+910 loc · ccn 65 · commits (last 12mo) 5</title></rect>
+<rect x="504.42" y="181.31" width="32.02" height="21.96" fill="#ecd2b2" stroke="white" stroke-width="0.5"><title>services/current-account/client/starlark.go
+352 loc · ccn 52 · commits (last 12mo) 5</title></rect>
+<rect x="504.42" y="203.27" width="32.02" height="21.21" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/current-account/client/client_test.go
+340 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="504.42" y="224.48" width="32.02" height="15.97" fill="#f2d1aa" stroke="white" stroke-width="0.5"><title>services/current-account/client/client.go
+256 loc · ccn 55 · commits (last 12mo) 6</title></rect>
+<rect x="473.68" y="240.46" width="62.76" height="43.80" fill="#eba386" stroke="white" stroke-width="0.5"><title>services/current-account/e2e/saga_compensation_test.go
+1376 loc · ccn 150 · commits (last 12mo) 5</title></rect>
+<rect x="536.44" y="181.31" width="24.56" height="28.15" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/current-account/webhook/notifier.go
+346 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="560.99" y="181.31" width="19.52" height="28.15" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>services/current-account/webhook/notifier_test.go
+275 loc · ccn 23 · commits (last 12mo) 4</title></rect>
+<rect x="536.44" y="209.46" width="30.05" height="17.95" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/current-account/webhook/repository_test.go
+270 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="566.48" y="209.46" width="14.02" height="17.95" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/current-account/webhook/repository.go
+126 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="580.51" y="181.31" width="24.31" height="24.90" fill="#e7cdb5" stroke="white" stroke-width="0.5"><title>services/current-account/observability/metrics_test.go
+303 loc · ccn 69 · commits (last 12mo) 4</title></rect>
+<rect x="580.51" y="206.21" width="24.31" height="21.20" fill="#fddfb5" stroke="white" stroke-width="0.5"><title>services/current-account/observability/metrics.go
+258 loc · ccn 24 · commits (last 12mo) 10</title></rect>
+<rect x="536.44" y="227.41" width="25.48" height="14.19" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/current-account/cmd/main.go
+181 loc · ccn 32 · commits (last 12mo) 37</title></rect>
+<rect x="536.44" y="241.60" width="17.82" height="15.13" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/current-account/cmd/party_wrapper_test.go
+135 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="554.26" y="241.60" width="7.66" height="8.35" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/current-account/cmd/main_test.go
+32 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="554.26" y="249.95" width="7.66" height="6.78" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/current-account/cmd/Dockerfile
+26 loc · ccn 4 · commits (last 12mo) 11</title></rect>
+<rect x="536.44" y="256.74" width="25.48" height="14.59" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/deployment.yaml
+186 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="536.44" y="271.32" width="16.21" height="12.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/networkpolicy.yaml
+105 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="552.65" y="271.32" width="9.26" height="5.82" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/configmap.yaml
+27 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="552.65" y="277.14" width="4.77" height="7.12" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="557.42" y="277.14" width="4.49" height="4.00" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="557.42" y="281.15" width="4.49" height="3.11" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="561.91" y="227.41" width="12.17" height="10.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251216000002_audit_system.sql
+63 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="574.08" y="227.41" width="11.01" height="10.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251216000001_initial.sql
+57 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="561.91" y="237.75" width="9.25" height="9.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260206000001_create_valuation_features.sql
+46 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="561.91" y="247.69" width="9.25" height="9.29" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251231000001_add_webhook_deliveries.sql
+43 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="571.16" y="237.75" width="7.60" height="6.31" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251231000002_create_withdrawal_table.sql
+24 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="578.76" y="237.75" width="6.33" height="6.31" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260226000004_backfill_precision.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="571.16" y="244.06" width="4.95" height="8.07" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260204000001_create_event_outbox.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="571.16" y="252.13" width="4.95" height="4.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260226000003_add_precision_columns.sql
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="576.11" y="244.06" width="5.13" height="3.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251224000001_add_status_audit_trail.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="581.24" y="244.06" width="3.85" height="3.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="576.11" y="247.18" width="3.45" height="2.89" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260108000001_remove_balance_columns.sql
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="579.57" y="247.18" width="2.76" height="2.89" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260226000002_backfill_behavior_class.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="582.33" y="247.18" width="2.76" height="2.89" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="576.11" y="250.07" width="2.61" height="2.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260214000002_add_org_scoping_indexes.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="576.11" y="252.37" width="2.61" height="2.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260225000001_add_instrument_columns.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="576.11" y="254.67" width="2.61" height="2.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260206000003_add_lien_valuation_fields.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="578.72" y="250.07" width="2.39" height="2.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20251217000001_fix_audit_status_constraint.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="581.11" y="250.07" width="2.39" height="2.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260214000001_add_org_party_id.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="583.50" y="250.07" width="1.59" height="2.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260220000001_add_product_type_columns.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="578.72" y="252.58" width="1.82" height="2.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260206000002_backfill_identity_valuation_features.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="578.72" y="254.78" width="1.82" height="2.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260105000001_add_lien_bucket_id.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="580.54" y="252.58" width="1.82" height="2.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260306000001_drop_legacy_currency_columns.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="580.54" y="254.78" width="1.82" height="1.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260226000001_add_behavior_class_column.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="580.54" y="255.88" width="1.82" height="1.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260220000002_add_product_type_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="582.36" y="252.58" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260416000001_drop_syndicate_scope_integrity_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="583.72" y="252.58" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260225000002_migrate_currency_data.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="582.36" y="254.05" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260225000004_drop_currency_column.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="583.72" y="254.05" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260225000003_recreate_scope_integrity_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="582.36" y="255.51" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260316000001_add_event_outbox_tenant_id.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="583.72" y="255.51" width="1.36" height="1.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/migrations/20260316000002_add_event_outbox_tenant_id_index.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="585.09" y="227.41" width="19.73" height="21.16" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/current-account/app/container.go
+209 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="585.09" y="248.57" width="19.73" height="8.40" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/app/container_test.go
+83 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="561.91" y="256.97" width="14.57" height="27.29" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>services/current-account/README.md
+199 loc · ccn 0 · commits (last 12mo) 10</title></rect>
+<rect x="576.48" y="256.97" width="14.88" height="15.17" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/current-account/config/accounts_test.go
+113 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="591.36" y="256.97" width="4.08" height="15.17" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/current-account/config/accounts.go
+31 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="576.48" y="272.14" width="14.51" height="12.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/current-account/rbac/method_permissions.go
+88 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="590.99" y="272.14" width="4.45" height="12.12" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/current-account/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="595.45" y="256.97" width="9.37" height="9.81" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/testhelpers/factories.go
+46 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="595.45" y="266.78" width="9.37" height="4.48" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/current-account/testhelpers/factories_test.go
+21 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="595.45" y="271.26" width="9.37" height="13.00" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/current-account/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="604.82" y="0.00" width="70.62" height="47.95" fill="#ecd2b2" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/record_measurement_test.go
+1695 loc · ccn 51 · commits (last 12mo) 5</title></rect>
+<rect x="675.44" y="0.00" width="41.87" height="47.95" fill="#e7cbb3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/adapters_test.go
+1005 loc · ccn 75 · commits (last 12mo) 4</title></rect>
+<rect x="717.32" y="0.00" width="40.12" height="47.95" fill="#e1c3b2" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/account_validator_test.go
+963 loc · ccn 111 · commits (last 12mo) 3</title></rect>
+<rect x="604.82" y="47.95" width="37.52" height="45.69" fill="#f2cfa7" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/balance_integration_test.go
+858 loc · ccn 61 · commits (last 12mo) 6</title></rect>
+<rect x="604.82" y="93.64" width="37.52" height="44.68" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_migration_test.go
+839 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="604.82" y="138.32" width="37.52" height="31.31" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_migration_integration_test.go
+588 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="642.33" y="47.95" width="35.02" height="33.20" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/balance_test.go
+582 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="677.35" y="47.95" width="30.39" height="33.20" fill="#ecd6bb" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_batch_test.go
+505 loc · ccn 35 · commits (last 12mo) 5</title></rect>
+<rect x="707.74" y="47.95" width="26.17" height="33.20" fill="#e7d9c9" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/list_test.go
+435 loc · ccn 16 · commits (last 12mo) 4</title></rect>
+<rect x="733.91" y="47.95" width="23.53" height="33.20" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_validation_test.go
+391 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="642.33" y="81.15" width="25.79" height="29.75" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/reservation_test.go
+384 loc · ccn 48 · commits (last 12mo) 3</title></rect>
+<rect x="642.33" y="110.90" width="25.79" height="29.44" fill="#e7d5bf" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_test.go
+380 loc · ccn 37 · commits (last 12mo) 4</title></rect>
+<rect x="642.33" y="140.34" width="25.79" height="29.29" fill="#fdbb84" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/update.go
+378 loc · ccn 96 · commits (last 12mo) 9</title></rect>
+<rect x="668.12" y="81.15" width="27.37" height="26.28" fill="#e7ccb3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/account_validator.go
+360 loc · ccn 74 · commits (last 12mo) 4</title></rect>
+<rect x="668.12" y="107.43" width="27.37" height="22.92" fill="#ecccac" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/record_measurement.go
+314 loc · ccn 70 · commits (last 12mo) 5</title></rect>
+<rect x="668.12" y="130.35" width="27.37" height="19.78" fill="#fdcc96" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate.go
+271 loc · ccn 64 · commits (last 12mo) 9</title></rect>
+<rect x="668.12" y="150.14" width="27.37" height="19.49" fill="#e7d1b9" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_batch.go
+267 loc · ccn 53 · commits (last 12mo) 4</title></rect>
+<rect x="695.48" y="81.15" width="20.92" height="25.02" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/update_test.go
+262 loc · ccn 6 · commits (last 12mo) 3</title></rect>
+<rect x="716.40" y="81.15" width="20.68" height="25.02" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/update_status_transitions_test.go
+259 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="737.08" y="81.15" width="20.36" height="25.02" fill="#eccfaf" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_migration.go
+255 loc · ccn 61 · commits (last 12mo) 5</title></rect>
+<rect x="695.48" y="106.17" width="23.58" height="17.96" fill="#f2d5af" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/adapters.go
+212 loc · ccn 45 · commits (last 12mo) 6</title></rect>
+<rect x="719.07" y="106.17" width="19.47" height="17.96" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/server_coverage_test.go
+175 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="738.53" y="106.17" width="18.91" height="17.96" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/update_context_test.go
+170 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="695.48" y="124.13" width="20.20" height="15.63" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/balance.go
+158 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="695.48" y="139.76" width="20.20" height="15.53" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/reservation.go
+157 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="695.48" y="155.29" width="20.20" height="14.34" fill="#f2dfc5" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/service_test.go
+145 loc · ccn 11 · commits (last 12mo) 6</title></rect>
+<rect x="715.68" y="124.13" width="14.87" height="18.28" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/grpc_log_endpoints.go
+136 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="730.55" y="124.13" width="14.10" height="18.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/initiate_internal_test.go
+129 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="744.65" y="124.13" width="12.79" height="18.28" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/retrieve_test.go
+117 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="715.68" y="142.41" width="16.15" height="13.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/append_only_guard_test.go
+111 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="715.68" y="156.14" width="16.15" height="13.49" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/server.go
+109 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="731.83" y="142.41" width="13.01" height="14.43" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/metrics_test.go
+94 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="744.84" y="142.41" width="12.60" height="14.43" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/append_only_blocked_test.go
+91 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="731.83" y="156.84" width="8.75" height="12.79" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/metrics.go
+56 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="740.57" y="156.84" width="6.72" height="12.79" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/metrics_coverage_test.go
+43 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="747.29" y="156.84" width="10.15" height="6.10" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/append_only_guard.go
+31 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="747.29" y="162.94" width="8.06" height="6.69" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/append_only_blocked.go
+27 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="755.35" y="162.94" width="2.09" height="5.74" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/export_test.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="755.35" y="168.67" width="2.09" height="0.96" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/position-keeping/service/doc.go
+1 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="757.44" y="0.00" width="68.59" height="46.51" fill="#bc9ca0" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/financial_position_log_test.go
+1597 loc · ccn 336 · commits (last 12mo) 2</title></rect>
+<rect x="826.04" y="0.00" width="47.59" height="46.51" fill="#dcc9bf" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/balance_computer_test.go
+1108 loc · ccn 107 · commits (last 12mo) 2</title></rect>
+<rect x="757.44" y="46.51" width="31.98" height="30.11" fill="#ecccac" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/money_test.go
+482 loc · ccn 69 · commits (last 12mo) 5</title></rect>
+<rect x="789.42" y="46.51" width="31.78" height="30.11" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/events_test.go
+479 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="821.21" y="46.51" width="27.60" height="30.11" fill="#dcc9bf" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_lineage_test.go
+416 loc · ccn 105 · commits (last 12mo) 2</title></rect>
+<rect x="848.81" y="46.51" width="24.82" height="30.11" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/audit_trail_entry_test.go
+374 loc · ccn 58 · commits (last 12mo) 1</title></rect>
+<rect x="757.44" y="76.62" width="26.76" height="23.96" fill="#f2d5b0" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/events.go
+321 loc · ccn 43 · commits (last 12mo) 6</title></rect>
+<rect x="757.44" y="100.58" width="26.76" height="23.89" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/events_validation_test.go
+320 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="757.44" y="124.47" width="17.70" height="22.69" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/testfixtures/fixtures.go
+201 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="775.14" y="124.47" width="9.07" height="22.69" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/testfixtures/fixtures_test.go
+103 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="757.44" y="147.16" width="26.76" height="22.47" fill="#e7cdb4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/financial_position_log.go
+301 loc · ccn 70 · commits (last 12mo) 4</title></rect>
+<rect x="784.21" y="76.62" width="24.98" height="23.75" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_log_entry_test.go
+297 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="809.19" y="76.62" width="22.12" height="23.75" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/quantity_test.go
+263 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="831.31" y="76.62" width="21.70" height="23.75" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/balance_computer.go
+258 loc · ccn 52 · commits (last 12mo) 2</title></rect>
+<rect x="853.02" y="76.62" width="20.61" height="23.75" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/status_tracking_test.go
+245 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="784.21" y="100.37" width="20.34" height="23.87" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/financial_position_log_bench_test.go
+243 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="784.21" y="124.24" width="20.34" height="22.99" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/balance_test.go
+234 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="784.21" y="147.23" width="20.34" height="22.40" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/events_bench_test.go
+228 loc · ccn 28 · commits (last 12mo) 2</title></rect>
+<rect x="804.54" y="100.37" width="21.02" height="20.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/position_test.go
+213 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="825.56" y="100.37" width="17.27" height="20.24" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/event_publisher_test.go
+175 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="842.83" y="100.37" width="16.19" height="20.24" fill="#f7dab3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/quantity.go
+164 loc · ccn 31 · commits (last 12mo) 7</title></rect>
+<rect x="859.02" y="100.37" width="14.61" height="20.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/measurement_test.go
+148 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="804.54" y="120.61" width="15.41" height="18.93" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_status_test.go
+146 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="804.54" y="139.54" width="15.41" height="15.56" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/posting_direction_test.go
+120 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="804.54" y="155.10" width="15.41" height="14.52" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/money_bench_test.go
+112 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="819.95" y="120.61" width="12.55" height="16.87" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/measurement.go
+106 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="819.95" y="137.48" width="12.55" height="16.07" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/amount_integration_test.go
+101 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="819.95" y="153.55" width="12.55" height="16.07" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/reservation_test.go
+101 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="832.50" y="120.61" width="14.48" height="13.80" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/reservation.go
+100 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="846.98" y="120.61" width="14.48" height="13.80" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/reconciliation_status_test.go
+100 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="861.46" y="120.61" width="12.16" height="13.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_source_test.go
+84 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="832.50" y="134.41" width="13.39" height="12.39" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_lineage.go
+83 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="832.50" y="146.80" width="13.39" height="11.64" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/position.go
+78 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="832.50" y="158.44" width="13.39" height="11.19" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_status.go
+75 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="845.89" y="134.41" width="15.18" height="9.87" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/status_contract_test.go
+75 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="861.07" y="134.41" width="12.55" height="9.87" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_log_entry.go
+62 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="845.89" y="144.28" width="8.98" height="13.34" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/repository.go
+60 loc · ccn 1 · commits (last 12mo) 9</title></rect>
+<rect x="845.89" y="157.62" width="8.98" height="12.01" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/event_publisher.go
+54 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="854.87" y="144.28" width="9.58" height="10.01" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/status_tracking.go
+48 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="864.45" y="144.28" width="9.18" height="10.01" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/audit_trail_entry.go
+46 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="854.87" y="154.29" width="9.25" height="8.21" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/balance.go
+38 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="854.87" y="162.50" width="9.25" height="7.13" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/transaction_source.go
+33 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="864.12" y="154.29" width="9.51" height="5.46" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/reconciliation_status.go
+26 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="864.12" y="159.75" width="9.51" height="5.25" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/posting_direction.go
+25 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="864.12" y="165.01" width="9.08" height="4.62" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/current_account_client.go
+21 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="873.19" y="165.01" width="0.43" height="4.62" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/domain/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="604.82" y="169.63" width="42.77" height="37.74" fill="#e1c9b7" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_repository_test.go
+808 loc · ccn 95 · commits (last 12mo) 3</title></rect>
+<rect x="647.59" y="169.63" width="28.21" height="37.74" fill="#d6cdcb" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/postgres_repository_bench_test.go
+533 loc · ccn 102 · commits (last 12mo) 1</title></rect>
+<rect x="675.80" y="169.63" width="27.21" height="37.74" fill="#e1c6b5" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_read.go
+514 loc · ccn 104 · commits (last 12mo) 3</title></rect>
+<rect x="604.82" y="207.37" width="28.50" height="34.69" fill="#f8dfbc" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/postgres_repository_test.go
+495 loc · ccn 19 · commits (last 12mo) 7</title></rect>
+<rect x="604.82" y="242.07" width="28.50" height="22.57" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_write.go
+322 loc · ccn 63 · commits (last 12mo) 2</title></rect>
+<rect x="604.82" y="264.63" width="28.50" height="19.63" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_repository_position.go
+280 loc · ccn 70 · commits (last 12mo) 2</title></rect>
+<rect x="633.32" y="207.37" width="23.79" height="22.50" fill="#e7d0b8" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/measurement_repository.go
+268 loc · ccn 56 · commits (last 12mo) 4</title></rect>
+<rect x="657.11" y="207.37" width="22.99" height="22.50" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/measurement_repository_test.go
+259 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="680.10" y="207.37" width="16.78" height="22.50" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/testhelpers/schema.sql
+189 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="696.88" y="207.37" width="6.13" height="22.50" fill="#fde6c5" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+69 loc · ccn 5 · commits (last 12mo) 8</title></rect>
+<rect x="633.32" y="229.88" width="24.65" height="20.02" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_repository_query.go
+247 loc · ccn 47 · commits (last 12mo) 1</title></rect>
+<rect x="633.32" y="249.89" width="24.65" height="18.07" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_filter_test.go
+223 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="633.32" y="267.97" width="24.65" height="16.29" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/reservation_repository.go
+201 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="657.97" y="229.88" width="22.70" height="16.37" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/reservation_repository_test.go
+186 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="680.67" y="229.88" width="22.34" height="16.37" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_read_test.go
+183 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="657.97" y="246.24" width="15.77" height="21.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_write_test.go
+168 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="657.97" y="267.53" width="15.77" height="16.73" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_batch.go
+132 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="673.74" y="246.24" width="14.81" height="17.68" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/outbox_repository_test.go
+131 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="688.54" y="246.24" width="14.47" height="17.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_log_batch_test.go
+128 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="673.74" y="263.92" width="10.22" height="20.34" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_repository_tx_test.go
+104 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="683.95" y="263.92" width="10.73" height="16.56" fill="#fde0b8" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/postgres_repository.go
+89 loc · ccn 20 · commits (last 12mo) 13</title></rect>
+<rect x="694.69" y="263.92" width="8.32" height="16.56" fill="#f2dec4" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/position_repository.go
+69 loc · ccn 13 · commits (last 12mo) 6</title></rect>
+<rect x="683.95" y="280.49" width="19.06" height="3.77" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/persistence/reservation_repository_extra_test.go
+36 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="703.01" y="169.63" width="33.01" height="57.68" fill="#e7d2b9" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/balance_mapper_test.go
+953 loc · ccn 52 · commits (last 12mo) 4</title></rect>
+<rect x="703.01" y="227.31" width="33.01" height="23.48" fill="#ecdac3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/messaging/kafka_event_publisher_test.go
+388 loc · ccn 21 · commits (last 12mo) 5</title></rect>
+<rect x="703.01" y="250.79" width="14.79" height="22.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/messaging/outbox_event_publisher_test.go
+164 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="717.80" y="250.79" width="18.22" height="12.39" fill="#f2ddc2" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/messaging/kafka_event_publisher.go
+113 loc · ccn 16 · commits (last 12mo) 6</title></rect>
+<rect x="717.80" y="263.18" width="18.22" height="9.76" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/messaging/outbox_event_publisher.go
+89 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="703.01" y="272.94" width="33.01" height="11.32" fill="#e7d3bb" stroke="white" stroke-width="0.5"><title>services/position-keeping/adapters/balance_mapper.go
+187 loc · ccn 47 · commits (last 12mo) 4</title></rect>
+<rect x="736.02" y="169.63" width="40.51" height="39.65" fill="#f09b77" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/config_test.go
+804 loc · ccn 149 · commits (last 12mo) 6</title></rect>
+<rect x="776.53" y="169.63" width="23.33" height="39.65" fill="#fdca94" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/container.go
+463 loc · ccn 68 · commits (last 12mo) 15</title></rect>
+<rect x="736.02" y="209.28" width="21.82" height="28.57" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/container_init_test.go
+312 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="757.83" y="209.28" width="16.92" height="28.57" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/config.go
+242 loc · ccn 32 · commits (last 12mo) 8</title></rect>
+<rect x="774.75" y="209.28" width="12.91" height="22.13" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/container_test.go
+143 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="787.66" y="209.28" width="12.19" height="22.13" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/container_redis_test.go
+135 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="774.75" y="231.40" width="25.10" height="6.45" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/app/container_close.go
+81 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="736.02" y="237.85" width="37.28" height="25.99" fill="#e1cbba" stroke="white" stroke-width="0.5"><title>services/position-keeping/worker/compaction_worker.go
+485 loc · ccn 81 · commits (last 12mo) 3</title></rect>
+<rect x="736.02" y="263.84" width="37.28" height="20.42" fill="#e1ccbb" stroke="white" stroke-width="0.5"><title>services/position-keeping/worker/compaction_worker_test.go
+381 loc · ccn 78 · commits (last 12mo) 3</title></rect>
+<rect x="773.29" y="237.85" width="26.56" height="24.97" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/worker/compaction_worker_integration_test.go
+332 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="773.29" y="262.82" width="17.52" height="21.44" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/worker/compaction_worker_unhappy_test.go
+188 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="790.81" y="262.82" width="9.04" height="21.44" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/worker/metrics.go
+97 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="799.85" y="169.63" width="32.19" height="22.16" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/client_unhappy_test.go
+357 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="799.85" y="191.79" width="32.19" height="16.95" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/starlark_test.go
+273 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="832.04" y="169.63" width="24.83" height="21.24" fill="#e7d9c8" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/client_test.go
+264 loc · ccn 17 · commits (last 12mo) 4</title></rect>
+<rect x="832.04" y="190.87" width="24.83" height="17.86" fill="#ecd3b5" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/client.go
+222 loc · ccn 46 · commits (last 12mo) 5</title></rect>
+<rect x="856.87" y="169.63" width="16.76" height="20.86" fill="#f2dcbe" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/starlark.go
+175 loc · ccn 22 · commits (last 12mo) 6</title></rect>
+<rect x="856.87" y="190.49" width="16.76" height="18.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/client/starlark_unhappy_test.go
+153 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="799.85" y="208.73" width="24.32" height="36.23" fill="#fdc68f" stroke="white" stroke-width="0.5"><title>services/position-keeping/cmd/main.go
+441 loc · ccn 75 · commits (last 12mo) 25</title></rect>
+<rect x="824.17" y="208.73" width="20.62" height="24.51" fill="#f2d2ab" stroke="white" stroke-width="0.5"><title>services/position-keeping/cmd/main_test.go
+253 loc · ccn 52 · commits (last 12mo) 6</title></rect>
+<rect x="824.17" y="233.24" width="16.53" height="11.72" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/cmd/idempotency_test.go
+97 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="840.70" y="233.24" width="4.09" height="11.72" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/position-keeping/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 10</title></rect>
+<rect x="844.79" y="208.73" width="28.84" height="36.23" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/position-keeping/e2e/e2e_test.go
+523 loc · ccn 67 · commits (last 12mo) 2</title></rect>
+<rect x="799.85" y="244.97" width="14.48" height="16.55" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20251216000001_initial.sql
+120 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="814.34" y="244.97" width="9.41" height="16.55" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20251223000002_fix_audit_schema_compatibility.sql
+78 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="799.85" y="261.52" width="8.61" height="14.62" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20251217000001_audit_system.sql
+63 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="799.85" y="276.14" width="8.61" height="8.12" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260105000004_import_manifest.sql
+35 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="808.46" y="261.52" width="8.63" height="8.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20251223000001_event_outbox.sql
+35 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="817.09" y="261.52" width="6.66" height="8.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260105000003_rebucketing_audit_log.sql
+27 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="808.46" y="269.62" width="6.55" height="7.62" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260105000002_positions_append_only.sql
+25 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="808.46" y="277.25" width="6.55" height="7.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20251231000001_measurements.sql
+23 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="815.01" y="269.62" width="8.74" height="4.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260207000001_reservations.sql
+21 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="815.01" y="274.42" width="5.70" height="5.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260104000001_multi_asset_columns.sql
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="820.71" y="274.42" width="3.04" height="5.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260306000001_widen_currency_columns.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="815.01" y="279.69" width="2.62" height="4.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260105000001_measurement_bucket_id.sql
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="817.64" y="279.69" width="2.62" height="4.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="820.26" y="279.69" width="3.49" height="2.29" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="820.26" y="281.97" width="1.75" height="2.29" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260309000001_add_account_service_domain.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="822.00" y="281.97" width="1.75" height="1.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260316000001_add_event_outbox_tenant_id.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="822.00" y="283.12" width="1.75" height="1.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/migrations/20260316000002_add_event_outbox_tenant_id_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="823.75" y="244.97" width="16.60" height="11.31" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/redis_health_test.go
+94 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="823.75" y="256.28" width="16.60" height="8.43" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/health_test.go
+70 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="840.35" y="244.97" width="8.27" height="11.35" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/redis_health.go
+47 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="848.62" y="244.97" width="7.21" height="11.35" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/health.go
+41 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="840.35" y="256.32" width="8.58" height="8.39" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/metrics.go
+36 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="848.92" y="256.32" width="6.91" height="8.39" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/observability/metrics_test.go
+29 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="823.75" y="264.71" width="19.00" height="19.55" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/deployment.yaml
+186 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="842.75" y="264.71" width="13.08" height="11.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/networkpolicy.yaml
+72 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="842.75" y="275.70" width="5.37" height="8.55" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/configmap.yaml
+23 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="848.12" y="275.70" width="7.71" height="4.41" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="848.12" y="280.11" width="4.33" height="4.15" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="852.46" y="280.11" width="3.37" height="4.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="855.83" y="244.97" width="17.79" height="20.54" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/position-keeping/README.md
+183 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="855.83" y="265.51" width="12.74" height="10.67" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/rbac/method_permissions.go
+68 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="868.57" y="265.51" width="5.06" height="10.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/position-keeping/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="855.83" y="276.18" width="15.08" height="8.08" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/position-keeping/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="870.91" y="276.18" width="2.72" height="8.08" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/position-keeping/testhelpers/factories.go
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="284.26" width="57.69" height="33.94" fill="#fcb982" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/grpc_handler_test.go
+980 loc · ccn 99 · commits (last 12mo) 11</title></rect>
+<rect x="57.69" y="284.26" width="43.15" height="33.94" fill="#e7cfb7" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_validator_test.go
+733 loc · ccn 61 · commits (last 12mo) 4</title></rect>
+<rect x="0.00" y="318.20" width="40.32" height="27.80" fill="#ecd1b1" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/postgres_registry_test.go
+561 loc · ccn 55 · commits (last 12mo) 5</title></rect>
+<rect x="40.32" y="318.20" width="31.26" height="27.80" fill="#f7c293" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_validator.go
+435 loc · ccn 88 · commits (last 12mo) 7</title></rect>
+<rect x="71.59" y="318.20" width="29.25" height="27.80" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/validate_saga_test.go
+407 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="0.00" y="345.99" width="25.70" height="28.29" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/cache_test.go
+364 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="374.29" width="25.70" height="27.83" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/cached_registry_test.go
+358 loc · ccn 55 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="402.11" width="25.70" height="22.93" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/cache.go
+295 loc · ccn 60 · commits (last 12mo) 1</title></rect>
+<rect x="25.70" y="345.99" width="28.01" height="19.97" fill="#e1c6b5" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_extractor.go
+280 loc · ccn 103 · commits (last 12mo) 3</title></rect>
+<rect x="53.72" y="345.99" width="23.61" height="19.97" fill="#f7d4a7" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/seeder.go
+236 loc · ccn 48 · commits (last 12mo) 7</title></rect>
+<rect x="77.33" y="345.99" width="23.51" height="19.97" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/postgres_registry_write.go
+235 loc · ccn 53 · commits (last 12mo) 3</title></rect>
+<rect x="25.70" y="365.96" width="20.19" height="19.79" fill="#fde2bd" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/seeder_test.go
+200 loc · ccn 15 · commits (last 12mo) 14</title></rect>
+<rect x="25.70" y="385.75" width="20.19" height="19.79" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/grpc_handler_lifecycle.go
+200 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="25.70" y="405.55" width="20.19" height="19.50" fill="#fdd8a6" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/grpc_handler.go
+197 loc · ccn 40 · commits (last 12mo) 9</title></rect>
+<rect x="45.89" y="365.96" width="19.51" height="20.07" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/product_type_resolver_test.go
+196 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="65.40" y="365.96" width="18.22" height="20.07" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/grpc_handler_validation.go
+183 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="83.62" y="365.96" width="17.22" height="20.07" fill="#fddaaa" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/postgres_registry.go
+173 loc · ccn 36 · commits (last 12mo) 11</title></rect>
+<rect x="45.89" y="386.03" width="16.85" height="20.28" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_extractor_test.go
+171 loc · ccn 27 · commits (last 12mo) 5</title></rect>
+<rect x="45.89" y="406.31" width="16.85" height="18.74" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/grpc_handler_query.go
+158 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="62.74" y="386.03" width="19.13" height="13.06" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_helpers.go
+125 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="81.86" y="386.03" width="18.97" height="13.06" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/postgres_registry_read.go
+124 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="62.74" y="399.09" width="15.70" height="14.00" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/testhelpers_test.go
+110 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="62.74" y="413.08" width="15.70" height="11.96" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/cached_registry.go
+94 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="78.44" y="399.09" width="12.80" height="13.74" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/reference_helpers_test.go
+88 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="91.24" y="399.09" width="9.60" height="13.74" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/registry.go
+66 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="78.44" y="412.82" width="10.30" height="12.22" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/e2e_seeder_test.go
+63 loc · ccn 4 · commits (last 12mo) 10</title></rect>
+<rect x="88.74" y="412.82" width="12.10" height="7.27" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/product_type_resolver.go
+44 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="88.74" y="420.09" width="12.10" height="4.95" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/saga/testmain_test.go
+30 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="425.04" width="46.76" height="39.35" fill="#e6bfa6" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/grpc_handler_test.go
+921 loc · ccn 112 · commits (last 12mo) 4</title></rect>
+<rect x="46.76" y="425.04" width="27.72" height="39.35" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_handler_test.go
+546 loc · ccn 74 · commits (last 12mo) 2</title></rect>
+<rect x="74.49" y="425.04" width="26.35" height="39.35" fill="#f7b485" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/grpc_handler.go
+519 loc · ccn 109 · commits (last 12mo) 7</title></rect>
+<rect x="0.00" y="464.39" width="26.08" height="36.62" fill="#dccbc1" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/mapping_handler.go
+478 loc · ccn 98 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="501.01" width="26.08" height="35.85" fill="#d6cfcc" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/node_handler.go
+468 loc · ccn 83 · commits (last 12mo) 1</title></rect>
+<rect x="26.08" y="464.39" width="24.12" height="36.69" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/mapping_handler_test.go
+443 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="26.08" y="501.08" width="24.12" height="35.78" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_handler_error_test.go
+432 loc · ccn 49 · commits (last 12mo) 1</title></rect>
+<rect x="50.20" y="464.39" width="27.17" height="29.11" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/node_handler_test.go
+396 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="77.37" y="464.39" width="23.47" height="29.11" fill="#f2c69f" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_handler.go
+342 loc · ccn 82 · commits (last 12mo) 6</title></rect>
+<rect x="50.20" y="493.50" width="18.85" height="24.28" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_helpers_test.go
+229 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="50.20" y="517.78" width="18.85" height="19.08" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_create.go
+180 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="69.04" y="493.50" width="18.23" height="19.73" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_query.go
+180 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="87.27" y="493.50" width="13.57" height="19.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/mapping_conversions_test.go
+134 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="69.04" y="513.23" width="19.36" height="12.07" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/node_error_mapping_test.go
+117 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="69.04" y="525.31" width="19.36" height="11.56" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/pagination_test.go
+112 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="88.41" y="513.23" width="12.43" height="16.72" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/account_type_update.go
+104 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="88.41" y="529.95" width="12.43" height="6.91" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/handler/pagination.go
+43 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="100.84" y="284.26" width="29.51" height="42.45" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/tiered_cache_test.go
+627 loc · ccn 62 · commits (last 12mo) 3</title></rect>
+<rect x="100.84" y="326.71" width="29.51" height="36.09" fill="#e1d0be" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/account_type_cache_test.go
+533 loc · ccn 61 · commits (last 12mo) 3</title></rect>
+<rect x="130.34" y="284.26" width="34.99" height="29.92" fill="#e1ccba" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/instrument_cache_test.go
+524 loc · ccn 80 · commits (last 12mo) 3</title></rect>
+<rect x="165.33" y="284.26" width="29.11" height="29.92" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/redis_cache_test.go
+436 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="130.34" y="314.18" width="25.80" height="26.48" fill="#e7ccb4" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/account_type_cache.go
+342 loc · ccn 71 · commits (last 12mo) 4</title></rect>
+<rect x="130.34" y="340.66" width="25.80" height="22.14" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/redis_cache.go
+286 loc · ccn 72 · commits (last 12mo) 2</title></rect>
+<rect x="156.15" y="314.18" width="19.19" height="23.63" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/instrument_cache.go
+227 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="175.34" y="314.18" width="19.11" height="23.63" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/prefetch_test.go
+226 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="156.15" y="337.81" width="17.03" height="24.99" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/event_subscriber_test.go
+213 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="173.18" y="337.81" width="21.27" height="15.69" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/tiered_cache.go
+167 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="173.18" y="353.50" width="15.04" height="9.30" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/prefetch.go
+70 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="188.21" y="353.50" width="6.23" height="9.30" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/cache/event_subscriber.go
+29 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="194.44" y="284.26" width="39.43" height="34.56" fill="#f7c99a" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_test.go
+682 loc · ccn 71 · commits (last 12mo) 7</title></rect>
+<rect x="233.87" y="284.26" width="30.06" height="34.56" fill="#fcac76" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry.go
+520 loc · ccn 113 · commits (last 12mo) 10</title></rect>
+<rect x="194.44" y="318.82" width="19.12" height="22.15" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/definition_test.go
+212 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="194.44" y="340.96" width="19.12" height="21.84" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_query.go
+209 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="213.56" y="318.82" width="20.89" height="15.68" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_helpers.go
+164 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="213.56" y="334.50" width="20.89" height="14.63" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_cel_test.go
+153 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="213.56" y="349.13" width="20.89" height="13.67" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_helpers_test.go
+143 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="234.46" y="318.82" width="15.07" height="18.16" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/postgres_registry_cel.go
+137 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="249.53" y="318.82" width="14.41" height="18.16" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/definition.go
+131 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="234.46" y="336.98" width="13.77" height="14.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/seeder_test.go
+102 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="234.46" y="351.78" width="13.77" height="11.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/seeder.go
+76 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="248.23" y="336.98" width="15.71" height="8.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/types_test.go
+65 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="248.23" y="345.25" width="8.63" height="9.03" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/status.go
+39 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="256.86" y="345.25" width="7.08" height="9.03" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/behavior_class.go
+32 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="248.23" y="354.28" width="6.33" height="8.52" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/registry.go
+27 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="254.56" y="354.28" width="5.39" height="8.52" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/errors.go
+23 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="259.95" y="354.28" width="3.99" height="8.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/accounttype/normal_balance.go
+17 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="100.84" y="362.80" width="36.34" height="62.99" fill="#e1c1b0" stroke="white" stroke-width="0.5"><title>services/reference-data/e2e/e2e_test.go
+1146 loc · ccn 118 · commits (last 12mo) 3</title></rect>
+<rect x="137.18" y="362.80" width="32.82" height="62.99" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>services/reference-data/e2e/product_directory_e2e_test.go
+1035 loc · ccn 84 · commits (last 12mo) 2</title></rect>
+<rect x="100.84" y="425.79" width="69.00" height="11.81" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reference-data/e2e/mapping_dry_run_test.go
+408 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="169.84" y="425.79" width="0.17" height="11.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/e2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="170.01" y="362.80" width="47.14" height="35.64" fill="#fdc48e" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/postgres_registry_test.go
+841 loc · ccn 78 · commits (last 12mo) 8</title></rect>
+<rect x="170.01" y="398.44" width="25.15" height="27.25" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/registry_instrument.go
+343 loc · ccn 67 · commits (last 12mo) 1</title></rect>
+<rect x="170.01" y="425.69" width="25.15" height="11.92" fill="#fddcae" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/postgres_registry.go
+150 loc · ccn 31 · commits (last 12mo) 10</title></rect>
+<rect x="195.16" y="398.44" width="21.99" height="13.08" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/registry_validation.go
+144 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="195.16" y="411.53" width="11.89" height="15.63" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/seeder.go
+93 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="207.05" y="411.53" width="10.10" height="15.63" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/registry.go
+79 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="195.16" y="427.16" width="13.00" height="10.45" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/instrument_status_test.go
+68 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="208.16" y="427.16" width="8.99" height="10.45" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reference-data/registry/instrument_status.go
+47 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="217.14" y="362.80" width="24.68" height="38.21" fill="#e1cab8" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/repository.go
+472 loc · ccn 91 · commits (last 12mo) 3</title></rect>
+<rect x="241.82" y="362.80" width="22.11" height="38.21" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/validator_test.go
+423 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="217.14" y="401.01" width="23.75" height="18.67" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/validator.go
+222 loc · ccn 77 · commits (last 12mo) 1</title></rect>
+<rect x="217.14" y="419.69" width="23.75" height="17.92" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/domain_test.go
+213 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="240.89" y="401.01" width="23.04" height="17.69" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/repository_test.go
+204 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="240.89" y="418.70" width="14.80" height="18.90" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/domain.go
+140 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="255.69" y="418.70" width="8.24" height="13.57" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/errors_test.go
+56 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="255.69" y="432.27" width="8.24" height="5.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/mapping/errors.go
+22 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="100.84" y="437.61" width="30.47" height="50.62" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>services/reference-data/node/postgres_repository_test.go
+772 loc · ccn 93 · commits (last 12mo) 2</title></rect>
+<rect x="131.31" y="437.61" width="36.15" height="21.77" fill="#e7c9b1" stroke="white" stroke-width="0.5"><title>services/reference-data/node/postgres_repository.go
+394 loc · ccn 83 · commits (last 12mo) 4</title></rect>
+<rect x="131.31" y="459.38" width="16.62" height="28.84" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reference-data/node/postgres_repository_traversal.go
+240 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="147.93" y="459.38" width="19.53" height="15.34" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/node/node_test.go
+150 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="147.93" y="474.72" width="19.53" height="13.50" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/reference-data/node/node.go
+132 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="100.84" y="488.22" width="26.58" height="25.94" fill="#e1cebd" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/postgres_policy.go
+345 loc · ccn 67 · commits (last 12mo) 3</title></rect>
+<rect x="100.84" y="514.16" width="26.58" height="22.70" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/postgres_method.go
+302 loc · ccn 59 · commits (last 12mo) 2</title></rect>
+<rect x="127.41" y="488.22" width="20.64" height="22.65" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/postgres_policy_test.go
+234 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="148.05" y="488.22" width="19.41" height="22.65" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/postgres_method_test.go
+220 loc · ccn 28 · commits (last 12mo) 2</title></rect>
+<rect x="127.41" y="510.87" width="13.68" height="25.99" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/seeder.go
+178 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="141.10" y="510.87" width="14.91" height="15.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/domain_test.go
+115 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="141.10" y="526.28" width="14.91" height="10.58" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/domain.go
+79 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="156.01" y="510.87" width="11.45" height="13.61" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/seeder_test.go
+78 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="156.01" y="524.48" width="11.45" height="12.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/valuation/helpers_test.go
+71 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="167.46" y="437.61" width="21.44" height="43.69" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reference-data/client/client_test.go
+469 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="188.90" y="437.61" width="22.77" height="22.46" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/reference-data/client/client.go
+256 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="188.90" y="460.07" width="22.77" height="21.23" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reference-data/client/grpc_source_test.go
+242 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="211.67" y="437.61" width="22.40" height="17.83" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reference-data/client/starlark_test.go
+200 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="211.67" y="455.44" width="11.89" height="18.82" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reference-data/client/grpc_source.go
+112 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="223.57" y="455.44" width="10.51" height="18.82" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/reference-data/client/starlark.go
+99 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="211.67" y="474.26" width="22.40" height="7.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/client/conversions_test.go
+79 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="234.08" y="437.61" width="29.86" height="43.69" fill="#f2cfa8" stroke="white" stroke-width="0.5"><title>services/reference-data/saga_migrations_test.go
+653 loc · ccn 59 · commits (last 12mo) 6</title></rect>
+<rect x="167.46" y="481.30" width="21.10" height="28.02" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/reference-data/middleware/rate_limit_interceptor_test.go
+296 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="188.56" y="481.30" width="15.97" height="28.02" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reference-data/middleware/rate_limit_interceptor.go
+224 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="167.46" y="509.32" width="37.07" height="27.54" fill="#e7d1b9" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations_test.go
+511 loc · ccn 53 · commits (last 12mo) 4</title></rect>
+<rect x="204.53" y="481.30" width="10.37" height="11.76" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260206000001_valuation_methods_policies.sql
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="214.90" y="481.30" width="7.31" height="11.76" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260104000001_initial.sql
+43 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="222.21" y="481.30" width="7.14" height="11.76" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260211000001_account_type_definitions.sql
+42 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="204.53" y="493.06" width="8.78" height="8.42" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260124000001_saga_definitions.sql
+37 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="204.53" y="501.47" width="8.78" height="7.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260210000001_reference_data_node.sql
+31 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="204.53" y="508.52" width="8.78" height="6.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260221000001_mapping_definition.sql
+29 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="213.32" y="493.06" width="8.68" height="5.98" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260125000001_platform_saga_definition.sql
+26 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="222.00" y="493.06" width="7.35" height="5.98" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260211000003_account_type_valuation_methods.sql
+22 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="213.32" y="499.04" width="6.41" height="6.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260124000002_saga_references.sql
+22 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="219.73" y="499.04" width="4.95" height="6.86" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260125000002_extend_saga_definition_platform_ref.sql
+17 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="224.68" y="499.04" width="4.66" height="6.86" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260128000002_versioned_platform_sagas_constraints.sql
+16 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="213.32" y="505.90" width="4.12" height="4.85" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260126000001_saga_fallback_resolution.sql
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="213.32" y="510.75" width="4.12" height="4.37" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260129000002_bitemporal_platform_sagas_constraints.sql
+9 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="217.43" y="505.90" width="4.12" height="3.88" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260406000001_remove_platform_ref.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="217.43" y="509.78" width="4.12" height="2.91" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260128000001_versioned_platform_sagas.sql
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="217.43" y="512.69" width="4.12" height="2.43" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260127000001_fix_platform_saga_unique_constraint.sql
+5 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="221.55" y="505.90" width="3.90" height="2.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260105000001_add_is_system.sql
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="225.44" y="505.90" width="3.90" height="2.56" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260106000001_add_successor_id.sql
+5 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="221.55" y="508.46" width="2.40" height="3.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260130000001_saga_validation_metadata.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="221.55" y="511.79" width="2.40" height="3.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260129000001_bitemporal_platform_sagas.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="223.95" y="508.46" width="2.70" height="2.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260227000002_add_carbon_data_dimensions_constraint.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="226.64" y="508.46" width="2.70" height="2.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260211000004_account_type_val_method_active_index.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="223.95" y="510.68" width="2.70" height="2.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260211000002_account_type_active_unique_index.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="223.95" y="512.90" width="2.70" height="2.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260221000002_mapping_definition_active_index.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="226.64" y="510.68" width="2.70" height="1.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260227000001_add_carbon_data_dimensions.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="226.64" y="512.16" width="2.70" height="1.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260106000002_successor_id_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="226.64" y="513.64" width="2.70" height="1.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/migrations/20260125000003_platform_ref_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="204.53" y="515.12" width="22.61" height="21.74" fill="#f2d6b2" stroke="white" stroke-width="0.5"><title>services/reference-data/cmd/main.go
+246 loc · ccn 40 · commits (last 12mo) 6</title></rect>
+<rect x="227.14" y="515.12" width="2.21" height="21.74" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/reference-data/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="229.34" y="481.30" width="18.58" height="14.41" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/deployment.yaml
+134 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="229.34" y="495.71" width="10.31" height="12.79" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/networkpolicy.yaml
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="239.65" y="495.71" width="8.28" height="4.83" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/configmap.yaml
+20 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="239.65" y="500.54" width="4.26" height="7.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="243.91" y="500.54" width="4.01" height="4.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="243.91" y="505.02" width="4.01" height="3.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="247.92" y="481.30" width="16.01" height="27.20" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/reference-data/README.md
+218 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="229.34" y="508.50" width="15.42" height="8.03" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/examples/energy-metering-feed.json
+62 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="229.34" y="516.54" width="15.42" height="7.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/examples/bank-x-party-onboarding.json
+60 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="244.76" y="508.50" width="6.07" height="15.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/examples/verra-carbon-credit.json
+48 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="229.34" y="524.31" width="17.19" height="12.55" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/rbac/method_permissions.go
+108 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="246.53" y="524.31" width="4.30" height="12.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reference-data/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="250.83" y="508.50" width="13.10" height="9.61" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/reference-data/cel/compiler_test.go
+63 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="250.83" y="518.11" width="13.10" height="3.66" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/reference-data/cel/compiler.go
+24 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="250.83" y="521.77" width="13.10" height="9.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reference-data/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="250.83" y="531.07" width="13.10" height="5.79" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reference-data/testhelpers/factories.go
+38 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="536.86" width="51.67" height="88.27" fill="#e9583e" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_service_test.go
+2283 loc · ccn 204 · commits (last 12mo) 17</title></rect>
+<rect x="0.00" y="625.13" width="51.67" height="49.53" fill="#fdbd86" stroke="white" stroke-width="0.5"><title>services/payment-order/service/integration_test.go
+1281 loc · ccn 94 · commits (last 12mo) 16</title></rect>
+<rect x="51.67" y="536.86" width="44.09" height="35.44" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_unhappy_path_test.go
+782 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="95.76" y="536.86" width="27.79" height="35.44" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handlers_test.go
+493 loc · ccn 29 · commits (last 12mo) 3</title></rect>
+<rect x="123.55" y="536.86" width="27.06" height="35.44" fill="#e7cab1" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_saga.go
+480 loc · ccn 82 · commits (last 12mo) 4</title></rect>
+<rect x="150.61" y="536.86" width="26.55" height="35.44" fill="#ecd9c1" stroke="white" stroke-width="0.5"><title>services/payment-order/service/bucket_solvency_test.go
+471 loc · ccn 23 · commits (last 12mo) 5</title></rect>
+<rect x="51.67" y="572.30" width="25.94" height="35.58" fill="#eccbab" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_lifecycle.go
+462 loc · ccn 71 · commits (last 12mo) 5</title></rect>
+<rect x="51.67" y="607.88" width="25.94" height="34.89" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/service/ledger_coverage_test.go
+453 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="51.67" y="642.77" width="25.94" height="31.89" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/account_resolver_test.go
+414 loc · ccn 39 · commits (last 12mo) 3</title></rect>
+<rect x="77.61" y="572.30" width="26.75" height="28.23" fill="#f2d0a9" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_ledger.go
+378 loc · ccn 56 · commits (last 12mo) 6</title></rect>
+<rect x="104.35" y="572.30" width="25.76" height="28.23" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_coverage_test.go
+364 loc · ccn 36 · commits (last 12mo) 2</title></rect>
+<rect x="130.11" y="572.30" width="24.69" height="28.23" fill="#f2d0a9" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_service_bench_test.go
+349 loc · ccn 56 · commits (last 12mo) 6</title></rect>
+<rect x="154.80" y="572.30" width="22.36" height="28.23" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/payment-order/service/billing_grpc_test.go
+316 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="77.61" y="600.53" width="24.39" height="25.31" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/payment-order/service/billing_grpc.go
+309 loc · ccn 59 · commits (last 12mo) 1</title></rect>
+<rect x="77.61" y="625.84" width="24.39" height="24.57" fill="#e7d0b8" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_update.go
+300 loc · ccn 57 · commits (last 12mo) 4</title></rect>
+<rect x="77.61" y="650.41" width="24.39" height="24.25" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handler_lien.go
+296 loc · ccn 42 · commits (last 12mo) 3</title></rect>
+<rect x="102.00" y="600.53" width="21.34" height="25.27" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/payment-order/service/server.go
+270 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="102.00" y="625.80" width="21.34" height="25.08" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_initiate.go
+268 loc · ccn 50 · commits (last 12mo) 3</title></rect>
+<rect x="102.00" y="650.89" width="21.34" height="23.77" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_lien_test.go
+254 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="123.34" y="600.53" width="18.50" height="22.79" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>services/payment-order/service/account_resolver.go
+211 loc · ccn 30 · commits (last 12mo) 4</title></rect>
+<rect x="141.84" y="600.53" width="17.88" height="22.79" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_integration_test.go
+204 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="159.72" y="600.53" width="17.44" height="22.79" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_lien.go
+199 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="123.34" y="623.32" width="19.89" height="18.99" fill="#fde0b8" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator.go
+189 loc · ccn 21 · commits (last 12mo) 17</title></rect>
+<rect x="123.34" y="642.31" width="19.89" height="16.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/service/bucket_evaluator_test.go
+163 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="123.34" y="658.69" width="19.89" height="15.97" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_mappers.go
+159 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="143.23" y="623.32" width="18.15" height="16.84" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/payment-order/service/billing_grpc_mappers.go
+153 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="161.38" y="623.32" width="15.78" height="16.84" fill="#f2d8b7" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handlers.go
+133 loc · ccn 32 · commits (last 12mo) 6</title></rect>
+<rect x="143.23" y="640.16" width="19.65" height="12.30" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/payment-order/service/bucket_evaluator.go
+121 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="162.88" y="640.16" width="14.29" height="12.30" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handler_gateway.go
+88 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="143.23" y="652.46" width="14.67" height="11.98" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_ledger_test.go
+88 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="143.23" y="664.45" width="14.67" height="10.21" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/payment_orchestrator_test.go
+75 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="157.90" y="652.46" width="9.78" height="13.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/HANDLER_ARCHITECTURE.md
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="167.68" y="652.46" width="9.48" height="13.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/service/grpc_query.go
+64 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="157.90" y="665.95" width="8.03" height="8.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handler_lien_test.go
+35 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="165.93" y="665.95" width="6.65" height="8.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/saga_handler_ledger.go
+29 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="172.58" y="665.95" width="4.59" height="8.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/service/lock_client.go
+20 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="674.66" width="27.39" height="23.93" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go
+328 loc · ccn 28 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="698.58" width="27.39" height="23.78" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/stripe_gateway_test.go
+326 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="722.36" width="27.39" height="18.82" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/webhook_adapter_test.go
+258 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="27.39" y="674.66" width="20.76" height="20.89" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/stripe_gateway.go
+217 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="48.14" y="674.66" width="20.09" height="20.89" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/client_test.go
+210 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="27.39" y="695.55" width="23.93" height="17.37" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/client.go
+208 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="51.32" y="695.55" width="16.91" height="17.37" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/webhook_adapter.go
+147 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="27.39" y="712.91" width="16.82" height="15.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/platform_fee_test.go
+133 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="27.39" y="728.71" width="16.82" height="12.47" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/manifest_tenant_config.go
+105 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="44.20" y="712.91" width="13.40" height="11.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/tenant_config_test.go
+77 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="57.61" y="712.91" width="10.62" height="11.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/platform_fee.go
+61 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="44.20" y="724.39" width="11.54" height="8.83" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/integration_test.go
+51 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="44.20" y="733.22" width="11.54" height="7.97" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/config.go
+46 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="55.74" y="724.39" width="12.49" height="6.24" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/idempotency_test.go
+39 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="55.74" y="730.63" width="6.81" height="10.56" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/config_test.go
+36 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="62.55" y="730.63" width="5.68" height="6.69" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/tenant_config.go
+19 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="62.55" y="737.31" width="5.68" height="3.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/stripe/idempotency.go
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="741.18" width="25.67" height="23.66" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/resilient_gateway_test.go
+304 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="0.00" y="764.85" width="25.67" height="15.72" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/financial_gateway_client_test.go
+202 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="25.67" y="741.18" width="18.72" height="20.92" fill="#e7d7c4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/resilient_gateway.go
+196 loc · ccn 27 · commits (last 12mo) 4</title></rect>
+<rect x="25.67" y="762.10" width="18.72" height="18.46" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/mock_gateway_test.go
+173 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="44.39" y="741.18" width="12.59" height="17.93" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/financial_gateway_client.go
+113 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="56.98" y="741.18" width="11.25" height="17.93" fill="#e7d9c8" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/mock_gateway.go
+101 loc · ccn 18 · commits (last 12mo) 4</title></rect>
+<rect x="44.39" y="759.12" width="14.06" height="11.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/financial_gateway_client_coverage_test.go
+81 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="44.39" y="770.62" width="14.06" height="9.94" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/payment_gateway_test.go
+70 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="58.45" y="759.12" width="9.78" height="8.78" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/config_test.go
+43 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="58.45" y="767.90" width="9.78" height="6.95" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/config.go
+34 loc · ccn 3 · commits (last 12mo) 4</title></rect>
+<rect x="58.45" y="774.85" width="9.78" height="5.72" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/gateway/payment_gateway.go
+28 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="68.23" y="674.66" width="29.71" height="35.51" fill="#fdddb2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/repository_test.go
+528 loc · ccn 27 · commits (last 12mo) 11</title></rect>
+<rect x="97.93" y="674.66" width="28.19" height="35.51" fill="#e1c6b5" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/billing_repository.go
+501 loc · ccn 104 · commits (last 12mo) 3</title></rect>
+<rect x="68.23" y="710.17" width="29.02" height="28.09" fill="#f2c59d" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/repository_bench_test.go
+408 loc · ccn 84 · commits (last 12mo) 6</title></rect>
+<rect x="97.25" y="710.17" width="28.87" height="28.09" fill="#fdc892" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/repository.go
+406 loc · ccn 71 · commits (last 12mo) 10</title></rect>
+<rect x="68.23" y="738.26" width="25.03" height="22.19" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/billing_repository_unit_test.go
+278 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="68.23" y="760.45" width="25.03" height="20.12" fill="#edddc8" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/audit_test.go
+252 loc · ccn 11 · commits (last 12mo) 5</title></rect>
+<rect x="93.25" y="738.26" width="17.13" height="25.90" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/billing_repository_test.go
+222 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="110.38" y="738.26" width="15.74" height="25.90" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/billing_list_test.go
+204 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="93.25" y="764.15" width="12.42" height="16.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/saga_execution_repository_test.go
+102 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="105.67" y="764.15" width="9.37" height="16.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/saga_execution_repository.go
+77 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="115.04" y="764.15" width="11.08" height="9.56" fill="#eddecb" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/payment_order_entity.go
+53 loc · ccn 5 · commits (last 12mo) 5</title></rect>
+<rect x="115.04" y="773.71" width="11.08" height="6.85" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/persistence/billing_entity.go
+38 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="126.12" y="674.66" width="25.62" height="31.12" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/webhook_handler_test.go
+399 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="151.74" y="674.66" width="25.43" height="31.12" fill="#ecd5b7" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/server_test.go
+396 loc · ccn 42 · commits (last 12mo) 5</title></rect>
+<rect x="126.12" y="705.77" width="31.29" height="18.70" fill="#ecd0b0" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/server.go
+293 loc · ccn 58 · commits (last 12mo) 5</title></rect>
+<rect x="126.12" y="724.48" width="31.29" height="16.60" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/webhook_handler.go
+260 loc · ccn 44 · commits (last 12mo) 3</title></rect>
+<rect x="157.41" y="705.77" width="19.75" height="18.31" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/server_coverage_test.go
+181 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="157.41" y="724.08" width="19.75" height="16.99" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/http/webhook_handler_coverage_test.go
+168 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="126.12" y="741.08" width="17.09" height="23.73" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/messaging/payment_event_consumer.go
+203 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="143.21" y="741.08" width="13.47" height="23.73" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/messaging/outbox_publisher_test.go
+160 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="126.12" y="764.81" width="14.83" height="15.76" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/messaging/payment_event_consumer_test.go
+117 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="140.95" y="764.81" width="15.72" height="10.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/messaging/payment_event_consumer_coverage_test.go
+79 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="140.95" y="774.85" width="15.72" height="5.72" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/messaging/outbox_publisher.go
+45 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="156.68" y="741.08" width="20.49" height="16.87" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/clients/reference_data_client_test.go
+173 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="156.68" y="757.95" width="11.31" height="12.19" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/clients/reference_data_client.go
+69 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="167.98" y="757.95" width="9.18" height="12.19" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/clients/party_client.go
+56 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="156.68" y="770.13" width="14.17" height="10.43" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/lock/redis_lock_client_test.go
+74 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="170.84" y="770.13" width="6.32" height="10.43" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/adapters/lock/redis_lock_client.go
+33 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="536.86" width="29.91" height="47.56" fill="#fdc58f" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/dunning_worker_test.go
+712 loc · ccn 77 · commits (last 12mo) 9</title></rect>
+<rect x="177.16" y="584.42" width="29.91" height="25.45" fill="#e1d0be" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_scheduler_test.go
+381 loc · ccn 61 · commits (last 12mo) 3</title></rect>
+<rect x="207.07" y="536.86" width="28.78" height="20.13" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/invoice_generator.go
+290 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="235.85" y="536.86" width="28.08" height="20.13" fill="#f7d3a4" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/dunning_worker.go
+283 loc · ccn 50 · commits (last 12mo) 7</title></rect>
+<rect x="207.07" y="556.99" width="26.15" height="20.40" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/invoice_generator_test.go
+267 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="207.07" y="577.39" width="26.15" height="16.28" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/invoice_generator_email_test.go
+213 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="207.07" y="593.67" width="26.15" height="16.20" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_scheduler_coverage_test.go
+212 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="233.22" y="556.99" width="15.68" height="25.24" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_scheduler_adapters.go
+198 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="248.89" y="556.99" width="15.04" height="25.24" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/payment_initiator_test.go
+190 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="233.22" y="582.23" width="16.41" height="14.86" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_metrics.go
+122 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="233.22" y="597.08" width="16.41" height="12.79" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/payment_initiator.go
+105 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="249.62" y="582.23" width="14.31" height="12.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_metrics_test.go
+88 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="249.62" y="594.51" width="14.31" height="12.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_scheduler_adapters_test.go
+87 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="249.62" y="606.66" width="14.31" height="3.21" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/worker/billing_scheduler.go
+23 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="177.16" y="609.87" width="17.90" height="26.90" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/testfixtures/fixtures.go
+241 loc · ccn 55 · commits (last 12mo) 2</title></rect>
+<rect x="195.06" y="609.87" width="14.26" height="22.00" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/testfixtures/fixtures_test.go
+157 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="195.06" y="631.87" width="14.26" height="4.90" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/testfixtures/fixtures_coverage_test.go
+35 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="636.77" width="32.15" height="25.66" fill="#e7d0b7" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/payment_order_test.go
+413 loc · ccn 59 · commits (last 12mo) 4</title></rect>
+<rect x="209.32" y="609.87" width="19.84" height="26.68" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/billing_test.go
+265 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="209.32" y="636.55" width="19.84" height="25.88" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/payment_order_unhappy_test.go
+257 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="229.16" y="609.87" width="17.83" height="27.11" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/payment_order.go
+242 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="246.99" y="609.87" width="16.95" height="27.11" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/billing.go
+230 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="229.16" y="636.98" width="20.41" height="14.09" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/quantity_test.go
+144 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="229.16" y="651.08" width="20.41" height="11.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/saga_test.go
+116 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="249.57" y="636.98" width="14.37" height="11.96" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/billing_dunning_test.go
+86 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="249.57" y="648.94" width="9.33" height="13.49" fill="#edddc8" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/quantity.go
+63 loc · ccn 11 · commits (last 12mo) 5</title></rect>
+<rect x="258.90" y="648.94" width="5.04" height="13.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/domain/saga.go
+34 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="662.43" width="44.22" height="40.48" fill="#fdc18b" stroke="white" stroke-width="0.5"><title>services/payment-order/e2e/e2e_test.go
+896 loc · ccn 84 · commits (last 12mo) 8</title></rect>
+<rect x="221.39" y="662.43" width="26.70" height="22.89" fill="#fdd09a" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/main.go
+306 loc · ccn 57 · commits (last 12mo) 44</title></rect>
+<rect x="221.39" y="685.33" width="26.70" height="17.58" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/clients.go
+235 loc · ccn 21 · commits (last 12mo) 3</title></rect>
+<rect x="248.09" y="662.43" width="15.84" height="15.76" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/types_test.go
+125 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="248.09" y="678.19" width="15.84" height="8.07" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/clients_test.go
+64 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="248.09" y="686.26" width="15.84" height="8.07" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/gateway_factory_test.go
+64 loc · ccn 6 · commits (last 12mo) 3</title></rect>
+<rect x="248.09" y="694.33" width="10.25" height="8.57" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/types.go
+44 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="258.34" y="694.33" width="5.59" height="8.57" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/payment-order/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 10</title></rect>
+<rect x="177.16" y="702.91" width="40.72" height="22.86" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/payment-order/app/container.go
+466 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="725.77" width="25.21" height="18.54" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/payment-order/app/container_clients.go
+234 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="202.37" y="725.77" width="15.51" height="18.54" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/payment-order/app/container_test.go
+144 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="744.31" width="25.57" height="24.14" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/payment-order/config/gateway_accounts_test.go
+309 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="177.16" y="768.46" width="25.57" height="12.11" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/payment-order/config/service_config_test.go
+155 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="202.73" y="744.31" width="15.15" height="19.51" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/payment-order/config/gateway_accounts.go
+148 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="202.73" y="763.82" width="15.15" height="10.68" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/payment-order/config/service_config.go
+81 loc · ccn 12 · commits (last 12mo) 3</title></rect>
+<rect x="202.73" y="774.50" width="15.15" height="6.06" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/config/gateway_accounts_coverage_test.go
+46 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="217.89" y="702.91" width="23.21" height="31.93" fill="#f2d8b6" stroke="white" stroke-width="0.5"><title>services/payment-order/observability/metrics.go
+371 loc · ccn 34 · commits (last 12mo) 6</title></rect>
+<rect x="241.10" y="702.91" width="22.84" height="31.93" fill="#e1cbba" stroke="white" stroke-width="0.5"><title>services/payment-order/observability/metrics_test.go
+365 loc · ccn 81 · commits (last 12mo) 3</title></rect>
+<rect x="217.89" y="734.84" width="11.21" height="11.94" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20251223000001_fix_audit_schema_compatibility.sql
+67 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="217.89" y="746.78" width="11.21" height="11.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20251217000001_audit_system.sql
+63 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="229.10" y="734.84" width="11.09" height="7.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260210000001_billing.sql
+42 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="240.18" y="734.84" width="10.30" height="7.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20251216000001_initial.sql
+39 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="229.10" y="742.41" width="6.15" height="7.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260212000001_saga_executions.sql
+24 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="229.10" y="750.21" width="6.15" height="7.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260331000002_communication_preferences.sql
+24 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="235.24" y="742.41" width="7.62" height="5.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260213000001_scheduler_execution.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="242.86" y="742.41" width="7.62" height="5.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260204000001_create_event_outbox.sql
+20 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="235.24" y="747.65" width="7.14" height="5.32" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260326000001_email_outbox.sql
+19 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="235.24" y="752.97" width="7.14" height="5.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260326000003_email_audit_log.sql
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="242.38" y="747.65" width="5.24" height="4.19" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260331000001_suppressed_addresses.sql
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="247.62" y="747.65" width="2.86" height="4.19" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260123000001_bucket_aware_solvency.sql
+6 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="242.38" y="751.84" width="3.24" height="3.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="242.38" y="755.54" width="3.24" height="2.47" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260326000002_email_outbox_index.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="245.62" y="751.84" width="3.24" height="2.47" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="248.86" y="751.84" width="1.62" height="2.47" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260123000002_bucket_id_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="245.62" y="754.31" width="2.16" height="1.85" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260211000001_billing_dunning.sql
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="245.62" y="756.16" width="2.16" height="1.85" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260331000003_email_outbox_category_party.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="247.78" y="754.31" width="2.70" height="1.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260211000002_billing_dunning_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="247.78" y="755.79" width="1.80" height="1.11" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260326000004_email_audit_provider_id_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="247.78" y="756.90" width="1.80" height="1.11" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260316000001_add_event_outbox_tenant_id.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="249.58" y="755.79" width="0.90" height="2.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/migrations/20260316000002_add_event_outbox_tenant_id_index.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="217.89" y="758.01" width="17.27" height="22.56" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/deployment.yaml
+195 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="235.16" y="758.01" width="15.32" height="14.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/networkpolicy.yaml
+115 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="235.16" y="773.00" width="6.34" height="7.56" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/configmap.yaml
+24 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="241.50" y="773.00" width="4.49" height="7.56" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="245.99" y="773.00" width="4.49" height="4.45" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/secret.yaml
+10 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="245.99" y="777.45" width="4.49" height="3.11" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/payment-order/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="250.48" y="734.84" width="13.46" height="22.27" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/payment-order/README.md
+150 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="250.48" y="757.11" width="13.46" height="10.39" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/payment-order/rbac/method_permissions.go
+70 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="250.48" y="767.50" width="13.46" height="4.01" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/payment-order/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="250.48" y="771.51" width="13.46" height="9.06" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>services/payment-order/atlas/atlas.hcl
+61 loc · ccn 2 · commits (last 12mo) 3</title></rect>
+<rect x="0.00" y="780.57" width="39.13" height="29.56" fill="#d6ccca" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/kafka_source_test.go
+579 loc · ccn 114 · commits (last 12mo) 1</title></rect>
+<rect x="39.13" y="780.57" width="23.18" height="29.56" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/outbox_source_test.go
+343 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="810.13" width="28.50" height="20.05" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/local_fanout_test.go
+286 loc · ccn 59 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="830.18" width="28.50" height="15.70" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/redis_fanout_test.go
+224 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="28.50" y="810.13" width="17.69" height="22.93" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/kafka_source.go
+203 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="46.18" y="810.13" width="16.12" height="22.93" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/outbox_source.go
+185 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="28.50" y="833.06" width="20.56" height="12.82" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/redis_fanout.go
+132 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="49.06" y="833.06" width="13.24" height="12.82" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/adapters/local_fanout.go
+85 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="62.30" y="780.57" width="31.96" height="65.32" fill="#dbc2b9" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/integration_test.go
+1045 loc · ccn 136 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="845.88" width="32.21" height="35.04" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/handler_test.go
+565 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="880.92" width="32.21" height="24.13" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/connection_test.go
+389 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="905.05" width="32.21" height="22.51" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/domain_test.go
+363 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="32.21" y="845.88" width="23.96" height="29.10" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/router_test.go
+349 loc · ccn 51 · commits (last 12mo) 3</title></rect>
+<rect x="56.17" y="845.88" width="19.98" height="29.10" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/router.go
+291 loc · ccn 60 · commits (last 12mo) 1</title></rect>
+<rect x="76.14" y="845.88" width="18.12" height="29.10" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/connection.go
+264 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="32.21" y="874.99" width="19.19" height="27.17" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/protocol_test.go
+261 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="32.21" y="902.16" width="19.19" height="25.40" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/chain_depth_test.go
+244 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="51.40" y="874.99" width="22.12" height="21.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/channel_test.go
+240 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="73.53" y="874.99" width="20.74" height="21.67" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/handler.go
+225 loc · ccn 44 · commits (last 12mo) 1</title></rect>
+<rect x="51.40" y="896.66" width="19.14" height="15.87" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/domain.go
+152 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="51.40" y="912.53" width="19.14" height="15.03" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/metrics_integration_test.go
+144 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="70.54" y="896.66" width="12.56" height="20.21" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/metrics.go
+127 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="83.09" y="896.66" width="11.17" height="20.21" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/metrics_test.go
+113 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="70.54" y="916.87" width="15.51" height="10.69" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/protocol.go
+83 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="86.05" y="916.87" width="8.22" height="7.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/channel.go
+32 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="86.05" y="924.65" width="7.54" height="2.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/ports.go
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="93.58" y="924.65" width="0.69" height="2.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/eventstream/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="0.00" y="927.56" width="40.79" height="37.71" fill="#dccbc1" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/jwt_middleware_test.go
+770 loc · ccn 97 · commits (last 12mo) 2</title></rect>
+<rect x="0.00" y="965.27" width="40.79" height="34.73" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/combined_middleware_test.go
+709 loc · ccn 76 · commits (last 12mo) 2</title></rect>
+<rect x="40.79" y="927.56" width="31.88" height="35.53" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/apikey_middleware_test.go
+567 loc · ccn 73 · commits (last 12mo) 1</title></rect>
+<rect x="72.67" y="927.56" width="21.59" height="35.53" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/rpc_apikey_validator_test.go
+384 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="40.79" y="963.09" width="25.66" height="18.53" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/combined_middleware.go
+238 loc · ccn 50 · commits (last 12mo) 2</title></rect>
+<rect x="40.79" y="981.62" width="25.66" height="18.38" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/apikey_middleware.go
+236 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="66.45" y="963.09" width="27.82" height="16.52" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/rpc_apikey_validator.go
+230 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="66.45" y="979.61" width="17.44" height="20.39" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/jwt_middleware.go
+178 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="83.88" y="979.61" width="10.38" height="15.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/composite_validator_test.go
+82 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="83.88" y="995.38" width="10.38" height="4.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth/composite_validator.go
+24 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="94.27" y="780.57" width="40.48" height="51.53" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/mapping/engine_test.go
+1044 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="134.74" y="780.57" width="13.69" height="48.31" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/mapping/engine_batch_test.go
+331 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="134.74" y="828.88" width="13.06" height="3.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/mapping/engine.go
+21 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="147.81" y="828.88" width="0.62" height="3.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/mapping/engine_batch.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="148.43" y="780.57" width="28.03" height="33.71" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/middleware/outbound_test.go
+473 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="176.46" y="780.57" width="18.73" height="33.71" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/middleware/mapping_middleware_test.go
+316 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="148.43" y="814.28" width="32.29" height="17.82" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/middleware/mapping_middleware.go
+288 loc · ccn 52 · commits (last 12mo) 2</title></rect>
+<rect x="180.73" y="814.28" width="14.47" height="10.08" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/middleware/response_recorder_test.go
+73 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="180.73" y="824.36" width="14.47" height="7.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/internal/middleware/response_recorder.go
+56 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="195.19" y="780.57" width="30.48" height="28.06" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/forward_curve_cache_test.go
+428 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="195.19" y="808.62" width="30.48" height="23.47" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/forward_curve_cache.go
+358 loc · ccn 56 · commits (last 12mo) 2</title></rect>
+<rect x="225.67" y="780.57" width="21.52" height="31.01" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/saga_binding_cache_test.go
+334 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="247.18" y="780.57" width="16.75" height="31.01" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/mds_source_test.go
+260 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="225.67" y="811.58" width="13.34" height="20.52" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/saga_binding_cache.go
+137 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="239.01" y="811.58" width="18.31" height="10.91" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/mds_source.go
+100 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="239.01" y="822.49" width="18.31" height="9.60" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/manifest_binding_source_test.go
+88 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="257.31" y="811.58" width="6.62" height="20.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/cache/manifest_binding_source.go
+68 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="94.27" y="832.09" width="34.75" height="45.53" fill="#e1cebd" stroke="white" stroke-width="0.5"><title>services/api-gateway/config_test.go
+792 loc · ccn 68 · commits (last 12mo) 3</title></rect>
+<rect x="94.27" y="877.62" width="34.75" height="42.94" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/transcoding_test.go
+747 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="94.27" y="920.56" width="34.75" height="42.77" fill="#fdc38c" stroke="white" stroke-width="0.5"><title>services/api-gateway/server_test.go
+744 loc · ccn 81 · commits (last 12mo) 8</title></rect>
+<rect x="94.27" y="963.33" width="34.75" height="36.67" fill="#f7c091" stroke="white" stroke-width="0.5"><title>services/api-gateway/registration_handler_test.go
+638 loc · ccn 90 · commits (last 12mo) 7</title></rect>
+<rect x="129.02" y="832.09" width="40.58" height="29.29" fill="#e7d4bf" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_sso_handler_test.go
+595 loc · ccn 39 · commits (last 12mo) 4</title></rect>
+<rect x="169.60" y="832.09" width="31.92" height="29.29" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/api-gateway/proxy_test.go
+468 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="201.52" y="832.09" width="20.46" height="29.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/cel/forward_curve_functions_test.go
+300 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="221.99" y="832.09" width="11.12" height="29.29" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/cel/forward_curve_functions.go
+163 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="233.10" y="832.09" width="30.83" height="29.29" fill="#f2c39b" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_sso_handler.go
+452 loc · ccn 89 · commits (last 12mo) 6</title></rect>
+<rect x="129.02" y="861.38" width="28.53" height="29.48" fill="#fcb982" stroke="white" stroke-width="0.5"><title>services/api-gateway/server.go
+421 loc · ccn 100 · commits (last 12mo) 21</title></rect>
+<rect x="157.55" y="861.38" width="28.12" height="29.48" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/integration_test/mapping_e2e_test.go
+415 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="185.67" y="861.38" width="14.33" height="23.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/networkpolicy.yaml
+172 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="200.00" y="861.38" width="13.58" height="23.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/deployment.yaml
+163 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="185.67" y="885.36" width="8.34" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/ingress.yaml
+23 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="194.01" y="885.36" width="7.61" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/configmap.yaml
+21 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="201.62" y="885.36" width="5.80" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/service.yaml
+16 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="207.42" y="885.36" width="3.26" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="210.69" y="885.36" width="2.90" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/k8s/kustomization.yaml
+8 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="213.59" y="861.38" width="25.21" height="29.48" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/content_negotiation_test.go
+372 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="238.79" y="861.38" width="25.14" height="27.58" fill="#fdcb94" stroke="white" stroke-width="0.5"><title>services/api-gateway/cmd/main.go
+347 loc · ccn 67 · commits (last 12mo) 8</title></rect>
+<rect x="238.79" y="888.96" width="25.14" height="1.91" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/api-gateway/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="129.02" y="890.87" width="25.43" height="28.76" fill="#fdcf98" stroke="white" stroke-width="0.5"><title>services/api-gateway/registration_handler.go
+366 loc · ccn 60 · commits (last 12mo) 9</title></rect>
+<rect x="129.02" y="919.62" width="25.43" height="27.66" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_flows_test.go
+352 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="129.02" y="947.28" width="25.43" height="26.79" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/api-gateway/verification_handler_test.go
+341 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="129.02" y="974.07" width="25.43" height="25.93" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>services/api-gateway/transcoding_bench_test.go
+330 loc · ccn 64 · commits (last 12mo) 3</title></rect>
+<rect x="154.45" y="890.87" width="23.12" height="28.43" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_handler_test.go
+329 loc · ccn 26 · commits (last 12mo) 5</title></rect>
+<rect x="154.45" y="919.29" width="23.12" height="27.31" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/api-gateway/README.md
+316 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="154.45" y="946.60" width="23.12" height="26.87" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/admin_handler_test.go
+311 loc · ccn 51 · commits (last 12mo) 1</title></rect>
+<rect x="154.45" y="973.47" width="12.00" height="17.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/health/health_test.go
+108 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="166.45" y="973.47" width="11.12" height="17.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/health/backend_checker_test.go
+100 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="154.45" y="991.45" width="15.41" height="8.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/health/backend_checker.go
+66 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="169.86" y="991.45" width="7.71" height="8.55" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/api-gateway/health/health.go
+33 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="177.57" y="890.87" width="23.13" height="25.31" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/api-gateway/headers_test.go
+293 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="200.70" y="890.87" width="22.03" height="25.31" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/password_reset_handler_test.go
+279 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="222.72" y="890.87" width="21.95" height="25.31" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/proxy_integration_test.go
+278 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="244.67" y="890.87" width="19.26" height="25.31" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/api-gateway/verification_handler.go
+244 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="177.57" y="916.17" width="21.59" height="22.21" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/api-gateway/resend_webhook_handler_test.go
+240 loc · ccn 42 · commits (last 12mo) 3</title></rect>
+<rect x="177.57" y="938.38" width="21.59" height="22.11" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/mcp_consent_handler_test.go
+239 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="177.57" y="960.49" width="21.59" height="20.54" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/api-gateway/password_reset_handler.go
+222 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="177.57" y="981.03" width="21.59" height="18.97" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/api-gateway/config.go
+205 loc · ccn 44 · commits (last 12mo) 3</title></rect>
+<rect x="199.16" y="916.17" width="22.53" height="17.73" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/server_integration_test.go
+200 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="221.69" y="916.17" width="22.19" height="17.73" fill="#f7dab2" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_handler.go
+197 loc · ccn 33 · commits (last 12mo) 7</title></rect>
+<rect x="243.88" y="916.17" width="20.05" height="17.73" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/metadata_test.go
+178 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="199.16" y="933.91" width="16.38" height="19.03" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/api-gateway/resend_webhook_handler.go
+156 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="215.54" y="933.91" width="16.27" height="19.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/providers_test.go
+155 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="231.81" y="933.91" width="16.06" height="19.03" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/mcp_consent_handler.go
+153 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="247.87" y="933.91" width="16.06" height="19.03" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/error_response_test.go
+153 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="199.16" y="952.94" width="16.43" height="17.51" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/consent_code_store_test.go
+144 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="199.16" y="970.45" width="16.43" height="16.30" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/admin_handler.go
+134 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="199.16" y="986.74" width="16.43" height="13.26" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/tenant_info_handler.go
+109 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="215.59" y="952.94" width="12.95" height="16.36" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/proxy.go
+106 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="215.59" y="969.29" width="12.95" height="15.59" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/tenant_info_handler_test.go
+101 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="215.59" y="984.88" width="12.95" height="15.12" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/consent_code_store.go
+98 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="228.53" y="952.94" width="12.17" height="16.08" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/api-gateway/error_response.go
+98 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="240.71" y="952.94" width="11.80" height="16.08" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_sso_state.go
+95 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="252.51" y="952.94" width="11.43" height="16.08" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_sso_state_test.go
+92 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="228.53" y="969.02" width="15.02" height="10.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_builder_test.go
+79 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="228.53" y="979.52" width="15.02" height="10.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/providers.go
+77 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="228.53" y="989.76" width="15.02" height="10.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/transcoder.go
+77 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="243.56" y="969.02" width="10.35" height="12.55" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/api-gateway/registration_rate_limiter.go
+65 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="253.90" y="969.02" width="10.03" height="12.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/transcoder_test.go
+63 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="243.56" y="981.57" width="11.27" height="9.22" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/api-gateway/auth_builder.go
+52 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="243.56" y="990.78" width="11.27" height="9.22" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/headers.go
+52 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="254.83" y="981.57" width="9.10" height="10.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/api-gateway/metadata.go
+48 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="254.83" y="992.10" width="9.10" height="7.90" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>services/api-gateway/registration_rate_limiter_test.go
+36 loc · ccn 6 · commits (last 12mo) 3</title></rect>
+<rect x="263.93" y="284.26" width="37.89" height="67.80" fill="#e7cbb2" stroke="white" stroke-width="0.5"><title>services/internal-account/service/server_test.go
+1286 loc · ccn 79 · commits (last 12mo) 4</title></rect>
+<rect x="263.93" y="352.06" width="37.89" height="33.80" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/internal-account/service/balance_service_test.go
+641 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="263.93" y="385.86" width="37.89" height="26.89" fill="#ecba9a" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_service.go
+510 loc · ccn 112 · commits (last 12mo) 5</title></rect>
+<rect x="301.83" y="284.26" width="29.15" height="31.39" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/internal-account/service/valuation_engine_test.go
+458 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="330.97" y="284.26" width="25.26" height="31.39" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/internal-account/service/valuation_feature_service_test.go
+397 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="356.24" y="284.26" width="25.01" height="31.39" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/service/server_unhappy_test.go
+393 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="381.25" y="284.26" width="23.99" height="31.39" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_integration_test.go
+377 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="301.83" y="315.65" width="26.91" height="26.95" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_precision_test.go
+363 loc · ccn 41 · commits (last 12mo) 2</title></rect>
+<rect x="301.83" y="342.60" width="26.91" height="24.27" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_idempotency_test.go
+327 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="301.83" y="366.87" width="26.91" height="23.38" fill="#e1cfbd" stroke="white" stroke-width="0.5"><title>services/internal-account/service/valuation_feature_service.go
+315 loc · ccn 65 · commits (last 12mo) 3</title></rect>
+<rect x="301.83" y="390.25" width="26.91" height="22.49" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/internal-account/service/product_type_test.go
+303 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="328.74" y="315.65" width="26.04" height="22.33" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/internal-account/service/valuation_engine.go
+291 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="354.78" y="315.65" width="25.59" height="22.33" fill="#e7d1b9" stroke="white" stroke-width="0.5"><title>services/internal-account/service/grpc_account_endpoints.go
+286 loc · ccn 53 · commits (last 12mo) 4</title></rect>
+<rect x="380.37" y="315.65" width="24.87" height="22.33" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_unhappy_test.go
+278 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="328.74" y="337.98" width="19.72" height="25.73" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/internal-account/service/health.go
+254 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="328.74" y="363.71" width="19.72" height="24.72" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/internal-account/service/valuation_feature_coverage_test.go
+244 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="328.74" y="388.43" width="19.72" height="24.31" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/internal-account/service/health_test.go
+240 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="348.46" y="337.98" width="19.97" height="21.60" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/service/server_coverage_test.go
+216 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="368.43" y="337.98" width="18.50" height="21.60" fill="#f7d8b0" stroke="white" stroke-width="0.5"><title>services/internal-account/service/server.go
+200 loc · ccn 35 · commits (last 12mo) 7</title></rect>
+<rect x="386.93" y="337.98" width="18.31" height="21.60" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/internal-account/service/mappers_test.go
+198 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="348.46" y="359.58" width="20.10" height="19.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_coverage_test.go
+195 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="348.46" y="378.96" width="20.10" height="17.79" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/internal-account/service/errors_test.go
+179 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="348.46" y="396.75" width="20.10" height="16.00" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_initiate_helpers.go
+161 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="368.56" y="359.58" width="18.34" height="15.69" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/internal-account/service/mappers.go
+144 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="386.90" y="359.58" width="18.34" height="15.69" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/service/grpc_account_helpers.go
+144 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="368.56" y="375.27" width="19.21" height="14.87" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/internal-account/service/health_coverage_test.go
+143 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="387.77" y="375.27" width="17.46" height="14.87" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_service_test.go
+130 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="368.56" y="390.14" width="18.47" height="11.46" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/service/lien_idempotency_coverage_test.go
+106 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="368.56" y="401.61" width="18.47" height="11.14" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/internal-account/service/grpc_query_endpoints.go
+103 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="387.03" y="390.14" width="18.21" height="10.75" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/internal-account/service/grpc_balance_endpoints.go
+98 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="387.03" y="400.90" width="13.65" height="11.85" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/service/outbox_test.go
+81 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="400.69" y="400.90" width="4.55" height="6.58" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/service/client_interfaces.go
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="400.69" y="407.48" width="4.55" height="4.83" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/service/errors.go
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="400.69" y="412.31" width="4.55" height="0.44" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/service/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="405.24" y="284.26" width="45.32" height="53.52" fill="#e6c3aa" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/repository_integration_test.go
+1214 loc · ccn 103 · commits (last 12mo) 4</title></rect>
+<rect x="450.56" y="284.26" width="27.96" height="53.52" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/mappers_test.go
+749 loc · ccn 53 · commits (last 12mo) 2</title></rect>
+<rect x="405.24" y="337.78" width="27.69" height="28.50" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/repository_test.go
+395 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="405.24" y="366.27" width="27.69" height="26.55" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/lien_repository_test.go
+368 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="432.93" y="337.78" width="24.43" height="25.02" fill="#eccaaa" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/repository.go
+306 loc · ccn 74 · commits (last 12mo) 5</title></rect>
+<rect x="457.36" y="337.78" width="21.16" height="25.02" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/lien_repository.go
+265 loc · ccn 54 · commits (last 12mo) 2</title></rect>
+<rect x="432.93" y="362.80" width="22.36" height="18.14" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/lien_conversion_test.go
+203 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="432.93" y="380.94" width="22.36" height="11.88" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/repository_methods_test.go
+133 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="455.29" y="362.80" width="23.23" height="11.27" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/mappers.go
+131 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="455.29" y="374.07" width="15.56" height="9.50" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/valuation_feature_repository_test.go
+74 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="455.29" y="383.57" width="15.56" height="9.25" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/account_entity.go
+72 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="470.85" y="374.07" width="7.67" height="13.54" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/lien_entity.go
+52 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="470.85" y="387.61" width="5.37" height="5.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/valuation_feature_repository.go
+14 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="476.22" y="387.61" width="2.30" height="4.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/valuation_feature_entity.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="476.22" y="391.95" width="2.30" height="0.87" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/persistence/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="405.24" y="392.82" width="53.73" height="19.93" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/grpc/position_keeping_client_test.go
+536 loc · ccn 61 · commits (last 12mo) 2</title></rect>
+<rect x="458.97" y="392.82" width="19.45" height="19.83" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/grpc/position_keeping_client.go
+193 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="458.97" y="412.64" width="19.45" height="0.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/grpc/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="478.42" y="392.82" width="0.10" height="19.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/adapters/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="412.75" width="38.85" height="56.67" fill="#e7ccb3" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/internal_account_test.go
+1102 loc · ccn 73 · commits (last 12mo) 4</title></rect>
+<rect x="263.93" y="469.42" width="38.85" height="21.14" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/counterparty_test.go
+411 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="302.78" y="412.75" width="22.56" height="26.57" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/account_status_test.go
+300 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="325.34" y="412.75" width="22.56" height="26.57" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/lien_test.go
+300 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="302.78" y="439.32" width="24.37" height="24.18" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/internal_account.go
+295 loc · ccn 75 · commits (last 12mo) 2</title></rect>
+<rect x="327.16" y="439.32" width="20.74" height="24.18" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/account_type_test.go
+251 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="302.78" y="463.50" width="21.12" height="13.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/clearing_purpose_test.go
+143 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="302.78" y="477.02" width="21.12" height="13.53" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/lien.go
+143 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="323.90" y="463.50" width="14.66" height="13.49" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/counterparty.go
+99 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="338.56" y="463.50" width="9.33" height="13.49" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/valuation_feature_test.go
+63 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="323.90" y="476.98" width="7.51" height="13.57" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/account_status.go
+51 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="331.41" y="476.98" width="7.51" height="7.72" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/account_type.go
+29 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="331.41" y="484.70" width="7.51" height="5.85" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/clearing_purpose.go
+22 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="338.92" y="476.98" width="8.98" height="4.89" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/repository.go
+22 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="338.92" y="481.88" width="4.61" height="8.68" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/errors.go
+20 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="343.52" y="481.88" width="4.37" height="8.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/valuation_feature.go
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="343.52" y="490.10" width="4.37" height="0.46" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/domain/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="263.93" y="490.55" width="67.09" height="42.97" fill="#e4a995" stroke="white" stroke-width="0.5"><title>services/internal-account/e2e/e2e_test.go
+1443 loc · ccn 159 · commits (last 12mo) 4</title></rect>
+<rect x="331.02" y="490.55" width="16.88" height="42.85" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/internal-account/e2e/get_balance_integration_test.go
+362 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="331.02" y="533.41" width="16.88" height="0.12" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/e2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="347.90" y="412.75" width="26.91" height="33.11" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>services/internal-account/benchmarks/load_test.go
+446 loc · ccn 71 · commits (last 12mo) 3</title></rect>
+<rect x="374.81" y="412.75" width="20.70" height="33.11" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/internal-account/benchmarks/nfr_validation_test.go
+343 loc · ccn 52 · commits (last 12mo) 3</title></rect>
+<rect x="347.90" y="445.86" width="20.52" height="30.09" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>services/internal-account/benchmarks/helpers_test.go
+309 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="368.41" y="445.86" width="27.09" height="21.61" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/internal-account/benchmarks/performance_bench_test.go
+293 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="368.41" y="467.47" width="27.09" height="8.48" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/internal-account/benchmarks/README.md
+115 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="347.90" y="475.95" width="28.25" height="30.76" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/internal-account/client/starlark_test.go
+435 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="376.15" y="475.95" width="19.35" height="30.76" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/client/client_rpc_test.go
+298 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="347.90" y="506.71" width="16.99" height="26.82" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/client/client_test.go
+228 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="364.88" y="506.71" width="16.54" height="26.82" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/internal-account/client/starlark.go
+222 loc · ccn 39 · commits (last 12mo) 3</title></rect>
+<rect x="381.42" y="506.71" width="14.08" height="26.82" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/internal-account/client/client.go
+189 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="395.50" y="412.75" width="22.71" height="28.41" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/internal-account/observability/health_test.go
+323 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="418.21" y="412.75" width="19.62" height="28.41" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/internal-account/observability/health.go
+279 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="395.50" y="441.16" width="24.48" height="16.57" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/internal-account/observability/metrics.go
+203 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="419.98" y="441.16" width="17.85" height="16.57" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/internal-account/observability/metrics_test.go
+148 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="437.83" y="412.75" width="21.22" height="22.68" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/default_accounts_test.go
+241 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="459.06" y="412.75" width="19.46" height="22.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/default_accounts.go
+221 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="437.83" y="435.43" width="19.36" height="22.29" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/templates.go
+216 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="457.19" y="435.43" width="21.33" height="12.83" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/templates_test.go
+137 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="457.19" y="448.26" width="14.57" height="9.46" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/hooks_test.go
+69 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="471.76" y="448.26" width="6.76" height="9.46" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/provisioning/hooks.go
+32 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="395.50" y="457.72" width="17.26" height="21.29" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/account_lifecycle.go
+184 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="395.50" y="479.02" width="17.26" height="17.71" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/README.md
+153 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="412.76" y="457.72" width="22.74" height="13.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/multi_asset.go
+152 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="412.76" y="471.07" width="22.74" height="13.00" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/counterparty_account.go
+148 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="412.76" y="484.07" width="14.06" height="12.65" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/query_balance.go
+89 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="426.82" y="484.07" width="8.69" height="12.42" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/create_clearing_account.go
+54 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="426.82" y="496.49" width="8.69" height="0.23" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/internal-account/examples/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="395.50" y="496.72" width="28.17" height="36.80" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/schema_test.go
+519 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="423.67" y="496.72" width="11.83" height="13.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260112000001_initial.sql
+77 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="423.67" y="509.72" width="11.83" height="7.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260206000001_create_valuation_features.sql
+46 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="423.67" y="517.49" width="11.83" height="7.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260207000001_create_lien_table.sql
+43 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="423.67" y="524.75" width="7.51" height="4.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260116000002_backfill_clearing_purpose.sql
+17 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="423.67" y="529.27" width="7.51" height="4.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260225000001_rename_to_internal_account.sql
+16 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="431.18" y="524.75" width="2.47" height="3.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260116000001_add_clearing_purpose_column.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="433.65" y="524.75" width="1.85" height="3.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260220000001_add_product_type_code.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="431.18" y="527.98" width="2.16" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260225000002_rename_correspondent_to_counterparty.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="433.35" y="527.98" width="2.16" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260214000001_add_org_party_id.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="431.18" y="530.75" width="1.44" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260220000002_add_product_type_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="432.62" y="530.75" width="1.44" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260306000001_widen_lien_currency.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="434.07" y="530.75" width="1.44" height="1.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260214000002_add_org_scoping_indexes.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="434.07" y="532.14" width="1.44" height="1.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/migrations/20260306000002_rename_lien_currency_to_instrument_code.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="435.51" y="457.72" width="24.53" height="36.97" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/internal-account/docs/openapi.json
+454 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="460.04" y="457.72" width="18.48" height="14.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/deployment.yaml
+137 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="460.04" y="472.53" width="11.15" height="12.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/networkpolicy.yaml
+67 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="471.19" y="472.53" width="7.33" height="12.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/hpa.yaml
+44 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="460.04" y="484.53" width="8.26" height="5.08" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/service.yaml
+21 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="460.04" y="489.61" width="8.26" height="5.08" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/configmap.yaml
+21 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="468.30" y="484.53" width="6.49" height="6.47" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/servicemonitor.yaml
+21 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="468.30" y="491.00" width="6.49" height="3.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/poddisruptionbudget.yaml
+12 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="474.78" y="484.53" width="3.74" height="5.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/kustomization.yaml
+10 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="474.78" y="489.88" width="3.74" height="4.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="435.51" y="494.69" width="15.17" height="21.20" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/internal-account/app/container.go
+161 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="450.68" y="494.69" width="7.26" height="21.20" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/app/container_test.go
+77 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="435.51" y="515.89" width="22.43" height="17.63" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/internal-account/README.md
+198 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="457.94" y="494.69" width="17.98" height="18.44" fill="#ecd8be" stroke="white" stroke-width="0.5"><title>services/internal-account/cmd/main.go
+166 loc · ccn 29 · commits (last 12mo) 5</title></rect>
+<rect x="475.92" y="494.69" width="2.60" height="18.44" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/internal-account/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="457.94" y="513.14" width="10.94" height="12.41" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/internal-account/rbac/method_permissions.go
+68 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="468.88" y="513.14" width="4.34" height="12.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/internal-account/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="457.94" y="525.55" width="15.29" height="7.97" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/atlas/atlas.hcl
+61 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="473.23" y="513.14" width="5.29" height="20.39" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/internal-account/testhelpers/factories.go
+54 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="478.52" y="284.26" width="56.17" height="69.11" fill="#fca973" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/financial_accounting_service_test.go
+1943 loc · ccn 116 · commits (last 12mo) 11</title></rect>
+<rect x="478.52" y="353.37" width="56.17" height="42.96" fill="#fdc993" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_integration_test.go
+1208 loc · ccn 70 · commits (last 12mo) 19</title></rect>
+<rect x="534.69" y="284.26" width="36.12" height="40.60" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/pure_functions_test.go
+734 loc · ccn 64 · commits (last 12mo) 3</title></rect>
+<rect x="534.69" y="324.86" width="36.12" height="37.78" fill="#f7d5a9" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/list_ledger_postings_test.go
+683 loc · ccn 44 · commits (last 12mo) 7</title></rect>
+<rect x="534.69" y="362.64" width="36.12" height="33.69" fill="#ecd2b2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/account_resolver_test.go
+609 loc · ccn 52 · commits (last 12mo) 5</title></rect>
+<rect x="570.80" y="284.26" width="39.79" height="28.57" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/idempotency_chaos_test.go
+569 loc · ccn 71 · commits (last 12mo) 3</title></rect>
+<rect x="610.59" y="284.26" width="38.39" height="28.57" fill="#fdd5a0" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/posting_service_test.go
+549 loc · ccn 48 · commits (last 12mo) 13</title></rect>
+<rect x="648.98" y="284.26" width="27.55" height="28.57" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/booking_log_endpoints_test.go
+394 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="570.80" y="312.83" width="26.56" height="29.04" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_booking_endpoints_test.go
+386 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="570.80" y="341.87" width="26.56" height="27.31" fill="#eccfaf" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_mappers.go
+363 loc · ccn 59 · commits (last 12mo) 5</title></rect>
+<rect x="570.80" y="369.17" width="26.56" height="27.16" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/adapters_test.go
+361 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="597.36" y="312.83" width="28.23" height="21.37" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/posting_service_bench_test.go
+302 loc · ccn 62 · commits (last 12mo) 3</title></rect>
+<rect x="625.59" y="312.83" width="25.70" height="21.37" fill="#e7d8c7" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/list_booking_logs_test.go
+275 loc · ccn 21 · commits (last 12mo) 4</title></rect>
+<rect x="651.29" y="312.83" width="25.24" height="21.37" fill="#eccfaf" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_posting_endpoints.go
+270 loc · ccn 61 · commits (last 12mo) 5</title></rect>
+<rect x="597.36" y="334.20" width="24.18" height="21.07" fill="#f7d0a1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_booking_endpoints.go
+255 loc · ccn 56 · commits (last 12mo) 7</title></rect>
+<rect x="597.36" y="355.27" width="24.18" height="20.82" fill="#f2dcbf" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/retrieve_list_service_test.go
+252 loc · ccn 21 · commits (last 12mo) 6</title></rect>
+<rect x="597.36" y="376.09" width="24.18" height="20.24" fill="#f7d8b0" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/posting_service.go
+245 loc · ccn 36 · commits (last 12mo) 7</title></rect>
+<rect x="621.54" y="334.20" width="19.14" height="23.91" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_posting_endpoints_test.go
+229 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="640.68" y="334.20" width="18.72" height="23.91" fill="#fdd09a" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/adapters.go
+224 loc · ccn 56 · commits (last 12mo) 8</title></rect>
+<rect x="659.40" y="334.20" width="17.13" height="23.91" fill="#ecd7bd" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/account_resolver.go
+205 loc · ccn 31 · commits (last 12mo) 5</title></rect>
+<rect x="621.54" y="358.11" width="19.39" height="20.60" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_ledger_endpoints_test.go
+200 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="621.54" y="378.71" width="19.39" height="17.62" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_validators.go
+171 loc · ccn 41 · commits (last 12mo) 2</title></rect>
+<rect x="640.93" y="358.11" width="17.86" height="15.77" fill="#ecd8be" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_control_endpoints.go
+141 loc · ccn 29 · commits (last 12mo) 5</title></rect>
+<rect x="658.80" y="358.11" width="17.73" height="15.77" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_control_endpoints_test.go
+140 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="640.93" y="373.88" width="19.04" height="12.90" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/server.go
+123 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="640.93" y="386.78" width="19.04" height="9.55" fill="#e7d9c7" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/grpc_ledger_endpoints.go
+91 loc · ccn 19 · commits (last 12mo) 4</title></rect>
+<rect x="659.98" y="373.88" width="16.55" height="10.98" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/server_coverage_test.go
+91 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="659.98" y="384.86" width="14.64" height="11.47" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/server_test.go
+84 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="674.61" y="384.86" width="1.92" height="10.42" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/client_interfaces.go
+10 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="674.61" y="395.29" width="1.92" height="1.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/service/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="478.52" y="396.33" width="36.60" height="44.71" fill="#f19f79" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/financial_booking_log_test.go
+819 loc · ccn 143 · commits (last 12mo) 6</title></rect>
+<rect x="478.52" y="441.04" width="36.60" height="25.17" fill="#dccbc1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/validation_test.go
+461 loc · ccn 100 · commits (last 12mo) 2</title></rect>
+<rect x="515.12" y="396.33" width="39.73" height="22.28" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/chart_of_accounts_test.go
+443 loc · ccn 92 · commits (last 12mo) 1</title></rect>
+<rect x="554.84" y="396.33" width="16.59" height="22.28" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/testfixtures/fixtures.go
+185 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="571.44" y="396.33" width="11.93" height="15.74" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/testfixtures/fixtures_test.go
+94 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="571.44" y="412.08" width="11.93" height="6.53" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/testfixtures/fixtures_coverage_test.go
+39 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="515.12" y="418.61" width="15.74" height="23.86" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/ledger_posting_test.go
+188 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="515.12" y="442.47" width="15.74" height="23.74" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/validation.go
+187 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="530.86" y="418.61" width="18.89" height="17.45" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/financial_booking_log.go
+165 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="530.86" y="436.06" width="18.89" height="15.23" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/transaction_status_test.go
+144 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="530.86" y="451.29" width="18.89" height="14.91" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/quantity_test.go
+141 loc · ccn 44 · commits (last 12mo) 1</title></rect>
+<rect x="549.74" y="418.61" width="18.29" height="14.86" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/cel_adapter_test.go
+136 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="568.03" y="418.61" width="15.33" height="14.86" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/account_type_test.go
+114 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="549.74" y="433.46" width="13.18" height="16.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/posting_direction_test.go
+109 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="549.74" y="449.99" width="13.18" height="16.22" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/chart_of_accounts.go
+107 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="562.92" y="433.46" width="11.59" height="13.10" fill="#e7dbcc" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/ledger_posting.go
+76 loc · ccn 9 · commits (last 12mo) 4</title></rect>
+<rect x="574.52" y="433.46" width="8.85" height="13.10" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/quantity.go
+58 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="562.92" y="446.56" width="10.07" height="10.32" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/currency_test.go
+52 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="562.92" y="456.88" width="10.07" height="9.33" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/currency_coverage_test.go
+47 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="572.99" y="446.56" width="10.37" height="6.93" fill="#f8e3c7" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/currency.go
+36 loc · ccn 5 · commits (last 12mo) 7</title></rect>
+<rect x="572.99" y="453.49" width="5.74" height="9.05" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/transaction_status.go
+26 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="578.73" y="453.49" width="4.63" height="9.05" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/account_type.go
+21 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="572.99" y="462.55" width="9.83" height="3.66" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/posting_direction.go
+18 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="582.82" y="462.55" width="0.55" height="3.66" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/domain/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="478.52" y="466.20" width="34.66" height="38.85" fill="#fdddb2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/repository_test.go
+674 loc · ccn 26 · commits (last 12mo) 13</title></rect>
+<rect x="478.52" y="505.05" width="34.66" height="28.47" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/repository_bench_test.go
+494 loc · ccn 92 · commits (last 12mo) 2</title></rect>
+<rect x="513.18" y="466.20" width="38.28" height="20.56" fill="#fdbd86" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/repository.go
+394 loc · ccn 93 · commits (last 12mo) 13</title></rect>
+<rect x="513.18" y="486.77" width="38.28" height="19.67" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/booking_log_repository_test.go
+377 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="513.18" y="506.44" width="18.88" height="27.08" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/cursor_pagination_test.go
+256 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="532.06" y="506.44" width="19.40" height="13.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/repository_mapping.go
+128 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="532.06" y="519.62" width="7.33" height="13.90" fill="#f2e0c8" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/ledger_posting_entity.go
+51 loc · ccn 7 · commits (last 12mo) 6</title></rect>
+<rect x="539.39" y="519.62" width="12.07" height="7.28" fill="#f2e0c8" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/booking_log_entity.go
+44 loc · ccn 7 · commits (last 12mo) 6</title></rect>
+<rect x="539.39" y="526.90" width="12.07" height="6.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/persistence/entity_test.go
+40 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="551.46" y="466.20" width="31.90" height="54.48" fill="#fcb982" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+870 loc · ccn 99 · commits (last 12mo) 13</title></rect>
+<rect x="551.46" y="520.69" width="31.90" height="12.84" fill="#ecd4b6" stroke="white" stroke-width="0.5"><title>services/financial-accounting/adapters/messaging/deposit_consumer.go
+205 loc · ccn 43 · commits (last 12mo) 5</title></rect>
+<rect x="583.36" y="396.33" width="31.21" height="28.74" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/starlark_test.go
+449 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="614.57" y="396.33" width="24.26" height="28.74" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/starlark_coverage_test.go
+349 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="583.36" y="425.07" width="18.34" height="36.81" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/starlark_handlers.go
+338 loc · ccn 60 · commits (last 12mo) 2</title></rect>
+<rect x="601.71" y="425.07" width="21.60" height="19.05" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/client.go
+206 loc · ccn 42 · commits (last 12mo) 3</title></rect>
+<rect x="601.71" y="444.13" width="21.60" height="17.76" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/client_methods_test.go
+192 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="623.31" y="425.07" width="15.52" height="22.39" fill="#fddfb5" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/starlark.go
+174 loc · ccn 24 · commits (last 12mo) 10</title></rect>
+<rect x="623.31" y="447.47" width="15.52" height="14.42" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/financial-accounting/client/client_test.go
+112 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="638.83" y="396.33" width="19.50" height="30.84" fill="#f7dbb4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/metrics.go
+301 loc · ccn 29 · commits (last 12mo) 7</title></rect>
+<rect x="658.33" y="396.33" width="18.20" height="30.84" fill="#ecd1b1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/health.go
+281 loc · ccn 53 · commits (last 12mo) 5</title></rect>
+<rect x="638.83" y="427.17" width="26.82" height="17.88" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/health_test.go
+240 loc · ccn 21 · commits (last 12mo) 3</title></rect>
+<rect x="638.83" y="445.05" width="26.82" height="16.83" fill="#f2d9b8" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/metrics_test.go
+226 loc · ccn 31 · commits (last 12mo) 6</title></rect>
+<rect x="665.65" y="427.17" width="10.88" height="28.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/health_coverage_test.go
+154 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="665.65" y="455.46" width="10.88" height="6.43" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/observability/metrics_coverage_test.go
+35 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="583.36" y="461.88" width="42.14" height="26.41" fill="#e7cfb6" stroke="white" stroke-width="0.5"><title>services/financial-accounting/worker/idempotency_cleanup_worker_test.go
+557 loc · ccn 63 · commits (last 12mo) 4</title></rect>
+<rect x="583.36" y="488.29" width="26.27" height="20.53" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/financial-accounting/worker/idempotency_cleanup_worker.go
+270 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="609.64" y="488.29" width="15.86" height="20.53" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/worker/idempotency_cleanup_worker_error_test.go
+163 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="583.36" y="508.82" width="42.14" height="24.70" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/e2e/e2e_test.go
+521 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="625.50" y="461.88" width="29.78" height="27.03" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/financial-accounting/app/container.go
+403 loc · ccn 66 · commits (last 12mo) 1</title></rect>
+<rect x="625.50" y="488.92" width="29.78" height="7.38" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/app/container_test.go
+110 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="655.28" y="461.88" width="21.25" height="21.15" fill="#fdd8a6" stroke="white" stroke-width="0.5"><title>services/financial-accounting/cmd/main.go
+225 loc · ccn 40 · commits (last 12mo) 37</title></rect>
+<rect x="655.28" y="483.04" width="16.73" height="13.26" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>services/financial-accounting/cmd/main_test.go
+111 loc · ccn 11 · commits (last 12mo) 4</title></rect>
+<rect x="672.01" y="483.04" width="4.52" height="10.61" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/financial-accounting/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 10</title></rect>
+<rect x="672.01" y="493.64" width="4.52" height="2.65" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/cmd/tools.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="625.50" y="496.29" width="18.58" height="20.21" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/deployment.yaml
+188 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="644.08" y="496.29" width="11.47" height="10.45" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/networkpolicy.yaml
+60 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="644.08" y="506.75" width="8.19" height="5.61" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/configmap.yaml
+23 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="644.08" y="512.36" width="8.19" height="4.15" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="652.27" y="506.75" width="3.28" height="5.49" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="652.27" y="512.24" width="3.28" height="4.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="625.50" y="516.51" width="9.39" height="17.02" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20251219000001_fix_audit_schema_compatibility.sql
+80 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="634.89" y="516.51" width="13.73" height="9.16" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20251217000001_audit_system.sql
+63 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="634.89" y="525.67" width="13.73" height="7.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20251216000001_initial.sql
+54 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="648.62" y="516.51" width="6.93" height="10.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20251223000001_event_outbox.sql
+35 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="648.62" y="526.60" width="4.04" height="3.96" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260105000001_multi_asset_support.sql
+8 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="648.62" y="530.56" width="4.04" height="2.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="652.66" y="526.60" width="2.89" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="652.66" y="529.37" width="1.44" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260309000001_add_account_service_domain.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="654.11" y="529.37" width="1.44" height="2.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260306000001_widen_base_currency.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="652.66" y="532.14" width="1.44" height="1.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260316000001_add_event_outbox_tenant_id.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="654.11" y="532.14" width="1.44" height="1.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/migrations/20260316000002_add_event_outbox_tenant_id_index.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="655.55" y="496.29" width="20.98" height="16.28" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/financial-accounting/README.md
+171 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="655.55" y="512.58" width="9.82" height="11.59" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/config/config_test.go
+57 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="665.37" y="512.58" width="5.34" height="11.59" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/config/config.go
+31 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="655.55" y="524.17" width="9.40" height="9.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-accounting/rbac/method_permissions.go
+44 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="664.95" y="524.17" width="5.77" height="9.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-accounting/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="670.71" y="512.58" width="5.82" height="20.95" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/financial-accounting/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="676.53" y="284.26" width="39.43" height="43.78" fill="#f7b485" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_service_test.go
+864 loc · ccn 108 · commits (last 12mo) 7</title></rect>
+<rect x="676.53" y="328.04" width="39.43" height="30.20" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_service_integration_test.go
+596 loc · ccn 30 · commits (last 12mo) 8</title></rect>
+<rect x="676.53" y="358.24" width="39.43" height="29.90" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/party/service/lifecycle_integration_test.go
+590 loc · ccn 33 · commits (last 12mo) 8</title></rect>
+<rect x="715.96" y="284.26" width="26.95" height="37.52" fill="#e7d1b8" stroke="white" stroke-width="0.5"><title>services/party/service/verification_service_test.go
+506 loc · ccn 55 · commits (last 12mo) 4</title></rect>
+<rect x="715.96" y="321.78" width="26.95" height="33.88" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/party/service/kafka_cascade_integration_test.go
+457 loc · ccn 42 · commits (last 12mo) 4</title></rect>
+<rect x="715.96" y="355.66" width="26.95" height="32.47" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/party/service/verification_integration_test.go
+438 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="742.90" y="284.26" width="30.77" height="27.98" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/party/service/update_control_test.go
+431 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="742.90" y="312.24" width="30.77" height="26.68" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/party/service/association_handlers_test.go
+411 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="742.90" y="338.92" width="30.77" height="24.86" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/service/demographics_handlers_test.go
+383 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="742.90" y="363.79" width="30.77" height="24.35" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_payment_methods_test.go
+375 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="773.67" y="284.26" width="26.22" height="28.04" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/party/service/proto_converters_test.go
+368 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="799.89" y="284.26" width="25.79" height="28.04" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/party/service/party_handlers.go
+362 loc · ccn 78 · commits (last 12mo) 2</title></rect>
+<rect x="825.68" y="284.26" width="24.36" height="28.04" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_party_type_test.go
+342 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="850.05" y="284.26" width="23.58" height="28.04" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/party/service/party_type_service_test.go
+331 loc · ccn 44 · commits (last 12mo) 2</title></rect>
+<rect x="773.67" y="312.30" width="21.05" height="28.76" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_payment_methods.go
+303 loc · ccn 70 · commits (last 12mo) 2</title></rect>
+<rect x="773.67" y="341.06" width="21.05" height="23.73" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/service/reference_handlers_test.go
+250 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="773.67" y="364.79" width="21.05" height="23.35" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/party/service/proto_converters.go
+246 loc · ccn 77 · commits (last 12mo) 1</title></rect>
+<rect x="794.72" y="312.30" width="24.13" height="20.37" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_payment_methods_integration_test.go
+246 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="794.72" y="332.67" width="24.13" height="19.54" fill="#e7d6c2" stroke="white" stroke-width="0.5"><title>services/party/service/verification_service.go
+236 loc · ccn 31 · commits (last 12mo) 4</title></rect>
+<rect x="794.72" y="352.20" width="24.13" height="18.30" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/service/attribute_validation_integration_test.go
+221 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="794.72" y="370.50" width="24.13" height="17.63" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/party/service/association_handlers.go
+213 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="818.86" y="312.30" width="18.90" height="21.67" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/service/attribute_validator_test.go
+205 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="837.76" y="312.30" width="18.26" height="21.67" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/party/service/health.go
+198 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="856.01" y="312.30" width="17.61" height="21.67" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/party/service/grpc_party_type.go
+191 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="818.86" y="333.97" width="19.36" height="18.88" fill="#f2e0c7" stroke="white" stroke-width="0.5"><title>services/party/service/kyc_guard_test.go
+183 loc · ccn 8 · commits (last 12mo) 6</title></rect>
+<rect x="818.86" y="352.85" width="19.36" height="17.75" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/party/service/demographics_handlers.go
+172 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="818.86" y="370.59" width="19.36" height="17.54" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/party/service/party_type_service.go
+170 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="838.22" y="333.97" width="19.78" height="16.36" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/party/service/outbox_event_publisher_test.go
+162 loc · ccn 12 · commits (last 12mo) 3</title></rect>
+<rect x="858.00" y="333.97" width="15.63" height="16.36" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/service/health_watch_test.go
+128 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="838.22" y="350.33" width="17.70" height="13.99" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/party/service/attribute_validator.go
+124 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="855.92" y="350.33" width="17.70" height="13.99" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/service/party_handlers_test.go
+124 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="838.22" y="364.32" width="17.28" height="12.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/service/health_test.go
+108 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="838.22" y="376.81" width="17.28" height="11.33" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/party/service/server.go
+98 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="855.50" y="364.32" width="18.12" height="10.03" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/service/reference_handlers.go
+91 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="855.50" y="374.35" width="11.02" height="13.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/service/server_test.go
+76 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="866.52" y="374.35" width="7.10" height="13.78" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/party/service/outbox_event_publisher.go
+49 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="676.53" y="388.13" width="43.27" height="31.72" fill="#fdd6a2" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_test.go
+687 loc · ccn 44 · commits (last 12mo) 17</title></rect>
+<rect x="719.80" y="388.13" width="36.72" height="31.72" fill="#e7d7c5" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/payment_method_repository_test.go
+583 loc · ccn 25 · commits (last 12mo) 4</title></rect>
+<rect x="676.53" y="419.85" width="27.19" height="42.62" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_extended_test.go
+580 loc · ccn 60 · commits (last 12mo) 1</title></rect>
+<rect x="676.53" y="462.47" width="27.19" height="31.52" fill="#fdbc85" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository.go
+429 loc · ccn 95 · commits (last 12mo) 14</title></rect>
+<rect x="703.72" y="419.85" width="28.99" height="23.15" fill="#fde1ba" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/verification_repository_test.go
+336 loc · ccn 18 · commits (last 12mo) 9</title></rect>
+<rect x="732.71" y="419.85" width="23.82" height="23.15" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_type_definition_repository_test.go
+276 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="703.72" y="443.00" width="16.69" height="25.86" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/payment_method_repository.go
+216 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="703.72" y="468.86" width="16.69" height="25.14" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_association_migration_test.go
+210 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="720.41" y="443.00" width="19.00" height="15.98" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/verification_repository.go
+152 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="739.40" y="443.00" width="17.12" height="15.98" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_association.go
+137 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="720.41" y="458.98" width="13.70" height="17.65" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_type_definition_repository.go
+121 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="720.41" y="476.63" width="13.70" height="17.36" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_attributes_test.go
+119 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="734.10" y="458.98" width="11.90" height="11.58" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_bank_relation.go
+69 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="746.00" y="458.98" width="10.52" height="11.58" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_demographic.go
+61 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="734.10" y="470.56" width="11.21" height="10.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/repository_reference.go
+57 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="745.31" y="470.56" width="11.21" height="10.16" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/bq_entities.go
+57 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="734.10" y="480.72" width="6.77" height="13.27" fill="#fde6c3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_entity.go
+45 loc · ccn 7 · commits (last 12mo) 8</title></rect>
+<rect x="740.87" y="480.72" width="12.64" height="6.64" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/verification_entity.go
+42 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="740.87" y="487.36" width="12.64" height="6.64" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/payment_method_entity.go
+42 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="753.52" y="480.72" width="3.01" height="13.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/adapters/persistence/party_type_definition_entity.go
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="676.53" y="493.99" width="30.57" height="39.53" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/party/adapters/http/verification_webhook_test.go
+605 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="707.10" y="493.99" width="21.07" height="39.53" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/adapters/http/stripe_webhook_adapter_test.go
+417 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="728.18" y="493.99" width="28.35" height="21.21" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/party/adapters/http/verification_webhook.go
+301 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="728.18" y="515.20" width="28.35" height="18.32" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/party/adapters/http/stripe_webhook_adapter.go
+260 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="756.53" y="388.13" width="35.14" height="29.73" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/party/verification/onfido_provider_test.go
+523 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="756.53" y="417.86" width="35.14" height="27.46" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/party/verification/timeout_handler_test.go
+483 loc · ccn 43 · commits (last 12mo) 4</title></rect>
+<rect x="791.67" y="388.13" width="25.85" height="30.99" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/party/verification/stripe_provider_test.go
+401 loc · ccn 41 · commits (last 12mo) 2</title></rect>
+<rect x="791.67" y="419.12" width="25.85" height="26.20" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/party/verification/onfido_provider.go
+339 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="817.52" y="388.13" width="31.97" height="20.12" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/party/verification/integration_test.go
+322 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="849.50" y="388.13" width="24.13" height="20.12" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>services/party/verification/stripe_provider.go
+243 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="817.52" y="408.25" width="23.55" height="19.76" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/party/verification/provider_test.go
+233 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="817.52" y="428.02" width="23.55" height="17.30" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/verification/mock_provider.go
+204 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="841.07" y="408.25" width="17.70" height="20.31" fill="#ecdac2" stroke="white" stroke-width="0.5"><title>services/party/verification/factory_test.go
+180 loc · ccn 22 · commits (last 12mo) 5</title></rect>
+<rect x="858.78" y="408.25" width="14.85" height="20.31" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/party/verification/timeout_handler.go
+151 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="841.07" y="428.57" width="15.74" height="16.75" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/party/verification/stripe_integration_test.go
+132 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="856.81" y="428.57" width="10.25" height="16.75" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>services/party/verification/provider.go
+86 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="867.07" y="428.57" width="6.56" height="16.75" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>services/party/verification/factory.go
+55 loc · ccn 11 · commits (last 12mo) 4</title></rect>
+<rect x="756.53" y="445.32" width="44.60" height="25.76" fill="#e7d2ba" stroke="white" stroke-width="0.5"><title>services/party/domain/party_test.go
+575 loc · ccn 49 · commits (last 12mo) 4</title></rect>
+<rect x="756.53" y="471.08" width="23.21" height="41.48" fill="#ecc6a6" stroke="white" stroke-width="0.5"><title>services/party/domain/party.go
+482 loc · ccn 87 · commits (last 12mo) 5</title></rect>
+<rect x="779.74" y="471.08" width="21.38" height="41.48" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/party/domain/party_bq_test.go
+444 loc · ccn 36 · commits (last 12mo) 2</title></rect>
+<rect x="756.53" y="512.56" width="26.49" height="20.96" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/domain/payment_method_test.go
+278 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="783.02" y="512.56" width="18.11" height="20.96" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/party/domain/payment_method.go
+190 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="801.12" y="445.32" width="28.09" height="35.49" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/party/client/starlark_test.go
+499 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="829.21" y="445.32" width="22.91" height="35.49" fill="#e1d0bf" stroke="white" stroke-width="0.5"><title>services/party/client/client_test.go
+407 loc · ccn 56 · commits (last 12mo) 3</title></rect>
+<rect x="852.12" y="445.32" width="21.50" height="20.81" fill="#e7d3bc" stroke="white" stroke-width="0.5"><title>services/party/client/starlark.go
+224 loc · ccn 44 · commits (last 12mo) 4</title></rect>
+<rect x="852.12" y="466.13" width="21.50" height="14.68" fill="#ecd8be" stroke="white" stroke-width="0.5"><title>services/party/client/client.go
+158 loc · ccn 30 · commits (last 12mo) 5</title></rect>
+<rect x="801.12" y="480.81" width="24.62" height="29.78" fill="#fdcf98" stroke="white" stroke-width="0.5"><title>services/party/cmd/main.go
+367 loc · ccn 59 · commits (last 12mo) 24</title></rect>
+<rect x="825.75" y="480.81" width="12.48" height="25.93" fill="#f7d8b0" stroke="white" stroke-width="0.5"><title>services/party/cmd/main_test.go
+162 loc · ccn 36 · commits (last 12mo) 7</title></rect>
+<rect x="825.75" y="506.75" width="12.48" height="3.84" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/party/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 10</title></rect>
+<rect x="801.12" y="510.59" width="27.96" height="22.94" fill="#ecd6bb" stroke="white" stroke-width="0.5"><title>services/party/config/verification_test.go
+321 loc · ccn 36 · commits (last 12mo) 5</title></rect>
+<rect x="829.08" y="510.59" width="9.15" height="22.94" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>services/party/config/verification.go
+105 loc · ccn 27 · commits (last 12mo) 5</title></rect>
+<rect x="838.23" y="480.81" width="18.47" height="14.82" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/party/k8s/deployment.yaml
+137 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="838.23" y="495.63" width="9.68" height="13.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/k8s/networkpolicy.yaml
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="847.90" y="495.63" width="8.80" height="5.22" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/party/k8s/configmap.yaml
+23 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="847.90" y="500.85" width="4.99" height="8.40" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/party/k8s/service.yaml
+21 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="852.90" y="500.85" width="3.80" height="4.73" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/party/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="852.90" y="505.58" width="3.80" height="3.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="856.70" y="480.81" width="8.60" height="14.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20251217000001_audit_system.sql
+63 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="865.30" y="480.81" width="8.33" height="14.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20251223000001_business_qualifiers.sql
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="856.70" y="495.45" width="7.67" height="7.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20251231000001_party_verification.sql
+28 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="856.70" y="502.74" width="7.67" height="6.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260210000001_party_payment_methods.sql
+25 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="864.37" y="495.45" width="5.61" height="7.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20251216000001_initial.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="869.98" y="495.45" width="3.65" height="7.12" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260221000003_party_type_definition.sql
+13 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="864.37" y="502.57" width="4.18" height="3.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260214000001_enhance_party_association.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="864.37" y="506.39" width="4.18" height="2.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="868.55" y="502.57" width="2.82" height="3.54" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260214000002_party_association_constraints.sql
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="871.37" y="502.57" width="2.26" height="3.54" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="868.55" y="506.11" width="1.90" height="3.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260221000001_add_party_attributes.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="870.45" y="506.11" width="1.90" height="2.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20251223000002_optimize_association_index.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="870.45" y="508.21" width="1.90" height="1.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260221000002_add_party_attributes_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="872.36" y="506.11" width="1.27" height="1.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260221000004_party_type_definition_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="872.36" y="507.68" width="1.27" height="1.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/migrations/20260404000001_fix_party_attributes_comment.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="838.23" y="509.26" width="18.44" height="24.27" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/party/README.md
+224 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="856.67" y="509.26" width="13.66" height="16.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/party/rbac/method_permissions.go
+112 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="870.33" y="509.26" width="3.29" height="16.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/party/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="856.67" y="525.63" width="16.96" height="7.89" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>services/party/atlas/atlas.hcl
+67 loc · ccn 2 · commits (last 12mo) 3</title></rect>
+<rect x="263.93" y="533.52" width="36.01" height="38.56" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/mapping_test.go
+695 loc · ccn 51 · commits (last 12mo) 3</title></rect>
+<rect x="263.93" y="572.08" width="36.01" height="34.45" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/service_test.go
+621 loc · ccn 65 · commits (last 12mo) 4</title></rect>
+<rect x="263.93" y="606.54" width="36.01" height="34.07" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/balance_assertor_test.go
+614 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="299.94" y="533.52" width="34.85" height="33.88" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_list_endpoints_test.go
+591 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="299.94" y="567.40" width="34.85" height="25.34" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/snapshot_capturer_integration_test.go
+442 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="299.94" y="592.74" width="34.85" height="24.82" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/finalizer_test.go
+433 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="299.94" y="617.56" width="34.85" height="23.04" fill="#e7d3bb" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/variance_detector_test.go
+402 loc · ccn 48 · commits (last 12mo) 4</title></rect>
+<rect x="334.79" y="533.52" width="25.52" height="28.34" fill="#e7d3bb" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/snapshot_capturer_test.go
+362 loc · ccn 46 · commits (last 12mo) 4</title></rect>
+<rect x="334.79" y="561.86" width="25.52" height="27.87" fill="#dccdc4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_pipeline_endpoints.go
+356 loc · ccn 80 · commits (last 12mo) 2</title></rect>
+<rect x="334.79" y="589.73" width="25.52" height="26.53" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_dispute_endpoints_test.go
+339 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="334.79" y="616.26" width="25.52" height="24.34" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/variance_valuator_test.go
+311 loc · ccn 28 · commits (last 12mo) 2</title></rect>
+<rect x="360.32" y="533.52" width="25.97" height="23.54" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/execute_handler_test.go
+306 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="386.28" y="533.52" width="25.71" height="23.54" fill="#ecc4a4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/mapping.go
+303 loc · ccn 93 · commits (last 12mo) 5</title></rect>
+<rect x="412.00" y="533.52" width="25.54" height="23.54" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_dispute_endpoints.go
+301 loc · ccn 71 · commits (last 12mo) 2</title></rect>
+<rect x="437.54" y="533.52" width="25.37" height="23.54" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/control_handler_test.go
+299 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="360.32" y="557.07" width="22.98" height="23.30" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/balance_assertor.go
+268 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="360.32" y="580.36" width="22.98" height="20.25" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_settlement_endpoints.go
+233 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="360.32" y="600.62" width="22.98" height="20.08" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/variance_detector.go
+231 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="360.32" y="620.70" width="22.98" height="19.91" fill="#ecd5b7" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/finalizer.go
+229 loc · ccn 42 · commits (last 12mo) 5</title></rect>
+<rect x="383.30" y="557.07" width="20.42" height="21.23" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/retrieve_handler_test.go
+217 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="403.72" y="557.07" width="20.42" height="21.23" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/variance_valuator.go
+217 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="424.14" y="557.07" width="20.33" height="21.23" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_list_endpoints.go
+216 loc · ccn 51 · commits (last 12mo) 2</title></rect>
+<rect x="444.47" y="557.07" width="18.44" height="21.23" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/fee_reconciler_test.go
+196 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="383.30" y="578.30" width="16.61" height="21.77" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/position_provider_test.go
+181 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="383.30" y="600.07" width="16.61" height="20.33" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/snapshot_capturer.go
+169 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="383.30" y="620.40" width="16.61" height="20.21" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_reference_data_provider_test.go
+168 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="399.91" y="578.30" width="17.83" height="17.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/pk_position_provider_test.go
+153 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="399.91" y="595.44" width="17.83" height="15.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/pk_client_test.go
+141 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="399.91" y="611.24" width="17.83" height="15.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_pk_client_test.go
+137 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="399.91" y="626.60" width="17.83" height="14.01" fill="#e7d6c2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/server.go
+125 loc · ccn 31 · commits (last 12mo) 4</title></rect>
+<rect x="417.74" y="578.30" width="16.22" height="13.80" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_reference_data_provider.go
+112 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="433.95" y="578.30" width="14.62" height="13.80" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_assertion_endpoints.go
+101 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="448.58" y="578.30" width="14.34" height="13.80" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/server_options_test.go
+99 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="417.74" y="592.09" width="15.53" height="12.74" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/fa_client_test.go
+99 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="433.27" y="592.09" width="15.37" height="12.74" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/fee_reconciler.go
+98 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="448.64" y="592.09" width="14.27" height="12.74" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/circuit_breaker_test.go
+91 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="417.74" y="604.83" width="14.69" height="12.24" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/account_party_resolver_test.go
+90 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="417.74" y="617.07" width="14.69" height="12.11" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/pk_position_provider.go
+89 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="417.74" y="629.18" width="14.69" height="11.43" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/circuit_breaker.go
+84 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="432.42" y="604.83" width="15.72" height="10.42" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/extract_caller_role_test.go
+82 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="448.15" y="604.83" width="14.77" height="10.42" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/grpc_pk_client.go
+77 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="432.42" y="615.25" width="11.74" height="13.10" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/server_test.go
+77 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="432.42" y="628.35" width="11.74" height="12.25" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/variance_valuator_helpers_test.go
+72 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="444.16" y="615.25" width="9.38" height="11.72" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/event_types_test.go
+55 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="453.54" y="615.25" width="9.38" height="11.72" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/valuation_engine_adapter_test.go
+55 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="444.16" y="626.97" width="12.16" height="6.90" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/account_party_resolver.go
+42 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="444.16" y="633.87" width="12.16" height="6.74" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/valuation_engine_adapter.go
+41 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="456.32" y="626.97" width="6.59" height="5.76" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/position_provider.go
+19 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="456.32" y="632.72" width="6.59" height="3.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/pk_client.go
+13 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="456.32" y="636.66" width="6.59" height="3.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/service/fa_client.go
+13 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="640.60" width="25.91" height="28.45" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/variance_repository_test.go
+369 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="289.85" y="640.60" width="24.72" height="28.45" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/balance_assertion_repository_test.go
+352 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="314.57" y="640.60" width="18.61" height="28.45" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/variance_repository.go
+265 loc · ccn 55 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="669.05" width="24.06" height="20.18" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go
+243 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="263.93" y="689.23" width="24.06" height="20.10" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/balance_assertion_repository.go
+242 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="709.33" width="24.06" height="19.18" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/settlement_run_repository_test.go
+231 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="287.99" y="669.05" width="22.64" height="20.12" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/settlement_run_repository.go
+228 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="310.63" y="669.05" width="22.54" height="20.12" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/imbalance_trend_repository_test.go
+227 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="287.99" y="689.17" width="20.36" height="21.29" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/main_test.go
+217 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="287.99" y="710.46" width="20.36" height="18.05" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/dispute_repository.go
+184 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="308.35" y="689.17" width="24.83" height="13.04" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/settlement_snapshot_repository.go
+162 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="308.35" y="702.20" width="13.74" height="21.81" fill="#f8e1c1" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/dispute_repository_test.go
+150 loc · ccn 13 · commits (last 12mo) 7</title></rect>
+<rect x="322.09" y="702.20" width="11.09" height="21.81" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/imbalance_trend_repository.go
+121 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="308.35" y="724.01" width="24.83" height="4.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/persistence/entity.go
+56 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="728.51" width="25.36" height="25.29" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/settlement_transformer_test.go
+321 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="289.30" y="728.51" width="21.65" height="25.29" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/settlement_ingestor_test.go
+274 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="753.80" width="15.06" height="24.95" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/settlement_ingestor.go
+188 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="278.99" y="753.80" width="12.73" height="24.95" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/balance_transaction_client_test.go
+159 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="291.72" y="753.80" width="19.22" height="14.03" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/settlement_transformer.go
+135 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="291.72" y="767.83" width="17.21" height="10.91" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/balance_transaction_client.go
+94 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="308.93" y="767.83" width="2.01" height="10.91" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/stripe/errors.go
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="310.94" y="728.51" width="22.23" height="14.20" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/messaging/kafka_publisher.go
+158 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="310.94" y="742.71" width="22.23" height="13.66" fill="#ecdac2" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/messaging/kafka_publisher_test.go
+152 loc · ccn 22 · commits (last 12mo) 5</title></rect>
+<rect x="310.94" y="756.37" width="22.23" height="11.86" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/messaging/outbox_event_publisher.go
+132 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="310.94" y="768.23" width="22.23" height="10.51" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/adapters/messaging/outbox_event_publisher_test.go
+117 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="333.18" y="640.60" width="22.83" height="24.33" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_run_test.go
+278 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="333.18" y="664.93" width="22.83" height="18.73" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/imbalance_trend_test.go
+214 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="333.18" y="683.66" width="22.83" height="15.40" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/domain_coverage_test.go
+176 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="333.18" y="699.06" width="22.83" height="14.18" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/balance_assertion_test.go
+162 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="356.01" y="640.60" width="17.15" height="18.29" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_run.go
+157 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="373.15" y="640.60" width="15.73" height="18.29" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance_test.go
+144 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="388.88" y="640.60" width="14.20" height="18.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/dispute_test.go
+130 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="403.08" y="640.60" width="14.09" height="18.29" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/run_status_test.go
+129 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="356.01" y="658.89" width="16.76" height="14.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/balance_imbalance_event_test.go
+124 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="356.01" y="673.67" width="16.76" height="13.59" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance_status_test.go
+114 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="356.01" y="687.26" width="16.76" height="13.11" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance.go
+110 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="356.01" y="700.37" width="16.76" height="12.87" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_snapshot_test.go
+108 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="372.77" y="658.89" width="15.49" height="12.51" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/dispute_status_test.go
+97 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="388.26" y="658.89" width="14.70" height="12.51" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/balance_assertion.go
+92 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="402.96" y="658.89" width="14.22" height="12.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/dispute.go
+89 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="372.77" y="671.40" width="10.89" height="15.97" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/assertion_status_test.go
+87 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="372.77" y="687.36" width="10.89" height="14.50" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/repository.go
+79 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="372.77" y="701.86" width="10.89" height="11.38" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/fee_variance.go
+62 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="383.65" y="671.40" width="11.66" height="9.60" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance_status.go
+56 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="395.31" y="671.40" width="11.03" height="9.60" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/run_status.go
+53 loc · ccn 13 · commits (last 12mo) 3</title></rect>
+<rect x="406.35" y="671.40" width="10.83" height="9.60" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_snapshot.go
+52 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="383.65" y="681.00" width="9.29" height="10.96" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/fee_variance_test.go
+51 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="383.65" y="691.96" width="9.29" height="10.96" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/dispute_status.go
+51 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="383.65" y="702.92" width="9.29" height="10.32" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance_reason_test.go
+48 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="392.95" y="681.00" width="8.38" height="10.97" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_type_test.go
+46 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="401.33" y="681.00" width="8.20" height="10.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/assertion_status.go
+45 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="409.52" y="681.00" width="7.65" height="10.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/reconciliation_scope_test.go
+42 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="392.95" y="691.96" width="7.61" height="10.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/balance_imbalance_event.go
+41 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="392.95" y="702.73" width="7.61" height="10.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/imbalance_trend.go
+40 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="400.55" y="691.96" width="8.31" height="8.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/assertion_scope_test.go
+35 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="408.86" y="691.96" width="8.31" height="8.41" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/variance_reason.go
+35 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="400.55" y="700.38" width="8.70" height="6.89" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/settlement_type.go
+30 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="400.55" y="707.27" width="8.70" height="5.97" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/reconciliation_scope.go
+26 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="409.25" y="700.38" width="7.92" height="6.56" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/errors.go
+26 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="409.25" y="706.93" width="7.60" height="6.30" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/assertion_scope.go
+24 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="416.86" y="706.93" width="0.32" height="6.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/domain/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="417.17" y="640.60" width="45.74" height="26.12" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/client/starlark_test.go
+598 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="417.17" y="666.72" width="45.74" height="22.93" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/reconciliation/client/client_test.go
+525 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="417.17" y="689.65" width="26.94" height="23.59" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/reconciliation/client/starlark.go
+318 loc · ccn 53 · commits (last 12mo) 3</title></rect>
+<rect x="444.11" y="689.65" width="18.80" height="23.59" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/reconciliation/client/client.go
+222 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="333.18" y="713.24" width="24.17" height="18.68" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/scheduler_adapters_test.go
+226 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="333.18" y="731.92" width="24.17" height="15.87" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/grpc_recon_client_test.go
+192 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="357.34" y="713.24" width="14.76" height="13.81" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/metrics.go
+102 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="372.10" y="713.24" width="12.59" height="13.81" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/scheduler_adapters.go
+87 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="357.34" y="727.05" width="13.77" height="10.59" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/grpc_recon_client.go
+73 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="357.34" y="737.64" width="13.77" height="10.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/period_test.go
+70 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="371.11" y="727.05" width="13.58" height="6.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/metrics_test.go
+45 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="371.11" y="733.67" width="7.60" height="7.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/types.go
+28 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="378.71" y="733.67" width="5.97" height="7.36" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/stub_refdata_client_test.go
+22 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="371.11" y="741.03" width="6.49" height="6.77" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/period.go
+22 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="377.60" y="741.03" width="4.43" height="6.77" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/stub_refdata_client.go
+15 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="382.03" y="741.03" width="2.66" height="6.77" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/worker/errors.go
+9 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="333.18" y="747.80" width="36.28" height="30.95" fill="#f2d8b7" stroke="white" stroke-width="0.5"><title>services/reconciliation/cmd/main_test.go
+562 loc · ccn 32 · commits (last 12mo) 6</title></rect>
+<rect x="369.45" y="747.80" width="15.23" height="27.80" fill="#fdd8a8" stroke="white" stroke-width="0.5"><title>services/reconciliation/cmd/main.go
+212 loc · ccn 38 · commits (last 12mo) 16</title></rect>
+<rect x="369.45" y="775.60" width="15.23" height="3.15" fill="#eddecc" stroke="white" stroke-width="0.5"><title>services/reconciliation/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 5</title></rect>
+<rect x="384.69" y="713.24" width="20.41" height="20.76" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/metrics.go
+212 loc · ccn 16 · commits (last 12mo) 3</title></rect>
+<rect x="384.69" y="733.99" width="20.41" height="12.92" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/metrics_test.go
+132 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="405.09" y="713.24" width="20.58" height="9.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/alerts.yaml
+102 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="405.09" y="723.14" width="10.61" height="9.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/health.go
+50 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="415.70" y="723.14" width="9.97" height="9.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/redis_health.go
+47 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="405.09" y="732.55" width="11.68" height="7.35" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/health_test.go
+43 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="405.09" y="739.91" width="11.68" height="7.01" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/tracing_test.go
+41 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="416.78" y="732.55" width="8.90" height="8.30" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/redis_health_test.go
+37 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="416.78" y="740.86" width="8.90" height="6.06" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/observability/tracing.go
+27 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="384.69" y="746.92" width="28.56" height="31.83" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/reconciliation/app/container.go
+455 loc · ccn 69 · commits (last 12mo) 2</title></rect>
+<rect x="413.25" y="746.92" width="12.43" height="31.83" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/app/container_test.go
+198 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="425.68" y="713.24" width="20.71" height="18.23" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/deployment.yaml
+189 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="425.68" y="731.47" width="12.31" height="13.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/networkpolicy.yaml
+85 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="437.99" y="731.47" width="8.40" height="5.95" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/configmap.yaml
+25 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="437.99" y="737.42" width="4.33" height="7.85" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="442.31" y="737.42" width="4.07" height="4.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="442.31" y="741.83" width="4.07" height="3.43" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="446.38" y="713.24" width="16.53" height="19.46" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/reconciliation/config/config.go
+161 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="446.38" y="732.70" width="16.53" height="12.57" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/config/config_test.go
+104 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="425.68" y="745.27" width="14.89" height="19.99" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000001_initial.sql
+149 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="440.57" y="745.27" width="8.80" height="7.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000004_scheduler_resilience.sql
+32 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="440.57" y="752.54" width="4.54" height="7.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000002_imbalance_trend.sql
+16 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="445.11" y="752.54" width="4.26" height="7.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260213000001b_align_scheduler_execution_backfill.sql
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="440.57" y="759.58" width="5.63" height="2.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000005b_pause_resume_constraints.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="440.57" y="762.41" width="5.63" height="2.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000003b_settlement_finality_constraints.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="446.20" y="759.58" width="3.17" height="2.52" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260213000001_align_scheduler_execution.sql
+4 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="446.20" y="762.10" width="1.90" height="3.15" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000005_pause_resume.sql
+3 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="448.10" y="762.10" width="1.27" height="3.15" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/reconciliation/migrations/20260209000003_settlement_finality.sql
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="425.68" y="765.25" width="23.69" height="13.49" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/README.md
+160 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="449.37" y="745.27" width="9.34" height="12.83" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/rbac/method_permissions.go
+60 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="458.71" y="745.27" width="4.20" height="12.83" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/reconciliation/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="449.37" y="758.10" width="13.55" height="11.65" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/reconciliation/testhelpers/factories.go
+79 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="449.37" y="769.75" width="13.55" height="9.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/reconciliation/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="778.75" width="60.41" height="37.86" fill="#e1d0bf" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_service_test.go
+1145 loc · ccn 60 · commits (last 12mo) 3</title></rect>
+<rect x="324.35" y="778.75" width="47.28" height="37.86" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/market-information/service/cel_validator_test.go
+896 loc · ccn 64 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="816.61" width="36.05" height="33.97" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_service_unhappy_test.go
+613 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="850.58" width="36.05" height="31.20" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/market-information/service/dataset_service_test.go
+563 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="881.78" width="36.05" height="27.16" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/market-information/service/source_service_test.go
+490 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="299.98" y="816.61" width="29.44" height="31.01" fill="#ecbe9e" stroke="white" stroke-width="0.5"><title>services/market-information/service/dataset_service.go
+457 loc · ccn 105 · commits (last 12mo) 5</title></rect>
+<rect x="329.43" y="816.61" width="21.39" height="31.01" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/market-information/service/dataset_service_unhappy_test.go
+332 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="350.82" y="816.61" width="20.81" height="31.01" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>services/market-information/service/cel_validator.go
+323 loc · ccn 65 · commits (last 12mo) 2</title></rect>
+<rect x="299.98" y="847.62" width="24.89" height="21.11" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_batch.go
+263 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="299.98" y="868.72" width="24.89" height="20.23" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_record.go
+252 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="299.98" y="888.95" width="24.89" height="19.99" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/market-information/service/health_test.go
+249 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="324.87" y="847.62" width="25.79" height="18.20" fill="#e7d4bf" stroke="white" stroke-width="0.5"><title>services/market-information/service/source_service.go
+235 loc · ccn 39 · commits (last 12mo) 4</title></rect>
+<rect x="350.66" y="847.62" width="20.96" height="18.20" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/market-information/service/event_publisher_test.go
+191 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="324.87" y="865.82" width="19.14" height="15.24" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/market-information/service/outbox_event_publisher_test.go
+146 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="324.87" y="881.06" width="19.14" height="14.51" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/market-information/service/health.go
+139 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="324.87" y="895.57" width="19.14" height="13.36" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_query.go
+128 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="344.01" y="865.82" width="14.04" height="17.22" fill="#f7dab2" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_service.go
+121 loc · ccn 32 · commits (last 12mo) 7</title></rect>
+<rect x="358.05" y="865.82" width="13.58" height="17.22" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/market-information/service/event_publisher.go
+117 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="344.01" y="883.04" width="12.34" height="13.43" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/service/server_test.go
+83 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="344.01" y="896.47" width="12.34" height="12.46" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/service/health_watch_test.go
+77 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="356.35" y="883.04" width="15.27" height="9.81" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/service/observation_coverage_test.go
+75 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="356.35" y="892.85" width="15.27" height="9.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/service/server.go
+70 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="356.35" y="902.00" width="15.27" height="6.93" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/service/outbox_event_publisher.go
+53 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="371.63" y="778.75" width="46.02" height="36.90" fill="#ecd7bc" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/observation_repository_test.go
+850 loc · ccn 32 · commits (last 12mo) 5</title></rect>
+<rect x="417.65" y="778.75" width="22.96" height="25.15" fill="#f7d8b0" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/testhelpers/testcontainer.go
+289 loc · ccn 36 · commits (last 12mo) 7</title></rect>
+<rect x="417.65" y="803.89" width="22.96" height="11.75" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/testhelpers/schema.sql
+135 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="440.61" y="778.75" width="22.31" height="36.90" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/mappers_coverage_test.go
+412 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="371.63" y="815.64" width="24.65" height="30.06" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/observation_repository_query.go
+371 loc · ccn 55 · commits (last 12mo) 1</title></rect>
+<rect x="371.63" y="845.71" width="24.65" height="25.85" fill="#ecd4b6" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/dataset_repository.go
+319 loc · ccn 43 · commits (last 12mo) 5</title></rect>
+<rect x="396.28" y="815.64" width="19.72" height="28.87" fill="#ecd3b5" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/source_repository.go
+285 loc · ccn 46 · commits (last 12mo) 5</title></rect>
+<rect x="396.28" y="844.51" width="19.72" height="27.05" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/dataset_repository_test.go
+267 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="416.00" y="815.64" width="27.62" height="16.05" fill="#ecd3b5" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/mappers.go
+222 loc · ccn 46 · commits (last 12mo) 5</title></rect>
+<rect x="443.63" y="815.64" width="19.29" height="16.05" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/source_repository_test.go
+155 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="416.00" y="831.70" width="13.63" height="20.08" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/base_repository_test.go
+137 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="416.00" y="851.77" width="13.63" height="19.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/pagination_test.go
+135 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="429.63" y="831.70" width="17.90" height="15.07" fill="#f2dec3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/observation_repository.go
+135 loc · ccn 15 · commits (last 12mo) 6</title></rect>
+<rect x="447.53" y="831.70" width="15.38" height="15.07" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/source_repository_unhappy_test.go
+116 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="429.63" y="846.76" width="12.57" height="13.83" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/helpers_test.go
+87 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="429.63" y="860.59" width="12.57" height="10.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/mappers_test.go
+69 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="442.20" y="846.76" width="11.49" height="11.48" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/base_repository.go
+66 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="453.69" y="846.76" width="9.22" height="11.48" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/entities.go
+53 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="442.20" y="858.24" width="7.35" height="13.31" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/helpers.go
+49 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="449.56" y="858.24" width="6.45" height="13.31" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/pagination.go
+43 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="456.01" y="858.24" width="6.90" height="7.24" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/repositories_test.go
+25 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="456.01" y="865.48" width="6.90" height="6.08" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/persistence/repositories.go
+21 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="371.63" y="871.56" width="33.30" height="37.38" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_worker_test.go
+623 loc · ccn 68 · commits (last 12mo) 2</title></rect>
+<rect x="404.92" y="871.56" width="19.35" height="37.38" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_parser_test.go
+362 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="424.27" y="871.56" width="24.53" height="20.44" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_worker.go
+251 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="424.27" y="892.00" width="24.53" height="16.94" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_parser.go
+208 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="448.80" y="871.56" width="14.11" height="24.49" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_client_test.go
+173 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="448.80" y="896.05" width="14.11" height="12.88" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/market-information/adapters/external/ecb/ecb_client.go
+91 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="908.94" width="43.79" height="32.57" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/market-information/domain/observation_test.go
+714 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="307.73" y="908.94" width="40.91" height="32.57" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/market-information/domain/dataset_test.go
+667 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="941.51" width="34.15" height="32.35" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/market-information/domain/data_source_test.go
+553 loc · ccn 47 · commits (last 12mo) 1</title></rect>
+<rect x="263.93" y="973.85" width="34.15" height="26.15" fill="#f7d2a4" stroke="white" stroke-width="0.5"><title>services/market-information/domain/repository_test.go
+447 loc · ccn 52 · commits (last 12mo) 7</title></rect>
+<rect x="298.09" y="941.51" width="27.58" height="22.53" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/market-information/domain/quality_level_test.go
+311 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="325.67" y="941.51" width="22.97" height="22.53" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/market-information/domain/dataset.go
+259 loc · ccn 59 · commits (last 12mo) 2</title></rect>
+<rect x="298.09" y="964.04" width="22.33" height="20.40" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/market-information/domain/observation.go
+228 loc · ccn 52 · commits (last 12mo) 2</title></rect>
+<rect x="298.09" y="984.43" width="22.33" height="15.57" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/market-information/domain/data_source.go
+174 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="320.42" y="964.04" width="14.28" height="11.75" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/market-information/domain/access_level_test.go
+84 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="334.70" y="964.04" width="13.94" height="11.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/domain/observation_context_test.go
+82 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="320.42" y="975.79" width="10.15" height="13.58" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/domain/dataset_status_test.go
+69 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="320.42" y="989.37" width="10.15" height="10.63" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/domain/data_category_test.go
+54 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="330.57" y="975.79" width="9.77" height="10.83" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/domain/dataset_status.go
+53 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="340.34" y="975.79" width="8.30" height="10.83" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>services/market-information/domain/repository.go
+45 loc · ccn 1 · commits (last 12mo) 8</title></rect>
+<rect x="330.57" y="986.62" width="9.11" height="7.02" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/domain/quality_level.go
+32 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="330.57" y="993.64" width="9.11" height="6.36" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>services/market-information/domain/errors.go
+29 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="339.68" y="986.62" width="8.96" height="5.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/domain/observation_context.go
+24 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="339.68" y="991.97" width="4.48" height="8.03" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/domain/data_category.go
+18 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="344.16" y="991.97" width="4.48" height="8.03" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/domain/access_level.go
+18 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="348.64" y="908.94" width="32.64" height="53.74" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/market-information/client/client_test.go
+878 loc · ccn 75 · commits (last 12mo) 2</title></rect>
+<rect x="381.28" y="908.94" width="29.78" height="29.79" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/market-information/client/starlark_test.go
+444 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="381.28" y="938.73" width="21.52" height="23.95" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>services/market-information/client/client.go
+258 loc · ccn 43 · commits (last 12mo) 2</title></rect>
+<rect x="402.79" y="938.73" width="8.26" height="23.95" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/market-information/client/starlark.go
+99 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="348.64" y="962.68" width="62.41" height="37.32" fill="#ecbd9d" stroke="white" stroke-width="0.5"><title>services/market-information/e2e/e2e_test.go
+1166 loc · ccn 107 · commits (last 12mo) 5</title></rect>
+<rect x="411.05" y="908.94" width="31.01" height="30.80" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/market-information/benchmarks/nfr_validation_test.go
+478 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="411.05" y="939.73" width="31.01" height="6.18" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/benchmarks/helpers_test.go
+96 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="442.06" y="908.94" width="20.85" height="21.84" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260116000001_initial.sql
+228 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="442.06" y="930.78" width="13.20" height="15.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260210000004_seed_utilization_datasets.sql
+100 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="455.26" y="930.78" width="7.65" height="9.13" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+35 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="455.26" y="939.91" width="5.66" height="3.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260119000004_seed_shared_ecb_datasets.sql
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="455.26" y="943.09" width="5.66" height="2.82" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260123000003_add_cursor_pagination_indexes.sql
+8 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="460.92" y="939.91" width="2.00" height="5.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260401000001_add_data_source_status.sql
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="460.92" y="944.92" width="2.00" height="1.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/migrations/20260119000003_add_shared_dataset_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="411.05" y="945.92" width="13.92" height="19.95" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/market-information/observability/metrics.go
+139 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="424.97" y="945.92" width="12.92" height="10.52" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/market-information/observability/metrics_test.go
+68 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="424.97" y="956.43" width="12.92" height="9.44" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/market-information/observability/metrics_coverage_test.go
+61 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="437.88" y="945.92" width="19.32" height="19.95" fill="#fddcae" stroke="white" stroke-width="0.5"><title>services/market-information/cmd/main.go
+193 loc · ccn 31 · commits (last 12mo) 10</title></rect>
+<rect x="457.21" y="945.92" width="5.71" height="11.55" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/cmd/main_test.go
+33 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="457.21" y="957.47" width="5.71" height="8.40" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/market-information/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 8</title></rect>
+<rect x="411.05" y="965.87" width="13.88" height="19.29" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/deployment.yaml
+134 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="424.93" y="965.87" width="11.70" height="10.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/networkpolicy.yaml
+60 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="424.93" y="976.11" width="8.17" height="4.89" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/configmap.yaml
+20 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="424.93" y="981.00" width="8.17" height="4.16" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="433.10" y="976.11" width="3.53" height="5.09" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="433.10" y="981.20" width="3.53" height="3.96" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="411.05" y="985.16" width="25.58" height="14.84" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/market-information/README.md
+190 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="436.63" y="965.87" width="26.28" height="13.53" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/market-information/app/container.go
+178 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="436.63" y="979.40" width="11.54" height="12.81" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/market-information/config/config_test.go
+74 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="436.63" y="992.21" width="11.54" height="7.79" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/market-information/config/config.go
+45 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="448.17" y="979.40" width="10.37" height="12.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/rbac/method_permissions.go
+64 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="458.54" y="979.40" width="4.37" height="12.33" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/market-information/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="448.17" y="991.73" width="14.74" height="8.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/market-information/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="533.52" width="39.58" height="75.56" fill="#fdc48d" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/postgres_provisioner_test.go
+1497 loc · ccn 80 · commits (last 12mo) 11</title></rect>
+<rect x="462.91" y="609.08" width="39.58" height="25.34" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/migration_runner_test.go
+502 loc · ccn 66 · commits (last 12mo) 4</title></rect>
+<rect x="502.50" y="533.52" width="31.84" height="29.74" fill="#fdd49e" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner_test.go
+474 loc · ccn 49 · commits (last 12mo) 8</title></rect>
+<rect x="534.33" y="533.52" width="31.17" height="29.74" fill="#e1cab8" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/circuit_breaker_test.go
+464 loc · ccn 91 · commits (last 12mo) 3</title></rect>
+<rect x="502.50" y="563.27" width="34.47" height="21.56" fill="#f1b992" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/migration_runner.go
+372 loc · ccn 107 · commits (last 12mo) 6</title></rect>
+<rect x="536.96" y="563.27" width="28.54" height="21.56" fill="#fdcf98" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/postgres_provisioner.go
+308 loc · ccn 60 · commits (last 12mo) 18</title></rect>
+<rect x="502.50" y="584.83" width="21.83" height="26.63" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner_persistence_test.go
+291 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="502.50" y="611.45" width="21.83" height="22.97" fill="#f7d4a5" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/mock_provisioner.go
+251 loc · ccn 49 · commits (last 12mo) 7</title></rect>
+<rect x="524.33" y="584.83" width="21.22" height="17.42" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/market_information_test.go
+185 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="545.55" y="584.83" width="19.96" height="17.42" fill="#fddeb4" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner.go
+174 loc · ccn 25 · commits (last 12mo) 15</title></rect>
+<rect x="524.33" y="602.25" width="18.94" height="17.61" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/postgres_provisioner_lifecycle.go
+167 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="524.33" y="619.86" width="18.94" height="14.56" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner_helpers.go
+138 loc · ccn 32 · commits (last 12mo) 3</title></rect>
+<rect x="543.27" y="602.25" width="11.94" height="20.58" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner_persistence.go
+123 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="555.21" y="602.25" width="10.29" height="20.58" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/circuit_breaker.go
+106 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="543.27" y="622.83" width="16.72" height="11.59" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/provisioner_helpers_test.go
+97 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="559.99" y="622.83" width="5.51" height="9.42" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/errors.go
+26 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="559.99" y="632.24" width="5.51" height="2.17" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/provisioner/errors_test.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="634.42" width="52.84" height="55.99" fill="#fc9661" stroke="white" stroke-width="0.5"><title>services/tenant/worker/provisioning_worker_test.go
+1481 loc · ccn 135 · commits (last 12mo) 11</title></rect>
+<rect x="462.91" y="690.41" width="52.84" height="33.08" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/tenant/worker/alerting_test.go
+875 loc · ccn 52 · commits (last 12mo) 3</title></rect>
+<rect x="515.76" y="634.42" width="29.48" height="30.76" fill="#ecccac" stroke="white" stroke-width="0.5"><title>services/tenant/worker/provisioning_worker_integration_test.go
+454 loc · ccn 69 · commits (last 12mo) 5</title></rect>
+<rect x="545.24" y="634.42" width="20.26" height="30.76" fill="#fdd39c" stroke="white" stroke-width="0.5"><title>services/tenant/worker/provisioning_worker.go
+312 loc · ccn 52 · commits (last 12mo) 19</title></rect>
+<rect x="515.76" y="665.18" width="25.92" height="20.96" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/tenant/worker/alerting_mock_test.go
+272 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="541.68" y="665.18" width="23.83" height="20.96" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/tenant/worker/alerting_mock.go
+250 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="515.76" y="686.14" width="24.50" height="20.22" fill="#e7d3bc" stroke="white" stroke-width="0.5"><title>services/tenant/worker/alerting.go
+248 loc · ccn 45 · commits (last 12mo) 4</title></rect>
+<rect x="515.76" y="706.37" width="24.50" height="17.12" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/tenant/worker/provisioning_worker_retry.go
+210 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="540.25" y="686.14" width="25.25" height="14.16" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/tenant/worker/dead_letter_queue_test.go
+179 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="540.25" y="700.31" width="17.66" height="12.21" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/tenant/worker/rate_limiter_test.go
+108 loc · ccn 19 · commits (last 12mo) 3</title></rect>
+<rect x="540.25" y="712.52" width="17.66" height="10.97" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/tenant/worker/dead_letter_queue.go
+97 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="557.92" y="700.31" width="7.58" height="23.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/tenant/worker/rate_limiter.go
+88 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="565.50" y="533.52" width="46.13" height="65.30" fill="#fcb982" stroke="white" stroke-width="0.5"><title>services/tenant/service/grpc_service_test.go
+1508 loc · ccn 99 · commits (last 12mo) 15</title></rect>
+<rect x="611.64" y="533.52" width="28.70" height="33.90" fill="#e1d0be" stroke="white" stroke-width="0.5"><title>services/tenant/service/async_provisioning_integration_test.go
+487 loc · ccn 61 · commits (last 12mo) 3</title></rect>
+<rect x="611.64" y="567.43" width="28.70" height="31.40" fill="#e1c9b8" stroke="white" stroke-width="0.5"><title>services/tenant/service/slug_cache_test.go
+451 loc · ccn 94 · commits (last 12mo) 3</title></rect>
+<rect x="640.33" y="533.52" width="23.38" height="30.93" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/tenant/service/grpc_tenant_endpoints.go
+362 loc · ccn 75 · commits (last 12mo) 2</title></rect>
+<rect x="663.71" y="533.52" width="17.83" height="30.93" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>services/tenant/service/cached_registry_test.go
+276 loc · ccn 54 · commits (last 12mo) 3</title></rect>
+<rect x="640.33" y="564.45" width="17.15" height="18.29" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/tenant/service/grpc_provisioning_endpoints.go
+157 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="640.33" y="582.75" width="17.15" height="16.08" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>services/tenant/service/cached_registry.go
+138 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="657.48" y="564.45" width="12.98" height="12.62" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/tenant/service/mappers.go
+82 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="670.46" y="564.45" width="11.08" height="12.62" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/tenant/service/health.go
+70 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="657.48" y="577.07" width="10.65" height="12.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/service/health_test.go
+66 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="657.48" y="589.45" width="10.65" height="9.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/service/party_client_adapter_test.go
+50 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="668.13" y="577.07" width="13.41" height="7.30" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/service/slug_cache.go
+49 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="668.13" y="584.37" width="13.41" height="6.85" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/service/party_client_adapter.go
+46 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="668.13" y="591.23" width="9.47" height="7.60" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/tenant/service/server.go
+36 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="677.60" y="591.23" width="3.94" height="7.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/service/client_interfaces.go
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="565.50" y="598.83" width="45.33" height="40.77" fill="#fdc892" stroke="white" stroke-width="0.5"><title>services/tenant/adapters/persistence/repository_test.go
+925 loc · ccn 72 · commits (last 12mo) 12</title></rect>
+<rect x="610.83" y="598.83" width="38.42" height="20.49" fill="#fdc089" stroke="white" stroke-width="0.5"><title>services/tenant/adapters/persistence/repository.go
+394 loc · ccn 88 · commits (last 12mo) 11</title></rect>
+<rect x="610.83" y="619.31" width="29.45" height="20.28" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/tenant/adapters/persistence/audit_test.go
+299 loc · ccn 19 · commits (last 12mo) 3</title></rect>
+<rect x="640.28" y="619.31" width="8.96" height="16.49" fill="#fde4c1" stroke="white" stroke-width="0.5"><title>services/tenant/adapters/persistence/entity.go
+74 loc · ccn 10 · commits (last 12mo) 8</title></rect>
+<rect x="640.28" y="635.81" width="8.96" height="3.79" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>services/tenant/adapters/persistence/audit.go
+17 loc · ccn 4 · commits (last 12mo) 3</title></rect>
+<rect x="649.25" y="598.83" width="32.29" height="30.25" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/tenant/domain/tenant_test.go
+489 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="649.25" y="629.08" width="28.49" height="10.52" fill="#f7dcb8" stroke="white" stroke-width="0.5"><title>services/tenant/domain/tenant.go
+150 loc · ccn 25 · commits (last 12mo) 7</title></rect>
+<rect x="677.74" y="629.08" width="3.80" height="10.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/domain/repository.go
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="565.50" y="639.60" width="28.79" height="30.95" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/tenant/cmd/main_test.go
+446 loc · ccn 41 · commits (last 12mo) 4</title></rect>
+<rect x="565.50" y="670.54" width="24.19" height="13.46" fill="#fdddb2" stroke="white" stroke-width="0.5"><title>services/tenant/cmd/main.go
+163 loc · ccn 26 · commits (last 12mo) 23</title></rect>
+<rect x="589.69" y="670.54" width="4.60" height="13.46" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>services/tenant/cmd/Dockerfile
+31 loc · ccn 4 · commits (last 12mo) 13</title></rect>
+<rect x="565.50" y="684.01" width="28.79" height="24.91" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>services/tenant/notifier/slack_test.go
+359 loc · ccn 30 · commits (last 12mo) 4</title></rect>
+<rect x="565.50" y="708.92" width="28.79" height="14.57" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/tenant/notifier/slack.go
+210 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="594.29" y="639.60" width="26.18" height="15.19" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/tenant/client/client_methods_test.go
+199 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="594.29" y="654.78" width="26.18" height="14.50" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/tenant/client/client_test.go
+190 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="620.47" y="639.60" width="11.30" height="29.69" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/tenant/client/client.go
+168 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="594.29" y="669.28" width="37.48" height="28.52" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/tenant/migrations_test/provisioning_status_integration_test.go
+535 loc · ccn 59 · commits (last 12mo) 1</title></rect>
+<rect x="594.29" y="697.80" width="24.65" height="25.69" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/tenant/pagerduty/client_test.go
+317 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="618.94" y="697.80" width="12.83" height="25.69" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/tenant/pagerduty/client.go
+165 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="631.77" y="639.60" width="26.86" height="24.92" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/tenant/app/container.go
+335 loc · ccn 53 · commits (last 12mo) 2</title></rect>
+<rect x="631.77" y="664.51" width="26.86" height="9.97" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/tenant/app/container_test.go
+134 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="658.63" y="639.60" width="22.91" height="27.30" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/tenant/observability/metrics_test.go
+313 loc · ccn 72 · commits (last 12mo) 2</title></rect>
+<rect x="658.63" y="666.89" width="22.91" height="7.59" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>services/tenant/observability/metrics.go
+87 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="631.77" y="674.48" width="16.27" height="26.64" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/tenant/config/alerting_test.go
+217 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="648.05" y="674.48" width="11.32" height="26.64" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/tenant/config/alerting.go
+151 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="631.77" y="701.12" width="15.81" height="22.37" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/deployment.yaml
+177 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="647.58" y="701.12" width="11.79" height="10.85" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/networkpolicy.yaml
+64 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="647.58" y="711.97" width="9.01" height="5.98" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/configmap.yaml
+27 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="647.58" y="717.95" width="9.01" height="5.54" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/service.yaml
+25 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="656.59" y="711.97" width="2.77" height="6.48" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="656.59" y="718.45" width="2.77" height="5.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="659.37" y="674.48" width="22.17" height="16.76" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20251216000001_initial.sql
+186 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="659.37" y="691.24" width="9.46" height="6.13" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20260223000002_fix_audit_outbox_column_types_data.sql
+29 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="668.82" y="691.24" width="5.54" height="6.13" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20260226000001_seed_master_tenant.sql
+17 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="674.37" y="691.24" width="4.89" height="3.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20260223000001_fix_audit_outbox_column_types.sql
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="674.37" y="694.91" width="4.89" height="2.45" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20260323000001_align_audit_schema.sql
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="679.26" y="691.24" width="2.28" height="3.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20260323000002_align_audit_schema_data.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="679.26" y="694.74" width="2.28" height="2.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/migrations/20251223000001_add_status_updated_at_index.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="659.37" y="697.36" width="22.17" height="15.32" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/tenant/README.md
+170 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="659.37" y="712.68" width="11.27" height="10.81" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/tenant/atlas/atlas.hcl
+61 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="670.64" y="712.68" width="5.91" height="10.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/tenant/rbac/method_permissions.go
+32 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="676.55" y="712.68" width="4.99" height="10.81" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/tenant/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="681.54" y="533.52" width="36.50" height="55.99" fill="#e77f6a" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy_test.go
+1023 loc · ccn 194 · commits (last 12mo) 6</title></rect>
+<rect x="681.54" y="589.51" width="36.50" height="35.85" fill="#dbc6bc" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/audit_test.go
+655 loc · ccn 121 · commits (last 12mo) 2</title></rect>
+<rect x="681.54" y="625.36" width="36.50" height="35.41" fill="#e7c7ae" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/refdata_test.go
+647 loc · ccn 93 · commits (last 12mo) 4</title></rect>
+<rect x="718.04" y="533.52" width="28.24" height="35.72" fill="#dccbc1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/simulation_test.go
+505 loc · ccn 97 · commits (last 12mo) 2</title></rect>
+<rect x="718.04" y="569.24" width="28.24" height="31.26" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/manifest_fix_test.go
+442 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="718.04" y="600.51" width="28.24" height="30.27" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy_generator_test.go
+428 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="718.04" y="630.78" width="28.24" height="29.99" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/refdata_saga.go
+424 loc · ccn 68 · commits (last 12mo) 1</title></rect>
+<rect x="746.29" y="533.52" width="29.55" height="26.57" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/gateway_coverage_test.go
+393 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="775.84" y="533.52" width="28.94" height="26.57" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/gateway.go
+385 loc · ccn 63 · commits (last 12mo) 3</title></rect>
+<rect x="804.78" y="533.52" width="28.87" height="26.57" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy_graph.go
+384 loc · ccn 55 · commits (last 12mo) 2</title></rect>
+<rect x="833.65" y="533.52" width="28.49" height="26.57" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/sdk_test.go
+379 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="746.29" y="560.10" width="28.58" height="26.22" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/gateway_test.go
+375 loc · ccn 37 · commits (last 12mo) 2</title></rect>
+<rect x="746.29" y="586.31" width="28.58" height="25.17" fill="#e7d0b8" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/audit.go
+360 loc · ccn 57 · commits (last 12mo) 4</title></rect>
+<rect x="746.29" y="611.48" width="28.58" height="25.03" fill="#e1c6b5" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/manifest_fix.go
+358 loc · ccn 103 · commits (last 12mo) 3</title></rect>
+<rect x="746.29" y="636.51" width="28.58" height="24.26" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy_manifest.go
+347 loc · ccn 54 · commits (last 12mo) 2</title></rect>
+<rect x="774.87" y="560.10" width="30.47" height="22.68" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/simulation.go
+346 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="805.34" y="560.10" width="30.12" height="22.68" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/validation_test.go
+342 loc · ccn 71 · commits (last 12mo) 3</title></rect>
+<rect x="835.46" y="560.10" width="26.68" height="22.68" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/cookbook_discover.go
+303 loc · ccn 51 · commits (last 12mo) 2</title></rect>
+<rect x="774.87" y="582.78" width="22.47" height="26.41" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/cookbook.go
+297 loc · ccn 62 · commits (last 12mo) 2</title></rect>
+<rect x="774.87" y="609.19" width="22.47" height="26.14" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/audit_reconciliation.go
+294 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="774.87" y="635.34" width="22.47" height="25.43" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy_generator.go
+286 loc · ccn 42 · commits (last 12mo) 4</title></rect>
+<rect x="797.33" y="582.78" width="22.83" height="22.22" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/reference.go
+254 loc · ccn 16 · commits (last 12mo) 3</title></rect>
+<rect x="820.16" y="582.78" width="21.39" height="22.22" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/cookbook_discover_test.go
+238 loc · ccn 56 · commits (last 12mo) 2</title></rect>
+<rect x="841.56" y="582.78" width="20.58" height="22.22" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/cookbook_test.go
+229 loc · ccn 64 · commits (last 12mo) 2</title></rect>
+<rect x="797.33" y="605.01" width="23.04" height="19.86" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/gateway_status.go
+229 loc · ccn 69 · commits (last 12mo) 1</title></rect>
+<rect x="797.33" y="624.87" width="23.04" height="18.91" fill="#e7d5c1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/validation.go
+218 loc · ccn 34 · commits (last 12mo) 4</title></rect>
+<rect x="797.33" y="643.77" width="6.25" height="7.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/pattern.json
+23 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="797.33" y="651.13" width="6.25" height="1.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/manifest.yaml
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="803.58" y="643.77" width="5.39" height="7.05" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/pattern.json
+19 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="803.58" y="650.82" width="5.39" height="2.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/manifest.yaml
+6 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="797.33" y="653.04" width="6.21" height="7.73" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/registry.json
+24 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="803.54" y="653.04" width="5.43" height="6.62" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/component.json
+18 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="803.54" y="659.67" width="5.43" height="1.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/balance.tsx
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="808.97" y="643.77" width="6.73" height="5.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook_discover/patterns/energy-settlement/pattern.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="808.97" y="649.41" width="6.73" height="5.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook_discover/patterns/precious-metals/pattern.json
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="815.70" y="643.77" width="4.67" height="5.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook_discover/patterns/fiat-foundation/pattern.json
+14 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="815.70" y="649.76" width="4.67" height="4.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook_discover/patterns/conflicting-pattern/pattern.json
+11 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="808.97" y="654.46" width="11.40" height="6.31" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testdata/cookbook_discover/registry.json
+36 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="820.37" y="605.01" width="21.56" height="17.79" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/parse_manifest_input_test.go
+192 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="841.93" y="605.01" width="20.21" height="17.79" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/reference_test.go
+180 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="820.37" y="622.80" width="18.68" height="19.04" fill="#f7ddb9" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/refdata.go
+178 loc · ccn 23 · commits (last 12mo) 7</title></rect>
+<rect x="820.37" y="641.84" width="18.68" height="18.93" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/tenant_isolation_test.go
+177 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="839.05" y="622.80" width="23.10" height="14.96" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/refdata_instrument.go
+173 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="839.05" y="637.76" width="16.58" height="11.93" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/testhelper_test.go
+99 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="839.05" y="649.69" width="16.58" height="11.08" fill="#fde2bb" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/economy.go
+92 loc · ccn 16 · commits (last 12mo) 9</title></rect>
+<rect x="855.63" y="637.76" width="6.51" height="23.01" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/tools/sdk.go
+75 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="681.54" y="660.77" width="45.58" height="37.78" fill="#fdd7a5" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oidc_test.go
+862 loc · ccn 41 · commits (last 12mo) 9</title></rect>
+<rect x="681.54" y="698.55" width="45.58" height="24.94" fill="#f7d9b1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oauth_test.go
+569 loc · ccn 34 · commits (last 12mo) 7</title></rect>
+<rect x="727.12" y="660.77" width="25.90" height="33.71" fill="#fdc48d" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oauth.go
+437 loc · ccn 80 · commits (last 12mo) 11</title></rect>
+<rect x="727.12" y="694.48" width="25.90" height="29.01" fill="#fdc892" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oidc.go
+376 loc · ccn 72 · commits (last 12mo) 12</title></rect>
+<rect x="753.02" y="660.77" width="23.62" height="20.63" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/registration.go
+244 loc · ccn 48 · commits (last 12mo) 3</title></rect>
+<rect x="776.64" y="660.77" width="22.75" height="20.63" fill="#e7d5c0" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/subdomain_test.go
+235 loc · ccn 36 · commits (last 12mo) 4</title></rect>
+<rect x="753.02" y="681.40" width="17.42" height="22.59" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oidc_consent.go
+197 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="753.02" y="704.00" width="17.42" height="19.50" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/registration_test.go
+170 loc · ccn 14 · commits (last 12mo) 4</title></rect>
+<rect x="770.44" y="681.40" width="16.55" height="19.32" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/jwks_validator_test.go
+160 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="786.98" y="681.40" width="12.41" height="19.32" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/auth_test.go
+120 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="770.44" y="700.72" width="15.00" height="15.31" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/subdomain.go
+115 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="770.44" y="716.03" width="15.00" height="7.46" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/auth.go
+56 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="785.44" y="700.72" width="13.95" height="7.88" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/jwks_validator.go
+55 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="785.44" y="708.60" width="13.95" height="7.59" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/redirect_internal_test.go
+53 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="785.44" y="716.19" width="13.95" height="7.30" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/auth/oidc_state_full_test.go
+51 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="799.39" y="660.77" width="27.39" height="14.15" fill="#e1d2c2" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/resources/resources_test.go
+194 loc · ccn 46 · commits (last 12mo) 3</title></rect>
+<rect x="799.39" y="674.92" width="10.91" height="17.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/resources/docs/cel-reference.md
+98 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="810.31" y="674.92" width="8.13" height="17.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/resources/docs/starlark-guide.md
+73 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="818.44" y="674.92" width="8.35" height="17.94" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/resources/resources.go
+75 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="799.39" y="692.86" width="27.39" height="16.41" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/prompts/prompts_test.go
+225 loc · ccn 54 · commits (last 12mo) 2</title></rect>
+<rect x="799.39" y="709.27" width="27.39" height="14.22" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/prompts/prompts.go
+195 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="826.79" y="660.77" width="20.25" height="23.68" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/errors/formatter.go
+240 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="847.04" y="660.77" width="15.10" height="23.68" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/errors/formatter_test.go
+179 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="826.79" y="684.45" width="15.52" height="12.36" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/rate_limiter_test.go
+96 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="826.79" y="696.81" width="15.52" height="11.20" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/plan_cache_test.go
+87 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="842.30" y="684.45" width="10.13" height="14.00" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/session_test.go
+71 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="852.44" y="684.45" width="9.71" height="14.00" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/rate_limiter.go
+68 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="842.30" y="698.44" width="12.11" height="9.57" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/plan_cache.go
+58 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="854.42" y="698.44" width="7.73" height="9.57" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/session/session.go
+37 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="826.79" y="708.01" width="17.03" height="15.48" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/mcputil/mcputil_test.go
+132 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="843.82" y="708.01" width="4.39" height="15.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/mcputil/mcputil.go
+34 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="848.21" y="708.01" width="13.94" height="9.89" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/clients/clients.go
+69 loc · ccn 5 · commits (last 12mo) 4</title></rect>
+<rect x="848.21" y="717.90" width="13.94" height="5.59" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/internal/clients/clients_test.go
+39 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="862.14" y="533.52" width="11.48" height="36.01" fill="#fddaac" stroke="white" stroke-width="0.5"><title>services/mcp-server/cmd/wire.go
+207 loc · ccn 34 · commits (last 12mo) 13</title></rect>
+<rect x="862.14" y="569.53" width="11.48" height="35.66" fill="#fddbad" stroke="white" stroke-width="0.5"><title>services/mcp-server/cmd/main.go
+205 loc · ccn 32 · commits (last 12mo) 20</title></rect>
+<rect x="862.14" y="605.20" width="11.48" height="4.18" fill="#eddecc" stroke="white" stroke-width="0.5"><title>services/mcp-server/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 5</title></rect>
+<rect x="862.14" y="609.37" width="11.48" height="52.88" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>services/mcp-server/README.md
+304 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="862.14" y="662.26" width="11.48" height="28.18" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/deployment.yaml
+162 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="862.14" y="690.44" width="11.48" height="10.44" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/networkpolicy.yaml
+60 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="862.14" y="700.88" width="7.57" height="4.22" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/service.yaml
+16 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="862.14" y="705.10" width="7.57" height="3.96" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/configmap.yaml
+15 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="869.72" y="700.88" width="3.91" height="4.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="869.72" y="705.47" width="3.91" height="3.58" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="862.14" y="709.05" width="11.48" height="14.44" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/mcp-server/oauthwiring/wiring.go
+83 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="723.49" width="29.12" height="22.91" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/instruction_repository_test.go
+334 loc · ccn 25 · commits (last 12mo) 3</title></rect>
+<rect x="492.04" y="723.49" width="24.85" height="22.91" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/mappers.go
+285 loc · ccn 37 · commits (last 12mo) 2</title></rect>
+<rect x="462.91" y="746.40" width="20.99" height="25.50" fill="#f2cfa8" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/instruction_repository.go
+268 loc · ccn 60 · commits (last 12mo) 6</title></rect>
+<rect x="483.91" y="746.40" width="16.53" height="25.50" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/mappers_test.go
+211 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="500.44" y="746.40" width="16.45" height="25.50" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/entity_test.go
+210 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="771.90" width="17.92" height="23.19" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/route_repository_test.go
+208 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="795.10" width="17.92" height="21.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/connection_repository_test.go
+193 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="480.83" y="771.90" width="20.04" height="18.34" fill="#e7d9c8" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/setup_test.go
+184 loc · ccn 17 · commits (last 12mo) 4</title></rect>
+<rect x="500.87" y="771.90" width="16.01" height="18.34" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/instruction_entity.go
+147 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="480.83" y="790.24" width="18.48" height="13.40" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/connection_entity.go
+124 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="480.83" y="803.65" width="18.48" height="12.97" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/connection_repository.go
+120 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="499.31" y="790.24" width="8.90" height="17.05" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/route_repository.go
+76 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="508.22" y="790.24" width="8.67" height="17.05" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/route_entity.go
+74 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="499.31" y="807.29" width="10.29" height="9.32" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/route_resolver_test.go
+48 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="509.60" y="807.29" width="7.29" height="9.32" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/persistence/route_resolver.go
+34 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="516.89" y="723.49" width="35.68" height="46.91" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
+838 loc · ccn 91 · commits (last 12mo) 2</title></rect>
+<rect x="552.57" y="723.49" width="15.42" height="46.91" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/httpadapter/http_dispatcher.go
+362 loc · ccn 60 · commits (last 12mo) 2</title></rect>
+<rect x="516.89" y="770.41" width="23.30" height="33.44" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/mapping/mapping_transformer_test.go
+390 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="516.89" y="803.84" width="23.30" height="12.77" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/mapping/mapping_transformer.go
+149 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="540.19" y="770.41" width="14.13" height="25.73" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/messaging/outbox_publisher.go
+182 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="554.32" y="770.41" width="13.67" height="25.73" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/messaging/outbox_publisher_test.go
+176 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="540.19" y="796.13" width="16.78" height="14.65" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/passthrough/passthrough_transformer_test.go
+123 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="540.19" y="810.78" width="16.78" height="5.84" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/passthrough/passthrough_transformer.go
+49 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="556.97" y="796.13" width="11.02" height="14.14" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/secrets/env_secret_store_test.go
+78 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="556.97" y="810.27" width="11.02" height="6.34" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/adapters/secrets/env_secret_store.go
+35 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="816.62" width="36.25" height="35.82" fill="#ecc8a8" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_service_test.go
+650 loc · ccn 80 · commits (last 12mo) 5</title></rect>
+<rect x="462.91" y="852.44" width="36.25" height="34.45" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_query_test.go
+625 loc · ccn 51 · commits (last 12mo) 1</title></rect>
+<rect x="499.16" y="816.62" width="38.99" height="25.11" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_mappers_test.go
+490 loc · ccn 78 · commits (last 12mo) 1</title></rect>
+<rect x="538.15" y="816.62" width="29.84" height="25.11" fill="#e7c4ab" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_mappers.go
+375 loc · ccn 101 · commits (last 12mo) 4</title></rect>
+<rect x="499.16" y="841.72" width="28.27" height="24.03" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_route_service_test.go
+340 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="499.16" y="865.75" width="28.27" height="21.13" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/server.go
+299 loc · ccn 68 · commits (last 12mo) 2</title></rect>
+<rect x="527.43" y="841.72" width="23.38" height="21.28" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_query.go
+249 loc · ccn 59 · commits (last 12mo) 2</title></rect>
+<rect x="550.81" y="841.72" width="17.18" height="21.28" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/route_server.go
+183 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="527.43" y="863.00" width="15.05" height="23.89" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_connection_service.go
+180 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="542.48" y="863.00" width="18.48" height="13.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/route_server_test.go
+126 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="542.48" y="876.62" width="18.48" height="10.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/server_test.go
+95 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="560.96" y="863.00" width="7.03" height="23.89" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/service/grpc_connection_service_test.go
+84 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="567.99" y="723.49" width="38.21" height="22.74" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/instruction_test.go
+435 loc · ccn 60 · commits (last 12mo) 1</title></rect>
+<rect x="567.99" y="746.24" width="38.21" height="19.29" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/provider_connection_test.go
+369 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="606.20" y="723.49" width="30.65" height="17.73" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/instruction.go
+272 loc · ccn 55 · commits (last 12mo) 2</title></rect>
+<rect x="606.20" y="741.22" width="18.08" height="24.31" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/provider_connection.go
+220 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="624.28" y="741.22" width="12.57" height="14.30" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/instruction_route_test.go
+90 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="624.28" y="755.52" width="12.57" height="10.01" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/operational-gateway/domain/instruction_route.go
+63 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="567.99" y="765.53" width="35.96" height="40.39" fill="#e1c8b6" stroke="white" stroke-width="0.5"><title>services/operational-gateway/worker/dispatch_worker_test.go
+727 loc · ccn 99 · commits (last 12mo) 3</title></rect>
+<rect x="603.95" y="765.53" width="16.67" height="30.91" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/operational-gateway/worker/dispatch_worker.go
+258 loc · ccn 51 · commits (last 12mo) 3</title></rect>
+<rect x="620.63" y="765.53" width="16.22" height="30.91" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/operational-gateway/worker/expiry_worker_test.go
+251 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="603.95" y="796.44" width="32.90" height="9.47" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/operational-gateway/worker/expiry_worker.go
+156 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="567.99" y="805.91" width="26.33" height="20.11" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/client/starlark_test.go
+265 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="567.99" y="826.02" width="26.33" height="19.96" fill="#e1d0bf" stroke="white" stroke-width="0.5"><title>services/operational-gateway/client/starlark.go
+263 loc · ccn 58 · commits (last 12mo) 3</title></rect>
+<rect x="594.32" y="805.91" width="14.76" height="17.06" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/operational-gateway/client/client.go
+126 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="594.32" y="822.97" width="14.76" height="12.05" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/client/starlark_helpers_test.go
+89 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="594.32" y="835.02" width="14.76" height="10.96" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/client/client_test.go
+81 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="609.07" y="805.91" width="27.77" height="40.07" fill="#e1ccbb" stroke="white" stroke-width="0.5"><title>services/operational-gateway/e2e/e2e_test.go
+557 loc · ccn 78 · commits (last 12mo) 3</title></rect>
+<rect x="567.99" y="845.98" width="20.02" height="14.07" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/operational-gateway/observability/metrics_test.go
+141 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="567.99" y="860.05" width="20.02" height="12.07" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/observability/tracing_test.go
+121 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="588.01" y="845.98" width="9.48" height="18.34" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/observability/metrics.go
+87 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="588.01" y="864.32" width="9.48" height="7.80" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/observability/tracing.go
+37 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="567.99" y="872.12" width="29.50" height="14.76" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/operational-gateway/cmd/main.go
+218 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="597.49" y="845.98" width="10.91" height="10.63" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/repositories.go
+58 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="597.49" y="856.61" width="10.91" height="8.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/secret_store_test.go
+47 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="608.39" y="845.98" width="8.83" height="8.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/payload_transformer_test.go
+36 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="608.39" y="854.13" width="8.83" height="4.53" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/payload_transformer.go
+20 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="608.39" y="858.65" width="3.35" height="6.56" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/dispatcher.go
+11 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="611.74" y="858.65" width="5.48" height="3.28" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/secret_store.go
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="611.74" y="861.93" width="5.48" height="3.28" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/ports/route_resolver.go
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="617.22" y="845.98" width="19.63" height="19.24" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/README.md
+189 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="597.49" y="865.22" width="11.89" height="14.78" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/migrations/20260301000001_operational_gateway_initial.sql
+88 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="597.49" y="880.00" width="6.67" height="6.89" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/migrations/20260302000001_instruction_routes.sql
+23 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="604.16" y="880.00" width="5.22" height="3.83" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/migrations/20260401000001_add_connection_route_status.sql
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="604.16" y="883.83" width="5.22" height="3.06" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/migrations/20260302000002_circuit_breaker_and_lifecycle_columns.sql
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="609.38" y="865.22" width="11.62" height="15.31" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/config/config_test.go
+89 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="609.38" y="880.52" width="11.62" height="6.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/config/config.go
+37 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="620.99" y="865.22" width="12.00" height="13.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/rbac/method_permissions.go
+84 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="632.99" y="865.22" width="3.86" height="13.99" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/operational-gateway/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="620.99" y="879.20" width="15.86" height="7.69" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/operational-gateway/atlas/atlas.hcl
+61 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="886.89" width="40.95" height="74.84" fill="#f28963" stroke="white" stroke-width="0.5"><title>services/identity/service/grpc_service_test.go
+1534 loc · ccn 161 · commits (last 12mo) 7</title></rect>
+<rect x="503.86" y="886.89" width="22.54" height="30.32" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>services/identity/service/integration_test.go
+342 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="526.40" y="886.89" width="15.29" height="30.32" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/identity/service/grpc_auth_endpoints.go
+232 loc · ccn 47 · commits (last 12mo) 1</title></rect>
+<rect x="503.86" y="917.20" width="19.58" height="17.96" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/identity/service/grpc_identity_endpoints.go
+176 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="523.44" y="917.20" width="18.24" height="17.96" fill="#ecd5b9" stroke="white" stroke-width="0.5"><title>services/identity/service/server.go
+164 loc · ccn 38 · commits (last 12mo) 5</title></rect>
+<rect x="503.86" y="935.16" width="19.40" height="14.62" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/identity/service/grpc_role_endpoints.go
+142 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="503.86" y="949.78" width="19.40" height="11.94" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/identity/service/grpc_invitation_endpoints.go
+116 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="523.26" y="935.16" width="18.42" height="12.58" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/identity/service/mappers.go
+116 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="523.26" y="947.74" width="13.57" height="13.99" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/identity/service/mappers_test.go
+95 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="536.83" y="947.74" width="4.86" height="13.99" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/service/server_test.go
+34 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="462.91" y="961.73" width="21.45" height="38.27" fill="#ecd8be" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/repository_test.go
+411 loc · ccn 30 · commits (last 12mo) 5</title></rect>
+<rect x="484.37" y="961.73" width="20.41" height="38.27" fill="#f2c199" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/repository.go
+391 loc · ccn 95 · commits (last 12mo) 6</title></rect>
+<rect x="504.78" y="961.73" width="19.15" height="25.98" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/token_entity_test.go
+249 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="523.92" y="961.73" width="17.76" height="25.98" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/token_repository_test.go
+231 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="504.78" y="987.71" width="8.78" height="12.29" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/identity_entity.go
+54 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="513.56" y="987.71" width="8.13" height="12.29" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/role_assignment_entity.go
+50 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="521.69" y="987.71" width="6.99" height="12.29" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/invitation_entity.go
+43 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="528.68" y="987.71" width="6.50" height="12.29" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/verification_token_entity.go
+40 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="535.18" y="987.71" width="6.50" height="12.29" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/identity/adapters/persistence/password_reset_token_entity.go
+40 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="541.69" y="886.89" width="29.66" height="22.50" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/identity/domain/identity_test.go
+334 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="571.35" y="886.89" width="21.23" height="22.50" fill="#e7d3bb" stroke="white" stroke-width="0.5"><title>services/identity/domain/identity.go
+239 loc · ccn 47 · commits (last 12mo) 4</title></rect>
+<rect x="541.69" y="909.38" width="18.38" height="15.98" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/identity/domain/role_assignment.go
+147 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="541.69" y="925.36" width="18.38" height="15.00" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/identity/domain/role_assignment_test.go
+138 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="560.07" y="909.38" width="11.03" height="17.21" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/domain/invitation.go
+95 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="560.07" y="926.59" width="11.03" height="13.77" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/domain/password_reset_token_test.go
+76 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="571.10" y="909.38" width="11.34" height="13.39" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/domain/verification_token_test.go
+76 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="582.43" y="909.38" width="10.14" height="13.39" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/domain/verification_token.go
+68 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="571.10" y="922.78" width="15.45" height="8.79" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/domain/invitation_test.go
+68 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="571.10" y="931.57" width="15.45" height="8.79" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/domain/password_reset_token.go
+68 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="586.55" y="922.78" width="6.02" height="8.96" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>services/identity/domain/errors.go
+27 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="586.55" y="931.73" width="6.02" height="8.62" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>services/identity/domain/repository.go
+26 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="592.57" y="886.89" width="28.21" height="29.46" fill="#f2d1aa" stroke="white" stroke-width="0.5"><title>services/identity/connector/connector_test.go
+416 loc · ccn 55 · commits (last 12mo) 6</title></rect>
+<rect x="620.78" y="886.89" width="16.07" height="29.46" fill="#f2d6b3" stroke="white" stroke-width="0.5"><title>services/identity/connector/connector.go
+237 loc · ccn 39 · commits (last 12mo) 6</title></rect>
+<rect x="592.57" y="916.35" width="15.48" height="24.01" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/identity/connector/integration_test.go
+186 loc · ccn 10 · commits (last 12mo) 3</title></rect>
+<rect x="608.05" y="916.35" width="18.48" height="12.44" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/connector/connector_lockout_test.go
+115 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="608.05" y="928.79" width="18.48" height="11.57" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/connector/connector_lockout_integration_test.go
+107 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="626.53" y="916.35" width="10.32" height="18.78" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>services/identity/connector/claims_test.go
+97 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="626.53" y="935.13" width="10.32" height="5.23" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/identity/connector/claims.go
+27 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="541.69" y="940.36" width="19.70" height="30.02" fill="#f2cda6" stroke="white" stroke-width="0.5"><title>services/identity/bootstrap/bootstrap.go
+296 loc · ccn 64 · commits (last 12mo) 6</title></rect>
+<rect x="561.39" y="940.36" width="16.17" height="30.02" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/identity/bootstrap/bootstrap_test.go
+243 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="541.69" y="970.37" width="26.97" height="15.18" fill="#ecd6ba" stroke="white" stroke-width="0.5"><title>services/identity/bootstrap/demo_users_test.go
+205 loc · ccn 37 · commits (last 12mo) 5</title></rect>
+<rect x="541.69" y="985.56" width="26.97" height="14.44" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>services/identity/bootstrap/self_registered_admin_test.go
+195 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="568.66" y="970.37" width="8.90" height="29.63" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/identity/bootstrap/self_registered_admin.go
+132 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="577.56" y="940.36" width="18.03" height="17.28" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>services/identity/dex/server_test.go
+156 loc · ccn 14 · commits (last 12mo) 4</title></rect>
+<rect x="595.59" y="940.36" width="15.60" height="17.28" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/identity/dex/clients_test.go
+135 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="577.56" y="957.64" width="16.49" height="12.85" fill="#e7d9c9" stroke="white" stroke-width="0.5"><title>services/identity/dex/server.go
+106 loc · ccn 16 · commits (last 12mo) 4</title></rect>
+<rect x="577.56" y="970.49" width="16.49" height="11.15" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>services/identity/dex/connector_adapter_test.go
+92 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="594.05" y="957.64" width="17.15" height="10.72" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>services/identity/dex/clients.go
+92 loc · ccn 17 · commits (last 12mo) 3</title></rect>
+<rect x="594.05" y="968.36" width="12.64" height="6.80" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>services/identity/dex/connector_adapter.go
+43 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="594.05" y="975.15" width="12.64" height="6.48" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>services/identity/dex/config_test.go
+41 loc · ccn 4 · commits (last 12mo) 3</title></rect>
+<rect x="606.68" y="968.36" width="4.51" height="13.28" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>services/identity/dex/config.go
+30 loc · ccn 5 · commits (last 12mo) 3</title></rect>
+<rect x="611.20" y="940.36" width="25.65" height="17.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/identity/oidc/connector_config_test.go
+222 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="611.20" y="957.65" width="12.66" height="23.99" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/identity/oidc/connector_config.go
+152 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="623.86" y="957.65" width="12.99" height="12.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/oidc/client.go
+79 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="623.86" y="969.80" width="12.99" height="11.84" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/oidc/client_test.go
+77 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="577.56" y="981.64" width="22.30" height="18.36" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/identity/README.md
+205 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="599.86" y="981.64" width="8.60" height="13.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260425000001_audit_system.sql
+56 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="608.46" y="981.64" width="7.83" height="13.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260302000001_initial.sql
+51 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="599.86" y="994.65" width="5.60" height="5.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000004_password_reset_tokens.sql
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="605.46" y="994.65" width="5.60" height="5.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000003_email_verification_tokens.sql
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="611.06" y="994.65" width="2.99" height="2.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260326000002_add_tenant_id_indexes.sql
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="614.05" y="994.65" width="2.24" height="2.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000006_add_role_constraint.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="611.06" y="997.32" width="2.24" height="2.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000002_add_pending_verification_status.sql
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="613.30" y="997.32" width="1.49" height="2.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260326000001_add_tenant_id.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="614.79" y="997.32" width="1.49" height="1.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000001_drop_identity_status_constraint.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="614.79" y="998.66" width="1.49" height="1.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/migrations/20260327000005_drop_role_constraint.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="616.29" y="981.64" width="13.38" height="10.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/identity/rbac/method_permissions.go
+72 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="616.29" y="992.39" width="13.38" height="7.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/identity/rbac/method_permissions_test.go
+51 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="629.67" y="981.64" width="7.18" height="18.36" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/identity/atlas/atlas.hcl
+66 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="723.49" width="48.89" height="31.05" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/runner_test.go
+760 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="636.85" y="754.55" width="48.89" height="25.66" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/builtins_coverage_test.go
+628 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="685.74" y="723.49" width="27.58" height="34.33" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/runner_coverage_test.go
+474 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="685.74" y="757.82" width="27.58" height="22.38" fill="#dccec4" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/builtins.go
+309 loc · ccn 76 · commits (last 12mo) 2</title></rect>
+<rect x="713.32" y="723.49" width="22.17" height="26.04" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/security_test.go
+289 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="735.49" y="723.49" width="20.94" height="26.04" fill="#ecd4b6" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/runner.go
+273 loc · ccn 43 · commits (last 12mo) 5</title></rect>
+<rect x="713.32" y="749.53" width="16.41" height="30.67" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/runner_convert.go
+252 loc · ccn 70 · commits (last 12mo) 1</title></rect>
+<rect x="729.73" y="749.53" width="26.70" height="17.36" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/builtins_test.go
+232 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="729.73" y="766.89" width="26.70" height="13.32" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/forecasting/starlark/coverage_test.go
+178 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="780.21" width="31.70" height="22.18" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/strategy_repository_test.go
+352 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="636.85" y="802.39" width="31.70" height="19.60" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/strategy_repository.go
+311 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="668.55" y="780.21" width="24.29" height="17.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/mappers_test.go
+215 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="668.55" y="797.89" width="13.18" height="13.49" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/testhelpers/testcontainer.go
+89 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="668.55" y="811.38" width="13.18" height="10.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/helpers_test.go
+70 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="681.73" y="797.89" width="11.11" height="11.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/mappers.go
+64 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="681.73" y="809.40" width="11.11" height="8.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/helpers.go
+47 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="681.73" y="817.85" width="11.11" height="4.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/persistence/entities.go
+23 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="821.99" width="38.49" height="16.66" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/mds/mds_test.go
+321 loc · ccn 39 · commits (last 12mo) 2</title></rect>
+<rect x="675.34" y="821.99" width="10.07" height="16.66" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/mds/mds_adapter.go
+84 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="685.41" y="821.99" width="7.43" height="13.44" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/mds/refdata_adapter_test.go
+50 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="685.41" y="835.42" width="7.43" height="3.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/adapters/mds/refdata_adapter.go
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="838.65" width="33.29" height="45.67" fill="#e7cdb5" stroke="white" stroke-width="0.5"><title>services/forecasting/handler/forecasting_handler_test.go
+761 loc · ccn 68 · commits (last 12mo) 4</title></rect>
+<rect x="670.14" y="838.65" width="22.70" height="23.41" fill="#ecd6ba" stroke="white" stroke-width="0.5"><title>services/forecasting/handler/forecasting_handler.go
+266 loc · ccn 37 · commits (last 12mo) 5</title></rect>
+<rect x="670.14" y="862.05" width="22.70" height="22.26" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/forecasting/handler/internal_test.go
+253 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="692.84" y="780.21" width="38.86" height="20.31" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/forecasting_strategy_test.go
+395 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="692.84" y="800.51" width="21.94" height="22.67" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/forecasting_strategy.go
+249 loc · ccn 61 · commits (last 12mo) 2</title></rect>
+<rect x="714.79" y="800.51" width="16.92" height="12.40" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/strategy_status_test.go
+105 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="714.79" y="812.91" width="10.11" height="10.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/strategy_status.go
+52 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="724.90" y="812.91" width="6.81" height="5.28" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/errors.go
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="724.90" y="818.19" width="6.81" height="4.99" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/forecasting/domain/repository.go
+17 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="731.71" y="780.21" width="24.73" height="15.83" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/forecasting/scheduler/scheduler_adapters_test.go
+196 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="731.71" y="796.04" width="24.73" height="14.46" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/forecasting/scheduler/metrics_test.go
+179 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="731.71" y="810.50" width="14.96" height="12.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/scheduler/metrics.go
+95 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="746.67" y="810.50" width="9.77" height="12.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/scheduler/scheduler_adapters.go
+62 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="692.84" y="823.18" width="26.31" height="16.86" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/forecasting/validation/strategy_validator.go
+222 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="692.84" y="840.04" width="26.31" height="14.27" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/forecasting/validation/strategy_validator_test.go
+188 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="719.15" y="823.18" width="7.38" height="31.13" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/validation/strategy_validator_coverage_test.go
+115 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="692.84" y="854.31" width="32.09" height="30.00" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/forecasting/templates/templates_test.go
+482 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="724.94" y="854.31" width="1.60" height="30.00" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/forecasting/templates/templates.go
+24 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="726.53" y="823.18" width="27.72" height="21.98" fill="#f2d4ad" stroke="white" stroke-width="0.5"><title>services/forecasting/cmd/main.go
+305 loc · ccn 47 · commits (last 12mo) 6</title></rect>
+<rect x="754.25" y="823.18" width="2.18" height="21.98" fill="#eddecc" stroke="white" stroke-width="0.5"><title>services/forecasting/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 5</title></rect>
+<rect x="726.53" y="845.16" width="17.65" height="18.11" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/deployment.yaml
+160 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="744.19" y="845.16" width="12.25" height="9.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/networkpolicy.yaml
+57 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="744.19" y="854.46" width="4.76" height="8.81" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/configmap.yaml
+21 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="748.95" y="854.46" width="7.48" height="4.54" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="748.95" y="859.00" width="4.21" height="4.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/secret.yaml
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="753.16" y="859.00" width="3.27" height="4.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="726.53" y="863.27" width="12.53" height="21.05" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/forecasting/README.md
+132 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="739.06" y="863.27" width="9.06" height="13.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/atlas/atlas.hcl
+60 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="748.13" y="863.27" width="8.31" height="8.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/migrations/20260210000001_initial.sql
+35 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="748.13" y="871.69" width="8.31" height="4.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/migrations/20260213000001_scheduler_execution.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="739.06" y="876.49" width="6.90" height="7.82" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/forecasting/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="745.96" y="876.49" width="3.07" height="7.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/rbac/method_permissions.go
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="749.03" y="876.49" width="7.41" height="4.31" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/forecasting/config/config_test.go
+16 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="749.03" y="880.81" width="7.41" height="3.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/forecasting/config/config.go
+13 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="756.44" y="723.49" width="24.62" height="31.64" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/saga_trigger_client_test.go
+390 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="781.06" y="723.49" width="21.78" height="31.64" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/position_keeping_client_test.go
+345 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="756.44" y="755.14" width="25.40" height="19.19" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/manifest_client_test.go
+244 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="756.44" y="774.33" width="25.40" height="14.86" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/position_keeping_client.go
+189 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="781.84" y="755.14" width="21.00" height="17.50" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/saga_trigger_client.go
+184 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="781.84" y="772.64" width="11.47" height="16.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/manifest_client.go
+95 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="793.30" y="772.64" width="9.53" height="16.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/grpc/error_handling_test.go
+79 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="802.84" y="723.49" width="39.29" height="46.78" fill="#dcc8be" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/messaging/audit_consumer_test.go
+920 loc · ccn 112 · commits (last 12mo) 2</title></rect>
+<rect x="802.84" y="770.27" width="16.05" height="18.92" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/messaging/platform_metering_handler_test.go
+152 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="818.89" y="770.27" width="13.83" height="18.92" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/messaging/platform_metering_handler.go
+131 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="832.73" y="770.27" width="9.40" height="18.92" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/messaging/audit_consumer.go
+89 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="842.12" y="723.49" width="31.50" height="42.93" fill="#e7cbb2" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/mds/market_data_publisher_test.go
+677 loc · ccn 78 · commits (last 12mo) 4</title></rect>
+<rect x="842.12" y="766.42" width="31.50" height="22.77" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/event-router/adapters/mds/market_data_publisher.go
+359 loc · ccn 51 · commits (last 12mo) 2</title></rect>
+<rect x="756.44" y="789.19" width="26.16" height="33.07" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>services/event-router/internal/handlers/saga_dispatch_handler_test.go
+433 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="756.44" y="822.26" width="26.16" height="18.71" fill="#f2d5af" stroke="white" stroke-width="0.5"><title>services/event-router/internal/handlers/saga_dispatch_handler.go
+245 loc · ccn 44 · commits (last 12mo) 6</title></rect>
+<rect x="782.59" y="789.19" width="26.63" height="21.60" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/event-router/internal/registry/saga_registry_test.go
+288 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="782.59" y="810.80" width="26.63" height="5.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/internal/registry/saga_registry.go
+67 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="809.22" y="789.19" width="19.35" height="18.79" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/event-router/internal/idempotency/store_test.go
+182 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="809.22" y="807.98" width="19.35" height="7.84" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/internal/idempotency/store.go
+76 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="782.59" y="815.82" width="19.78" height="14.75" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/event-router/internal/worker/idempotency_cleanup_worker_test.go
+146 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="782.59" y="830.57" width="19.78" height="10.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/internal/worker/idempotency_cleanup_worker.go
+103 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="802.37" y="815.82" width="13.82" height="16.19" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/event-router/internal/correlation/extractor_test.go
+112 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="802.37" y="832.01" width="13.82" height="8.96" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/event-router/internal/correlation/extractor.go
+62 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="816.19" y="815.82" width="12.39" height="14.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/internal/observability/metrics.go
+91 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="816.19" y="830.50" width="12.39" height="10.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/internal/observability/metrics_test.go
+65 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="756.44" y="840.98" width="28.40" height="28.35" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/event-router/domain/measurement_test.go
+403 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="756.44" y="869.33" width="28.40" height="14.99" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/event-router/domain/instruments_test.go
+213 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="784.83" y="840.98" width="20.56" height="14.87" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/event-router/domain/utilization_publisher_test.go
+153 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="784.83" y="855.84" width="20.56" height="14.67" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/event-router/domain/metrics_test.go
+151 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="784.83" y="870.52" width="20.56" height="13.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/domain/audit_event_transformer_test.go
+142 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="805.39" y="840.98" width="12.75" height="18.96" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/domain/metrics.go
+121 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="818.14" y="840.98" width="10.43" height="18.96" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/domain/saga_trigger_test.go
+99 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="805.39" y="859.93" width="11.75" height="12.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/domain/tenant_mapping_test.go
+73 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="817.15" y="859.93" width="11.43" height="12.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/event-router/domain/handler_test.go
+71 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="805.39" y="872.34" width="8.84" height="11.98" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/instruments.go
+53 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="814.23" y="872.34" width="9.51" height="6.09" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/measurement.go
+29 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="814.23" y="878.43" width="9.51" height="5.88" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/tenant_mapping.go
+28 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="823.74" y="872.34" width="4.84" height="3.72" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/position_keeping_client.go
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="823.74" y="876.06" width="4.84" height="3.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/handler.go
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="823.74" y="879.36" width="4.84" height="2.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/saga_trigger.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="823.74" y="881.84" width="4.03" height="2.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/utilization_publisher.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="827.77" y="881.84" width="0.81" height="2.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/domain/audit_event_transformer.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="828.58" y="789.19" width="26.81" height="31.66" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>services/event-router/tests/integration/saga_dispatch_test.go
+425 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="855.39" y="789.19" width="18.23" height="31.66" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>services/event-router/tests/integration/testutil_setup_test.go
+289 loc · ccn 51 · commits (last 12mo) 2</title></rect>
+<rect x="828.58" y="820.85" width="26.61" height="24.92" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>services/event-router/cmd/main.go
+332 loc · ccn 57 · commits (last 12mo) 2</title></rect>
+<rect x="855.19" y="820.85" width="18.44" height="22.32" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>services/event-router/cmd/main_test.go
+206 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="855.19" y="843.18" width="18.44" height="2.60" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/event-router/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="828.58" y="845.78" width="19.80" height="32.28" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>services/event-router/app/config_test.go
+320 loc · ccn 79 · commits (last 12mo) 1</title></rect>
+<rect x="828.58" y="878.06" width="19.80" height="6.25" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/event-router/app/config.go
+62 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="848.38" y="845.78" width="25.25" height="14.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/deployment.yaml
+183 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="848.38" y="860.26" width="9.19" height="13.69" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/README.md
+63 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="857.57" y="860.26" width="8.32" height="13.69" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/networkpolicy.yaml
+57 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="865.89" y="860.26" width="7.73" height="6.72" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/configmap.yaml
+26 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="865.89" y="866.97" width="5.73" height="6.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/service.yaml
+20 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="871.62" y="866.97" width="2.01" height="6.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/event-router/k8s/kustomization.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="848.38" y="873.95" width="25.25" height="10.37" fill="#eddfce" stroke="white" stroke-width="0.5"><title>services/event-router/README.md
+131 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="636.85" y="884.32" width="38.76" height="26.59" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/payment_intent_adapter_test.go
+516 loc · ccn 60 · commits (last 12mo) 2</title></rect>
+<rect x="675.61" y="884.32" width="24.79" height="26.59" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/webhook_adapter_test.go
+330 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="910.91" width="25.92" height="22.97" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/payment_intent_adapter.go
+298 loc · ccn 41 · commits (last 12mo) 3</title></rect>
+<rect x="636.85" y="933.88" width="25.92" height="20.65" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/manifest_tenant_config_test.go
+268 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="954.53" width="25.92" height="16.11" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/client.go
+209 loc · ccn 32 · commits (last 12mo) 3</title></rect>
+<rect x="662.77" y="910.91" width="19.00" height="21.13" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/platform_fee_test.go
+201 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="681.77" y="910.91" width="18.63" height="21.13" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/client_test.go
+197 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="662.77" y="932.04" width="20.46" height="15.13" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/webhook_adapter.go
+155 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="683.23" y="932.04" width="17.16" height="15.13" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/circuit_breaker_test.go
+130 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="662.77" y="947.17" width="15.75" height="13.70" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/manifest_tenant_config.go
+108 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="662.77" y="960.87" width="15.75" height="9.77" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/tenant_config_test.go
+77 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="678.52" y="947.17" width="11.51" height="10.59" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/platform_fee.go
+61 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="690.03" y="947.17" width="10.37" height="10.59" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/circuit_breaker.go
+55 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="678.52" y="957.76" width="7.14" height="12.87" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/config.go
+46 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="685.66" y="957.76" width="6.36" height="12.87" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/config_test.go
+41 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="692.02" y="957.76" width="8.38" height="5.96" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/idempotency_test.go
+25 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="692.02" y="963.72" width="5.49" height="6.91" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/tenant_config.go
+19 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="697.51" y="963.72" width="2.89" height="6.91" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/stripe/idempotency.go
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="636.85" y="970.64" width="37.49" height="29.36" fill="#e7d6c1" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/http/webhook_handler_test.go
+551 loc · ccn 33 · commits (last 12mo) 4</title></rect>
+<rect x="674.34" y="970.64" width="26.06" height="29.36" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>services/financial-gateway/adapters/http/webhook_handler.go
+383 loc · ccn 65 · commits (last 12mo) 4</title></rect>
+<rect x="700.40" y="884.32" width="29.82" height="43.28" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>services/financial-gateway/client/starlark_test.go
+646 loc · ccn 66 · commits (last 12mo) 2</title></rect>
+<rect x="730.22" y="884.32" width="31.90" height="21.23" fill="#f2caa3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/client/starlark.go
+339 loc · ccn 71 · commits (last 12mo) 6</title></rect>
+<rect x="730.22" y="905.55" width="19.03" height="22.05" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/financial-gateway/client/client_test.go
+210 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="749.25" y="905.55" width="12.87" height="22.05" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/financial-gateway/client/client.go
+142 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="700.40" y="927.59" width="39.41" height="30.72" fill="#e1cdbb" stroke="white" stroke-width="0.5"><title>services/financial-gateway/service/grpc_service_test.go
+606 loc · ccn 75 · commits (last 12mo) 3</title></rect>
+<rect x="739.81" y="927.59" width="22.31" height="19.97" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>services/financial-gateway/service/server.go
+223 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="739.81" y="947.56" width="22.31" height="10.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/service/server_test.go
+120 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="700.40" y="958.31" width="36.51" height="21.01" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/e2e/e2e_test.go
+384 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="700.40" y="979.32" width="27.82" height="20.68" fill="#ecd3b4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/cmd/main.go
+288 loc · ccn 48 · commits (last 12mo) 5</title></rect>
+<rect x="728.22" y="979.32" width="8.69" height="15.17" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/cmd/main_test.go
+66 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="728.22" y="994.49" width="8.69" height="5.51" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>services/financial-gateway/cmd/Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="736.91" y="958.31" width="11.47" height="15.85" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/observability/metrics.go
+91 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="748.38" y="958.31" width="7.40" height="11.34" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/observability/tracing_test.go
+42 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="755.78" y="958.31" width="6.34" height="11.34" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/observability/tracing.go
+36 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="748.38" y="969.65" width="13.74" height="4.51" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/observability/metrics_test.go
+31 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="736.91" y="974.16" width="25.21" height="11.89" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/README.md
+150 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="736.91" y="986.05" width="8.31" height="10.34" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>services/financial-gateway/config/config.go
+43 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="736.91" y="996.39" width="8.31" height="3.61" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/config/config_test.go
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="745.22" y="986.05" width="7.30" height="7.39" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/financial-gateway/rbac/method_permissions_test.go
+27 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="745.22" y="993.44" width="7.30" height="6.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/rbac/method_permissions.go
+24 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="752.52" y="986.05" width="9.60" height="9.16" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/atlas/atlas.hcl
+44 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="752.52" y="995.21" width="8.34" height="4.79" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/migrations/20260304000001_create_event_outbox.sql
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="760.87" y="995.21" width="1.25" height="1.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/migrations/20260329000001_add_event_outbox_causation_id_index.sql
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="760.87" y="996.81" width="1.25" height="1.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/migrations/20260316000001_add_event_outbox_tenant_id.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="760.87" y="998.40" width="1.25" height="1.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/financial-gateway/migrations/20260316000002_add_event_outbox_tenant_id_index.sql
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="762.12" y="884.32" width="26.83" height="31.79" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/kafka/consumer_test.go
+427 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="762.12" y="916.11" width="26.83" height="18.09" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/kafka/consumer.go
+243 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="788.95" y="884.32" width="26.79" height="20.88" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/persistence/tenant_audit_writer_integration_test.go
+280 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="788.95" y="905.19" width="26.79" height="13.72" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/persistence/tenant_audit_writer_cockroach_test.go
+184 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="788.95" y="918.91" width="15.42" height="15.29" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/persistence/tenant_audit_writer.go
+118 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="804.37" y="918.91" width="11.37" height="15.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/audit-worker/adapters/persistence/tenant_audit_writer_test.go
+87 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="762.12" y="934.20" width="27.36" height="27.46" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/config_test.go
+376 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="762.12" y="961.66" width="27.36" height="20.16" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/container_test.go
+276 loc · ccn 39 · commits (last 12mo) 3</title></rect>
+<rect x="789.48" y="934.20" width="26.27" height="18.48" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/container_cockroach_test.go
+243 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="789.48" y="952.68" width="26.27" height="13.46" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/container.go
+177 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="789.48" y="966.15" width="18.36" height="15.67" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/config.go
+144 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="807.84" y="966.15" width="7.91" height="12.13" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/db_wrapper_test.go
+48 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="807.84" y="978.28" width="7.91" height="3.54" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/app/db_wrapper.go
+14 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="815.74" y="884.32" width="28.14" height="29.75" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>services/audit-worker/service/audit_service_test.go
+419 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="843.88" y="884.32" width="17.78" height="22.70" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>services/audit-worker/service/server.go
+202 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="861.66" y="884.32" width="11.97" height="22.70" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/audit-worker/service/server_test.go
+136 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="843.88" y="907.01" width="29.75" height="7.05" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/service/audit_migration_schema_test.go
+105 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="815.74" y="914.07" width="20.59" height="29.30" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/audit_event_transformer_test.go
+302 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="836.33" y="914.07" width="20.32" height="29.30" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/measurement_test.go
+298 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="856.65" y="914.07" width="16.98" height="12.00" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/audit_event_transformer.go
+102 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="856.65" y="926.07" width="16.98" height="9.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/measurement.go
+78 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="856.65" y="935.25" width="12.30" height="8.12" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/audit_operation_test.go
+50 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="868.95" y="935.25" width="4.67" height="8.12" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/domain/audit_operation.go
+19 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="815.74" y="943.37" width="28.01" height="23.82" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>services/audit-worker/observability/metrics_test.go
+334 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="815.74" y="967.19" width="28.01" height="14.62" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>services/audit-worker/observability/metrics.go
+205 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="843.75" y="943.37" width="15.75" height="28.28" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>services/audit-worker/cmd/main_test.go
+223 loc · ccn 48 · commits (last 12mo) 3</title></rect>
+<rect x="859.50" y="943.37" width="14.13" height="23.48" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>services/audit-worker/cmd/main.go
+166 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="859.50" y="966.84" width="14.13" height="4.81" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>services/audit-worker/cmd/main_cockroach_test.go
+34 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="843.75" y="971.65" width="29.88" height="10.16" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>services/audit-worker/README.md
+152 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="762.12" y="981.82" width="111.18" height="18.18" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>services/README.md
+1012 loc · ccn 0 · commits (last 12mo) 19</title></rect>
+<rect x="873.30" y="981.82" width="0.33" height="18.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>services/embed.go
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="0.00" width="35.11" height="58.56" fill="#fdc18b" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/service_modules_test.go
+1029 loc · ccn 84 · commits (last 12mo) 8</title></rect>
+<rect x="873.63" y="58.56" width="35.11" height="35.85" fill="#ecd7bc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/schema_test.go
+630 loc · ccn 33 · commits (last 12mo) 5</title></rect>
+<rect x="908.73" y="0.00" width="31.66" height="37.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/handler_evolution_test.go
+594 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="908.73" y="37.48" width="31.66" height="31.05" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/derive_test.go
+492 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="908.73" y="68.53" width="31.66" height="25.87" fill="#e1c6b5" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/validation_modules.go
+410 loc · ccn 104 · commits (last 12mo) 3</title></rect>
+<rect x="940.39" y="0.00" width="29.17" height="23.01" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/coercion_test.go
+336 loc · ccn 61 · commits (last 12mo) 1</title></rect>
+<rect x="969.56" y="0.00" width="28.91" height="23.01" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/proto_resolve_test.go
+333 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="998.46" y="0.00" width="27.08" height="23.01" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/alignment_test.go
+312 loc · ccn 82 · commits (last 12mo) 1</title></rect>
+<rect x="940.39" y="23.01" width="21.83" height="27.27" fill="#fdc790" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/schema.go
+298 loc · ccn 74 · commits (last 12mo) 14</title></rect>
+<rect x="940.39" y="50.29" width="21.83" height="22.88" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/handlers_yaml_test.go
+250 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="940.39" y="73.17" width="21.83" height="21.23" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/validation_modules_test.go
+232 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="962.22" y="23.01" width="21.44" height="20.41" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/registry.go
+219 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="983.65" y="23.01" width="21.04" height="20.41" fill="#e7dbcc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/compensation_integration_test.go
+215 loc · ccn 9 · commits (last 12mo) 4</title></rect>
+<rect x="1004.70" y="23.01" width="20.85" height="20.41" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/derive.go
+213 loc · ccn 54 · commits (last 12mo) 3</title></rect>
+<rect x="962.22" y="43.43" width="22.65" height="18.61" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/handlers.yaml
+211 loc · ccn 0 · commits (last 12mo) 18</title></rect>
+<rect x="962.22" y="62.04" width="22.65" height="16.93" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/starlark_convert.go
+192 loc · ccn 59 · commits (last 12mo) 1</title></rect>
+<rect x="962.22" y="78.97" width="22.65" height="15.44" fill="#fde0b8" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/handlers_test.go
+175 loc · ccn 20 · commits (last 12mo) 10</title></rect>
+<rect x="984.87" y="43.43" width="14.03" height="18.52" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/contract_test.go
+130 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="998.90" y="43.43" width="13.70" height="18.52" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/proto_resolve.go
+127 loc · ccn 33 · commits (last 12mo) 3</title></rect>
+<rect x="1012.60" y="43.43" width="12.95" height="18.52" fill="#fdddb1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/service_modules.go
+120 loc · ccn 28 · commits (last 12mo) 12</title></rect>
+<rect x="984.87" y="61.94" width="14.28" height="16.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/service_modules_gaps_test.go
+118 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="984.87" y="78.45" width="14.28" height="15.95" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/coercion.go
+114 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="999.15" y="61.94" width="14.52" height="13.62" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/service_modules_coverage_test.go
+99 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1013.67" y="61.94" width="11.88" height="13.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/retry_policy_test.go
+81 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="999.15" y="75.56" width="15.37" height="10.53" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/handler_tree.go
+81 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="999.15" y="86.09" width="15.37" height="8.32" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/compensation.go
+64 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1014.52" y="75.56" width="11.03" height="6.16" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/schema_coverage_test.go
+34 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1014.52" y="81.72" width="5.72" height="9.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/authorization.go
+28 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1020.24" y="81.72" width="5.31" height="9.78" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/context.go
+26 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1014.52" y="91.51" width="11.03" height="2.90" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/schema/embedded.go
+16 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1025.55" y="0.00" width="28.82" height="24.33" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/report_test.go
+351 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1054.37" y="0.00" width="25.95" height="24.33" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/mock_generator_test.go
+316 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="1025.55" y="24.33" width="28.82" height="18.71" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/report.go
+270 loc · ccn 63 · commits (last 12mo) 2</title></rect>
+<rect x="1054.37" y="24.33" width="25.94" height="18.71" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/validator_test.go
+243 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1025.55" y="43.04" width="18.28" height="26.01" fill="#e7d4bf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/validator.go
+238 loc · ccn 39 · commits (last 12mo) 4</title></rect>
+<rect x="1025.55" y="69.05" width="18.28" height="25.35" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cached_validator_test.go
+232 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1043.83" y="43.04" width="22.57" height="19.38" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cache_test.go
+219 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="1066.40" y="43.04" width="13.91" height="19.38" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cache.go
+135 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1043.83" y="62.43" width="14.37" height="16.82" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/mock_generator.go
+121 loc · ccn 45 · commits (last 12mo) 2</title></rect>
+<rect x="1043.83" y="79.25" width="14.37" height="15.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/mock_generator_coverage_test.go
+109 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1058.20" y="62.43" width="12.53" height="15.63" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/metrics_test.go
+98 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1070.73" y="62.43" width="9.59" height="15.63" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cache_metrics_test.go
+75 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1058.20" y="78.06" width="15.40" height="8.18" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/metrics.go
+63 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1058.20" y="86.23" width="15.40" height="8.18" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cached_validator.go
+63 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1073.59" y="78.06" width="6.72" height="16.35" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validation/cache_metrics.go
+55 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="94.41" width="32.09" height="42.64" fill="#e1d2c2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/linter_test.go
+685 loc · ccn 46 · commits (last 12mo) 3</title></rect>
+<rect x="873.63" y="137.05" width="32.09" height="39.97" fill="#fdbd86" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/handlers_test.go
+642 loc · ccn 93 · commits (last 12mo) 8</title></rect>
+<rect x="873.63" y="177.01" width="32.09" height="39.47" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/suspend_test.go
+634 loc · ccn 43 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="216.48" width="32.09" height="36.48" fill="#e1cfbd" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/step_execution_integration_test.go
+586 loc · ccn 66 · commits (last 12mo) 3</title></rect>
+<rect x="873.63" y="252.96" width="32.09" height="30.50" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/composition_test.go
+490 loc · ccn 62 · commits (last 12mo) 1</title></rect>
+<rect x="905.72" y="94.41" width="31.93" height="29.28" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/step_execution_test.go
+468 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="937.65" y="94.41" width="31.45" height="29.28" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/causation_tree_test.go
+461 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="969.10" y="94.41" width="29.07" height="29.28" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/builtins_dsl_test.go
+426 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="998.17" y="94.41" width="28.66" height="29.28" fill="#f2c7a0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/step_execution.go
+420 loc · ccn 78 · commits (last 12mo) 6</title></rect>
+<rect x="1026.82" y="94.41" width="26.75" height="29.28" fill="#ecc09f" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/builtins.go
+392 loc · ccn 103 · commits (last 12mo) 5</title></rect>
+<rect x="1053.57" y="94.41" width="26.75" height="29.28" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/runtime_security_test.go
+392 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="905.72" y="123.69" width="26.61" height="29.13" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_executor_test.go
+388 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="905.72" y="152.82" width="26.61" height="27.03" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/events_test.go
+360 loc · ccn 43 · commits (last 12mo) 2</title></rect>
+<rect x="905.72" y="179.85" width="26.61" height="26.66" fill="#d6ccca" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/linter_visitor.go
+355 loc · ccn 114 · commits (last 12mo) 1</title></rect>
+<rect x="905.72" y="206.50" width="26.61" height="26.20" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/replay_test.go
+349 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="905.72" y="232.71" width="26.61" height="25.83" fill="#f7b98a" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validator.go
+344 loc · ccn 103 · commits (last 12mo) 7</title></rect>
+<rect x="905.72" y="258.54" width="26.61" height="24.93" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/composition.go
+332 loc · ccn 58 · commits (last 12mo) 1</title></rect>
+<rect x="932.32" y="123.69" width="25.29" height="25.43" fill="#fdca94" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/handlers.go
+322 loc · ccn 69 · commits (last 12mo) 12</title></rect>
+<rect x="957.62" y="123.69" width="25.21" height="25.43" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/claiming_test.go
+321 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="982.83" y="123.69" width="25.06" height="25.43" fill="#f7c394" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/runtime.go
+319 loc · ccn 84 · commits (last 12mo) 7</title></rect>
+<rect x="1007.89" y="123.69" width="24.90" height="25.43" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/party_scope_test.go
+317 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1032.79" y="123.69" width="23.80" height="25.43" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/migrations_integration_test.go
+303 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="1056.59" y="123.69" width="23.72" height="25.43" fill="#e7d5c1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/lease_renewer_test.go
+302 loc · ccn 34 · commits (last 12mo) 4</title></rect>
+<rect x="932.32" y="149.12" width="25.70" height="23.09" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/error_classification_test.go
+297 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="932.32" y="172.21" width="25.70" height="22.86" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/event_converter_test.go
+294 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="932.32" y="195.07" width="25.70" height="22.70" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/outbox_repository_test.go
+292 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="932.32" y="217.77" width="25.70" height="22.16" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/causation_tree.go
+285 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="932.32" y="239.93" width="25.70" height="22.08" fill="#ecd2b2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/suspend.go
+284 loc · ccn 50 · commits (last 12mo) 5</title></rect>
+<rect x="932.32" y="262.01" width="25.70" height="21.46" fill="#ecd4b6" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_executor.go
+276 loc · ccn 43 · commits (last 12mo) 5</title></rect>
+<rect x="958.02" y="149.12" width="21.26" height="23.12" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/zombie_test.go
+246 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="979.28" y="149.12" width="20.57" height="23.12" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/starlark_runner_test.go
+238 loc · ccn 23 · commits (last 12mo) 4</title></rect>
+<rect x="999.85" y="149.12" width="20.22" height="23.12" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_executor_backoff_test.go
+234 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1020.07" y="149.12" width="20.22" height="23.12" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/circular_detector_test.go
+234 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1040.30" y="149.12" width="20.14" height="23.12" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/circular_detector.go
+233 loc · ccn 74 · commits (last 12mo) 3</title></rect>
+<rect x="1060.44" y="149.12" width="19.88" height="23.12" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/orphan_watcher_test.go
+230 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="958.02" y="172.23" width="19.43" height="23.13" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/starlark_runner.go
+225 loc · ccn 29 · commits (last 12mo) 9</title></rect>
+<rect x="958.02" y="195.37" width="19.43" height="22.82" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/decimal_test.go
+222 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="958.02" y="218.19" width="19.43" height="22.31" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validator_test.go
+217 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="958.02" y="240.50" width="19.43" height="21.59" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/claiming.go
+210 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="958.02" y="262.08" width="19.43" height="21.38" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/visibility_validator_test.go
+208 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="977.45" y="172.23" width="21.77" height="18.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition_backfill_test.go
+200 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="999.22" y="172.23" width="21.12" height="18.35" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/cel_evaluator_test.go
+194 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1020.34" y="172.23" width="20.46" height="18.35" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/events.go
+188 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1040.80" y="172.23" width="20.03" height="18.35" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/replay.go
+184 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="1060.83" y="172.23" width="19.48" height="18.35" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/error_classification.go
+179 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="977.45" y="190.59" width="18.58" height="18.92" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/builtins_test.go
+176 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="977.45" y="209.51" width="18.58" height="18.60" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/conservation_test.go
+173 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="977.45" y="228.11" width="18.58" height="18.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/compensation_lint_test.go
+172 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="977.45" y="246.60" width="18.58" height="18.49" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/uuid_generator_test.go
+172 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="977.45" y="265.08" width="18.58" height="18.38" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/visibility_validator.go
+171 loc · ccn 44 · commits (last 12mo) 2</title></rect>
+<rect x="996.04" y="190.59" width="17.54" height="17.54" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/timeout_worker.go
+154 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="1013.58" y="190.59" width="17.20" height="17.54" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/runtime_test.go
+151 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="1030.77" y="190.59" width="16.86" height="17.54" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/admin_handler_test.go
+148 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1047.63" y="190.59" width="16.74" height="17.54" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/compensation_test.go
+147 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="1064.37" y="190.59" width="15.94" height="17.54" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/starlark_values_test.go
+140 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="996.04" y="208.13" width="17.18" height="15.69" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/decimal.go
+135 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="996.04" y="223.83" width="17.18" height="15.69" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/orphan_watcher.go
+135 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="996.04" y="239.52" width="17.18" height="14.88" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/models.go
+128 loc · ccn 12 · commits (last 12mo) 4</title></rect>
+<rect x="996.04" y="254.40" width="17.18" height="14.53" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/metrics.go
+125 loc · ccn 10 · commits (last 12mo) 3</title></rect>
+<rect x="996.04" y="268.93" width="17.18" height="14.53" fill="#fde4c1" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/linter.go
+125 loc · ccn 10 · commits (last 12mo) 11</title></rect>
+<rect x="1013.22" y="208.13" width="17.27" height="14.11" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/lease_renewer.go
+122 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1030.49" y="208.13" width="17.27" height="14.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/composition_coverage_test.go
+122 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1047.76" y="208.13" width="16.56" height="14.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition_repository_test.go
+117 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1064.32" y="208.13" width="15.99" height="14.11" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/admin_handler.go
+113 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1013.22" y="222.25" width="13.93" height="15.91" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/executor_coverage_test.go
+111 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1013.22" y="238.16" width="13.93" height="15.63" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_resume_test.go
+109 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1013.22" y="253.79" width="13.93" height="14.91" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition_backfill.go
+104 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1013.22" y="268.70" width="13.93" height="14.77" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/clone_test.go
+103 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1027.16" y="222.25" width="13.83" height="14.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/timeout_worker_test.go
+102 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1040.99" y="222.25" width="13.70" height="14.73" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/backoff_integration_test.go
+101 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1054.68" y="222.25" width="12.88" height="14.73" fill="#ecdac2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/migrations.go
+95 loc · ccn 22 · commits (last 12mo) 5</title></rect>
+<rect x="1067.57" y="222.25" width="12.75" height="14.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/decimal_coverage_test.go
+94 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1027.16" y="236.98" width="11.65" height="15.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/composite_ref_test.go
+92 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1027.16" y="252.76" width="11.65" height="15.44" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/party_scope.go
+90 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1027.16" y="268.20" width="11.65" height="15.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/outbox_repository.go
+89 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1038.80" y="236.98" width="14.45" height="11.89" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/test_helpers_test.go
+86 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="1053.26" y="236.98" width="14.29" height="11.89" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition_repository.go
+85 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1067.54" y="236.98" width="12.77" height="11.89" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/models_coverage_test.go
+76 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1038.80" y="248.86" width="10.57" height="13.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/backoff_test.go
+72 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1038.80" y="262.48" width="10.57" height="11.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/metadata_test.go
+59 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1038.80" y="273.63" width="10.57" height="9.83" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/composite_ref.go
+52 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1049.37" y="248.86" width="10.83" height="9.04" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/suspend_coverage_test.go
+49 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1060.20" y="248.86" width="10.83" height="9.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/uuid_generator.go
+49 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1071.03" y="248.86" width="9.28" height="9.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/backoff.go
+42 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1049.37" y="257.90" width="9.61" height="8.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition_test.go
+41 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1049.37" y="266.42" width="9.61" height="8.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/events_coverage_test.go
+41 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1049.37" y="274.95" width="9.61" height="8.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/withlogger_coverage_test.go
+41 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1058.98" y="257.90" width="7.51" height="10.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/cel_evaluator.go
+38 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1066.49" y="257.90" width="6.91" height="10.11" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/metrics_test.go
+35 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1073.40" y="257.90" width="6.91" height="10.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_resume.go
+35 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1058.98" y="268.02" width="8.40" height="8.08" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/event_converter.go
+34 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1058.98" y="276.10" width="8.40" height="7.37" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/saga_definition.go
+31 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1067.38" y="268.02" width="7.05" height="8.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/metrics_coverage_test.go
+30 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1074.44" y="268.02" width="5.88" height="8.50" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/replay_coverage_test.go
+25 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1067.38" y="276.51" width="5.75" height="6.95" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/validator_production_test.go
+20 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1073.13" y="276.51" width="4.31" height="6.95" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/uuid_generator_coverage_test.go
+15 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1077.44" y="276.51" width="2.87" height="6.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/reference_data_client.go
+9 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1077.44" y="282.77" width="2.87" height="0.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/saga/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="0.00" width="39.18" height="31.11" fill="#eccfaf" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/processor_test.go
+610 loc · ccn 61 · commits (last 12mo) 5</title></rect>
+<rect x="1080.31" y="31.11" width="27.66" height="18.56" fill="#ecd3b4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/processor.go
+257 loc · ccn 48 · commits (last 12mo) 5</title></rect>
+<rect x="1107.98" y="31.11" width="11.52" height="7.46" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/worker.go
+43 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="1107.98" y="38.56" width="7.38" height="11.10" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/instruction.go
+41 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1115.35" y="38.56" width="4.14" height="10.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/fetcher.go
+22 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1115.35" y="49.18" width="4.14" height="0.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/worker/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="49.67" width="13.28" height="10.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/invoice.html
+69 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="60.05" width="13.28" height="9.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/payment-received.html
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="69.98" width="13.28" height="9.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/dunning-notice.html
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1093.59" y="49.67" width="8.87" height="11.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/account-frozen.html
+50 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1102.46" y="49.67" width="8.51" height="11.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/account-lockout.html
+48 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1110.98" y="49.67" width="8.51" height="11.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/invite-user.html
+48 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1093.59" y="60.93" width="9.90" height="9.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/verify-email.html
+47 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1093.59" y="70.42" width="9.90" height="9.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/password-reset.html
+47 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1103.49" y="60.93" width="10.22" height="8.99" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/welcome.html
+46 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1113.71" y="60.93" width="5.78" height="8.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/dunning-notice.txt
+26 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1103.49" y="69.92" width="5.20" height="4.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/account-frozen.txt
+13 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1103.49" y="74.91" width="5.20" height="4.99" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/payment-received.txt
+13 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1108.69" y="69.92" width="4.20" height="5.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/invoice.txt
+12 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1108.69" y="75.62" width="4.20" height="4.28" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/account-lockout.txt
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1112.89" y="69.92" width="3.49" height="5.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/invite-user.txt
+9 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1116.39" y="69.92" width="3.11" height="5.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/verify-email.txt
+8 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1112.89" y="75.06" width="3.30" height="4.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/password-reset.txt
+8 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1116.19" y="75.06" width="3.30" height="4.84" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/templates/welcome.txt
+8 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1080.31" y="79.90" width="39.18" height="26.36" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/template_test.go
+517 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="1119.49" y="0.00" width="14.01" height="9.55" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/invoice.html
+67 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1133.51" y="0.00" width="13.80" height="9.55" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/payment-received.html
+66 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1119.49" y="9.55" width="10.63" height="10.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s3.html
+58 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1119.49" y="20.45" width="10.63" height="10.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s2.html
+57 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1130.12" y="9.55" width="9.16" height="12.44" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s1.html
+57 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1139.28" y="9.55" width="8.03" height="12.44" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/account-frozen.html
+50 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1130.12" y="21.99" width="6.31" height="4.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s3.txt
+15 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1130.12" y="26.74" width="6.31" height="4.43" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s2.txt
+14 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1136.43" y="21.99" width="5.66" height="4.59" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/account-frozen.txt
+13 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1136.43" y="26.58" width="5.66" height="4.59" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/dunning-notice-s1.txt
+13 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1142.09" y="21.99" width="5.22" height="4.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/payment-received.txt
+13 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1142.09" y="26.96" width="5.22" height="4.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/testdata/invoice.txt
+11 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1147.31" y="0.00" width="27.50" height="31.17" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>shared/pkg/email/notification_handler_test.go
+429 loc · ccn 36 · commits (last 12mo) 2</title></rect>
+<rect x="1174.81" y="0.00" width="19.68" height="31.17" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>shared/pkg/email/outbox_postgres.go
+307 loc · ccn 50 · commits (last 12mo) 3</title></rect>
+<rect x="1119.49" y="31.17" width="20.95" height="23.18" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/email/unsubscribe_test.go
+243 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1140.44" y="31.17" width="19.31" height="23.18" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/pkg/email/delivery_status_test.go
+224 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1159.75" y="31.17" width="17.84" height="23.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/email/outbox_postgres_test.go
+207 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1177.59" y="31.17" width="16.89" height="23.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/email/preference_enforcer_test.go
+196 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1119.49" y="54.35" width="17.20" height="21.37" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/notification_handler.go
+184 loc · ccn 39 · commits (last 12mo) 3</title></rect>
+<rect x="1119.49" y="75.72" width="17.20" height="16.61" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>shared/pkg/email/audit_postgres.go
+143 loc · ccn 21 · commits (last 12mo) 3</title></rect>
+<rect x="1119.49" y="92.33" width="17.20" height="13.94" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/suppression_test.go
+120 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1136.69" y="54.35" width="16.28" height="14.12" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/suppression.go
+115 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1136.69" y="68.46" width="16.28" height="13.01" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/email/category_map_test.go
+106 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1136.69" y="81.47" width="16.28" height="12.89" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/pkg/email/metrics.go
+105 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1136.69" y="94.36" width="16.28" height="11.91" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/audit_postgres_test.go
+97 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1152.97" y="54.35" width="14.23" height="13.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender_test.go
+97 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1167.20" y="54.35" width="13.79" height="13.62" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>shared/pkg/email/preference_enforcer.go
+94 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1180.99" y="54.35" width="13.50" height="13.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/preference_postgres.go
+92 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1152.97" y="67.96" width="13.09" height="13.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/resend.go
+87 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1152.97" y="81.24" width="13.09" height="12.51" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender.go
+82 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1152.97" y="93.75" width="13.09" height="12.51" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/email/unsubscribe.go
+82 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1166.06" y="67.96" width="15.09" height="10.19" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/composite_audit_repository_test.go
+77 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1181.15" y="67.96" width="13.33" height="10.19" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/email/delivery_status.go
+68 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1166.06" y="78.15" width="13.50" height="9.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/template.go
+65 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1166.06" y="87.77" width="13.50" height="9.32" fill="#edddc8" stroke="white" stroke-width="0.5"><title>shared/pkg/email/repository.go
+63 loc · ccn 12 · commits (last 12mo) 5</title></rect>
+<rect x="1166.06" y="97.09" width="13.50" height="9.17" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>shared/pkg/email/template_data.go
+62 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="1179.56" y="78.15" width="7.54" height="13.25" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender_factory_test.go
+50 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1187.10" y="78.15" width="7.39" height="13.25" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/email/outbox_entity.go
+49 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1179.56" y="91.41" width="7.53" height="8.23" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender_log.go
+31 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1179.56" y="99.63" width="7.53" height="6.63" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender_factory.go
+25 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1187.09" y="91.41" width="7.39" height="5.13" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/preference_repository.go
+19 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1187.09" y="96.54" width="7.39" height="4.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/category_map.go
+18 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1187.09" y="101.40" width="6.98" height="4.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/sender_noop.go
+17 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1194.07" y="101.40" width="0.41" height="4.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/email/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1194.48" y="0.00" width="41.96" height="27.38" fill="#dccac0" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/redis_service_test.go
+575 loc · ccn 102 · commits (last 12mo) 2</title></rect>
+<rect x="1236.44" y="0.00" width="41.30" height="27.38" fill="#dcc9c0" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/postgres_service_test.go
+566 loc · ccn 104 · commits (last 12mo) 2</title></rect>
+<rect x="1194.48" y="27.38" width="31.53" height="30.67" fill="#e1c9b8" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/executor_test.go
+484 loc · ccn 94 · commits (last 12mo) 3</title></rect>
+<rect x="1194.48" y="58.05" width="31.53" height="24.59" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/state_machine_test.go
+388 loc · ccn 68 · commits (last 12mo) 1</title></rect>
+<rect x="1194.48" y="82.63" width="31.53" height="23.64" fill="#ecc5a4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/redis_service.go
+373 loc · ccn 92 · commits (last 12mo) 5</title></rect>
+<rect x="1226.01" y="27.38" width="25.90" height="27.92" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/redis_service_errors_test.go
+362 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1251.91" y="27.38" width="25.83" height="27.92" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/idempotency_test.go
+361 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="1226.01" y="55.30" width="21.56" height="29.29" fill="#e7cdb4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/postgres_service.go
+316 loc · ccn 70 · commits (last 12mo) 4</title></rect>
+<rect x="1226.01" y="84.58" width="21.56" height="21.69" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/executor.go
+234 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="1247.57" y="55.30" width="16.08" height="18.14" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/metrics_test.go
+146 loc · ccn 19 · commits (last 12mo) 3</title></rect>
+<rect x="1263.65" y="55.30" width="14.10" height="18.14" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/metrics.go
+128 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1247.57" y="73.43" width="15.09" height="15.49" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/state_machine.go
+117 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="1262.66" y="73.43" width="15.09" height="15.49" fill="#ecdbc5" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/idempotency.go
+117 loc · ccn 16 · commits (last 12mo) 5</title></rect>
+<rect x="1247.57" y="88.92" width="9.91" height="17.34" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/lazy_service.go
+86 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1257.47" y="88.92" width="12.21" height="8.84" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/noop_service_test.go
+54 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1257.47" y="97.76" width="12.21" height="8.51" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/lazy_service_test.go
+52 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1269.68" y="88.92" width="8.06" height="9.17" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/noop_service.go
+37 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1269.68" y="98.09" width="8.06" height="7.93" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/executor_error_test.go
+32 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1269.68" y="106.02" width="8.06" height="0.25" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/idempotency/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="106.27" width="34.33" height="31.77" fill="#e6c2aa" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/circuitbreaker_test.go
+546 loc · ccn 104 · commits (last 12mo) 4</title></rect>
+<rect x="1114.64" y="106.27" width="26.72" height="31.77" fill="#e7cab1" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/retry_test.go
+425 loc · ccn 81 · commits (last 12mo) 4</title></rect>
+<rect x="1080.31" y="138.04" width="34.61" height="22.97" fill="#e1c9b8" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/resilient_test.go
+398 loc · ccn 94 · commits (last 12mo) 3</title></rect>
+<rect x="1114.93" y="138.04" width="26.44" height="22.97" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/saga_test.go
+304 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="161.01" width="21.11" height="25.46" fill="#e7d7c4" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/common_test.go
+269 loc · ccn 27 · commits (last 12mo) 4</title></rect>
+<rect x="1080.31" y="186.47" width="21.11" height="18.26" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/resilient.go
+193 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="1101.42" y="161.01" width="20.12" height="13.31" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/idempotency_test.go
+134 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="1121.54" y="161.01" width="19.82" height="13.31" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/circuitbreaker_example_test.go
+132 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1101.42" y="174.32" width="12.48" height="15.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/saga.go
+97 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1101.42" y="189.85" width="12.48" height="14.89" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/retry.go
+93 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1113.91" y="174.32" width="14.29" height="12.44" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/temporal_test.go
+89 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1128.20" y="174.32" width="13.17" height="12.44" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/circuitbreaker.go
+82 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="1113.91" y="186.76" width="14.90" height="9.66" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/grpc_factory.go
+72 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1113.91" y="196.42" width="14.90" height="8.32" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/common.go
+62 loc · ccn 21 · commits (last 12mo) 3</title></rect>
+<rect x="1128.80" y="186.76" width="12.56" height="6.68" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/grpc_factory_test.go
+42 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1128.80" y="193.44" width="5.84" height="11.29" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/idempotency.go
+33 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1134.64" y="193.44" width="6.72" height="7.73" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/temporal.go
+26 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1134.64" y="201.17" width="6.16" height="3.57" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/errors.go
+11 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1140.80" y="201.17" width="0.56" height="3.57" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/clients/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1080.31" y="204.73" width="37.97" height="36.62" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/compiler_test.go
+696 loc · ccn 66 · commits (last 12mo) 2</title></rect>
+<rect x="1118.29" y="204.73" width="23.08" height="36.62" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/benchmark_test.go
+423 loc · ccn 77 · commits (last 12mo) 1</title></rect>
+<rect x="1080.31" y="241.35" width="32.92" height="22.57" fill="#e1cbba" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/compiler.go
+372 loc · ccn 82 · commits (last 12mo) 3</title></rect>
+<rect x="1080.31" y="263.93" width="32.92" height="19.54" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/security_test.go
+322 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1113.23" y="241.35" width="28.13" height="16.48" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/determinism_test.go
+232 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="1113.23" y="257.83" width="14.80" height="25.64" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/regression_test.go
+190 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1128.04" y="257.83" width="13.32" height="16.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/chain_depth_test.go
+110 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1128.04" y="274.32" width="13.11" height="9.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/validate_cel_test.go
+60 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1141.14" y="274.32" width="0.22" height="9.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/cel/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1141.36" y="106.27" width="14.87" height="23.51" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/internal/builtins/builtins.go
+175 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="1156.23" y="106.27" width="13.85" height="23.51" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/internal/builtins/builtins_test.go
+163 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1141.36" y="129.78" width="28.72" height="18.29" fill="#e7cfb6" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/starlark_runtime.go
+263 loc · ccn 63 · commits (last 12mo) 4</title></rect>
+<rect x="1141.36" y="148.07" width="28.72" height="17.60" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/starlark_security_test.go
+253 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="1170.09" y="106.27" width="17.64" height="22.08" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/policy_runtime_test.go
+195 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1187.73" y="106.27" width="15.56" height="22.08" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/default_engine_test.go
+172 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1203.29" y="106.27" width="15.20" height="22.08" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/types_test.go
+168 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1170.09" y="128.35" width="15.47" height="20.14" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/starlark_runtime_test.go
+156 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="1170.09" y="148.49" width="15.47" height="17.17" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/cache.go
+133 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1185.56" y="128.35" width="16.79" height="15.35" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/cache_test.go
+129 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1202.35" y="128.35" width="16.14" height="15.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/types.go
+124 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1185.56" y="143.70" width="11.10" height="21.96" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/policy_runtime.go
+122 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1196.66" y="143.70" width="12.31" height="10.71" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/default_engine.go
+66 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1208.97" y="143.70" width="9.52" height="10.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/static_method_resolver.go
+51 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1196.66" y="154.41" width="8.70" height="11.26" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/static_method_resolver_test.go
+49 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1205.35" y="154.41" width="6.92" height="11.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/engine.go
+39 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1212.27" y="154.41" width="6.21" height="10.94" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/engine_test.go
+34 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1212.27" y="165.34" width="6.21" height="0.32" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuation/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1218.48" y="106.27" width="33.73" height="39.27" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/engine_test.go
+663 loc · ccn 47 · commits (last 12mo) 1</title></rect>
+<rect x="1252.21" y="106.27" width="25.54" height="39.27" fill="#d6cac8" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/engine.go
+502 loc · ccn 127 · commits (last 12mo) 1</title></rect>
+<rect x="1218.48" y="145.54" width="16.08" height="20.13" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/dryrun_test.go
+162 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1234.57" y="145.54" width="13.90" height="20.13" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/dryrun.go
+140 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1248.46" y="145.54" width="12.41" height="20.13" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/engine_batch_test.go
+125 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1260.87" y="145.54" width="16.88" height="12.55" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/engine_batch.go
+106 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1260.87" y="158.09" width="13.71" height="7.58" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/gjson_test.go
+52 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1274.58" y="158.09" width="3.16" height="6.95" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/gjson.go
+11 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1274.58" y="165.03" width="3.16" height="0.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/mapping/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1141.36" y="165.67" width="25.18" height="24.12" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/repository_test.go
+304 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1166.54" y="165.67" width="23.77" height="24.12" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/repository.go
+287 loc · ccn 55 · commits (last 12mo) 2</title></rect>
+<rect x="1141.36" y="189.79" width="19.93" height="28.36" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/seeder_test.go
+283 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="1141.36" y="218.15" width="19.93" height="16.54" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/resolution_test.go
+165 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1161.30" y="189.79" width="15.36" height="21.07" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/domain_test.go
+162 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1176.65" y="189.79" width="13.65" height="21.07" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/operations.go
+144 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="1161.30" y="210.86" width="18.53" height="13.91" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/operations_test.go
+129 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1161.30" y="224.77" width="18.53" height="9.92" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/domain.go
+92 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1179.83" y="210.86" width="10.48" height="9.15" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/seeder.go
+48 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1179.83" y="220.01" width="10.48" height="6.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/resolution.go
+33 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1179.83" y="226.30" width="5.72" height="8.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/entity.go
+24 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1185.54" y="226.30" width="4.76" height="7.97" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/errors.go
+19 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="1185.54" y="234.27" width="4.76" height="0.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/valuationfeature/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1141.36" y="234.69" width="26.50" height="32.49" fill="#e7c5ac" stroke="white" stroke-width="0.5"><title>shared/pkg/health/checkers_test.go
+431 loc · ccn 99 · commits (last 12mo) 4</title></rect>
+<rect x="1141.36" y="267.18" width="26.50" height="16.28" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/health/health_test.go
+216 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="1167.86" y="234.69" width="22.44" height="17.00" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>shared/pkg/health/checkers.go
+191 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="1167.86" y="251.69" width="22.44" height="14.86" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/pkg/health/http_test.go
+167 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="1167.86" y="266.55" width="12.99" height="16.91" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/health/health.go
+110 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1180.86" y="266.55" width="9.45" height="16.70" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/health/http.go
+79 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1180.86" y="283.26" width="9.45" height="0.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/health/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1190.31" y="165.67" width="19.83" height="21.36" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/fallback_resolver.go
+212 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="1190.31" y="187.02" width="19.83" height="19.24" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/fallback_resolver_test.go
+191 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1210.14" y="165.67" width="14.64" height="20.61" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/cached_resolver_test.go
+151 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1224.78" y="165.67" width="11.34" height="20.61" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/grpc_datasource_test.go
+117 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1210.14" y="186.27" width="11.69" height="19.99" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/cached_resolver.go
+117 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1221.83" y="186.27" width="14.29" height="8.95" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/instrument_resolver_test.go
+64 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1221.83" y="195.22" width="11.21" height="11.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/grpc_datasource.go
+62 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1233.04" y="195.22" width="3.07" height="10.40" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/instrument_resolver.go
+16 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1233.04" y="205.62" width="3.07" height="0.65" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/refdata/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1236.12" y="165.67" width="18.21" height="14.81" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/worker_test.go
+135 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1236.12" y="180.48" width="18.21" height="14.26" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/circuit_breaker_test.go
+130 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1236.12" y="194.74" width="18.21" height="11.52" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/worker.go
+105 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1254.32" y="165.67" width="13.03" height="15.95" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/backoff_test.go
+104 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1267.35" y="165.67" width="10.40" height="15.95" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/circuit_breaker.go
+83 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1254.32" y="181.62" width="13.41" height="11.77" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/instruction_test.go
+79 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1267.73" y="181.62" width="10.01" height="11.77" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/dispatcher_test.go
+59 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1254.32" y="193.39" width="11.01" height="6.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/instruction.go
+37 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1254.32" y="200.10" width="11.01" height="6.17" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/backoff.go
+34 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1265.34" y="193.39" width="7.20" height="8.05" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/domain_test.go
+29 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1272.54" y="193.39" width="5.21" height="8.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/domain.go
+21 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1265.34" y="201.44" width="8.69" height="4.83" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/dispatcher.go
+21 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1274.02" y="201.44" width="3.72" height="4.29" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/repository.go
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1274.02" y="205.73" width="3.72" height="0.54" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/dispatch/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1190.31" y="206.27" width="29.06" height="24.89" fill="#dbc6bd" stroke="white" stroke-width="0.5"><title>shared/pkg/types/mo_bench_test.go
+362 loc · ccn 118 · commits (last 12mo) 2</title></rect>
+<rect x="1190.31" y="231.15" width="24.04" height="17.12" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>shared/pkg/types/types_test.go
+206 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="1214.35" y="231.15" width="5.02" height="16.72" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/types/types.go
+42 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1214.35" y="247.87" width="5.02" height="0.40" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/types/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1190.31" y="248.27" width="29.06" height="17.39" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/amount/amount_test.go
+253 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="1190.31" y="265.66" width="15.15" height="17.81" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/amount/multi_dimension_test.go
+135 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1205.45" y="265.66" width="13.91" height="17.66" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>shared/pkg/amount/amount.go
+123 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="1205.45" y="283.32" width="13.91" height="0.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/amount/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1219.37" y="206.27" width="15.76" height="23.83" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/interceptors/metrics_test.go
+188 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1235.13" y="206.27" width="14.67" height="23.83" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/pkg/interceptors/recovery_test.go
+175 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1219.37" y="230.09" width="24.59" height="8.20" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/interceptors/recovery.go
+101 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1243.96" y="230.09" width="5.84" height="7.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/interceptors/metrics.go
+23 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1243.96" y="237.95" width="5.84" height="0.34" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/interceptors/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1249.80" y="206.27" width="27.94" height="20.23" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/pkg/money/money_test.go
+283 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="1249.80" y="226.50" width="27.77" height="11.80" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>shared/pkg/money/money.go
+164 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="1277.58" y="226.50" width="0.17" height="11.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/money/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1219.37" y="238.30" width="18.57" height="23.89" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/pkg/bucketing/bucketing_test.go
+222 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1237.93" y="238.30" width="11.37" height="23.71" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/pkg/bucketing/bucketing.go
+135 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1237.93" y="262.01" width="11.37" height="0.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/bucketing/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1219.37" y="262.18" width="24.22" height="21.28" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/grpc/client_test.go
+258 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="1243.58" y="262.18" width="5.73" height="20.94" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>shared/pkg/grpc/client.go
+60 loc · ccn 6 · commits (last 12mo) 3</title></rect>
+<rect x="1243.58" y="283.12" width="5.73" height="0.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/grpc/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1249.31" y="238.30" width="17.93" height="18.05" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/credentials/password_test.go
+162 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="1267.23" y="238.30" width="10.51" height="12.54" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/pkg/credentials/password.go
+66 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1267.23" y="250.84" width="7.25" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/credentials/types.go
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1274.48" y="250.84" width="3.26" height="4.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/credentials/errors.go
+8 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1274.48" y="255.74" width="3.26" height="0.61" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/credentials/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1249.31" y="256.35" width="17.53" height="12.65" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/pkg/tokens/token_test.go
+111 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="1249.31" y="269.00" width="9.80" height="14.47" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/pkg/tokens/expiry_test.go
+71 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1259.11" y="269.00" width="7.73" height="9.82" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>shared/pkg/tokens/token.go
+38 loc · ccn 7 · commits (last 12mo) 2</title></rect>
+<rect x="1259.11" y="278.82" width="7.30" height="4.65" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/pkg/tokens/expiry.go
+17 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1266.41" y="278.82" width="0.43" height="4.65" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/tokens/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1266.84" y="256.35" width="10.90" height="8.24" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/proto/mappers/currency_test.go
+45 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1266.84" y="264.60" width="10.53" height="5.31" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/pkg/proto/mappers/currency.go
+28 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="1277.37" y="264.60" width="0.38" height="5.31" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/proto/mappers/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1266.84" y="269.91" width="10.90" height="9.34" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/validation/account_id_test.go
+51 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1266.84" y="279.25" width="10.43" height="4.21" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/pkg/validation/account_id.go
+22 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1277.27" y="279.25" width="0.47" height="4.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/pkg/validation/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="283.47" width="57.06" height="36.52" fill="#f2c9a1" stroke="white" stroke-width="0.5"><title>shared/platform/auth/grpc_interceptor_test.go
+1043 loc · ccn 76 · commits (last 12mo) 6</title></rect>
+<rect x="930.68" y="283.47" width="33.20" height="36.52" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/rbac_test.go
+607 loc · ccn 83 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="319.99" width="34.60" height="29.50" fill="#e7cbb3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwt_test.go
+511 loc · ccn 76 · commits (last 12mo) 4</title></rect>
+<rect x="908.23" y="319.99" width="29.18" height="29.50" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>shared/platform/auth/oauth_test.go
+431 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="937.41" y="319.99" width="26.48" height="29.50" fill="#e7d5c0" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwks_test.go
+391 loc · ccn 36 · commits (last 12mo) 4</title></rect>
+<rect x="873.63" y="349.49" width="23.57" height="30.18" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>shared/platform/auth/method_rbac_interceptor_test.go
+356 loc · ccn 65 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="379.67" width="23.57" height="27.47" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/platform/auth/config_test.go
+324 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="407.14" width="23.57" height="25.18" fill="#f2cfa8" stroke="white" stroke-width="0.5"><title>shared/platform/auth/grpc_interceptor.go
+297 loc · ccn 60 · commits (last 12mo) 6</title></rect>
+<rect x="897.19" y="349.49" width="26.02" height="22.35" fill="#e7d1b8" stroke="white" stroke-width="0.5"><title>shared/platform/auth/rbac.go
+291 loc · ccn 55 · commits (last 12mo) 4</title></rect>
+<rect x="923.21" y="349.49" width="21.01" height="22.35" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/auth/tenant_interceptor_test.go
+235 loc · ccn 28 · commits (last 12mo) 2</title></rect>
+<rect x="944.22" y="349.49" width="19.67" height="22.35" fill="#e1d3c2" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwks.go
+220 loc · ccn 45 · commits (last 12mo) 3</title></rect>
+<rect x="897.19" y="371.84" width="19.56" height="21.25" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwt_signer_test.go
+208 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="897.19" y="393.09" width="19.56" height="19.82" fill="#e7d5c0" stroke="white" stroke-width="0.5"><title>shared/platform/auth/config.go
+194 loc · ccn 35 · commits (last 12mo) 4</title></rect>
+<rect x="897.19" y="412.90" width="19.56" height="19.41" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>shared/platform/auth/metrics_test.go
+190 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="916.75" y="371.84" width="23.63" height="15.64" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/auth/oauth.go
+185 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="940.38" y="371.84" width="23.51" height="15.64" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/platform/auth/platform_admin_interceptor_test.go
+184 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="916.75" y="387.48" width="18.36" height="16.54" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwt_signer.go
+152 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="916.75" y="404.02" width="18.36" height="14.15" fill="#ecd7bc" stroke="white" stroke-width="0.5"><title>shared/platform/auth/jwt.go
+130 loc · ccn 32 · commits (last 12mo) 5</title></rect>
+<rect x="916.75" y="418.17" width="18.36" height="14.15" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/auth/service_auth_test.go
+130 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="935.10" y="387.48" width="15.11" height="15.20" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/service_credentials_test.go
+115 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="950.22" y="387.48" width="13.67" height="15.20" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>shared/platform/auth/method_rbac_interceptor.go
+104 loc · ccn 24 · commits (last 12mo) 3</title></rect>
+<rect x="935.10" y="402.68" width="16.31" height="10.41" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/platform/auth/tenant_interceptor.go
+85 loc · ccn 16 · commits (last 12mo) 3</title></rect>
+<rect x="951.41" y="402.68" width="12.47" height="10.41" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/auth/actor_test.go
+65 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="935.10" y="413.09" width="11.64" height="10.82" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/service_auth.go
+63 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="935.10" y="423.90" width="11.64" height="8.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/rbac_coverage_test.go
+49 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="946.74" y="413.09" width="9.14" height="10.49" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/platform/auth/platform_admin_interceptor.go
+48 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="955.89" y="413.09" width="8.00" height="10.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/metrics.go
+42 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="946.74" y="423.58" width="5.94" height="8.74" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/auth/service_credentials.go
+26 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="952.69" y="423.58" width="5.71" height="8.74" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/auth/rbac_coverage.go
+25 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="958.40" y="423.58" width="5.49" height="8.38" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/auth/actor.go
+23 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="958.40" y="431.95" width="5.49" height="0.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/auth/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="432.32" width="45.65" height="30.99" fill="#e7c4ab" stroke="white" stroke-width="0.5"><title>shared/platform/db/integration_test.go
+708 loc · ccn 101 · commits (last 12mo) 4</title></rect>
+<rect x="919.27" y="432.32" width="22.95" height="30.99" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>shared/platform/db/pool_coverage_test.go
+356 loc · ccn 71 · commits (last 12mo) 3</title></rect>
+<rect x="942.22" y="432.32" width="21.66" height="30.99" fill="#e7d9c7" stroke="white" stroke-width="0.5"><title>shared/platform/db/gorm_tenant_scope_test.go
+336 loc · ccn 19 · commits (last 12mo) 4</title></rect>
+<rect x="873.63" y="463.30" width="25.29" height="24.49" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_isolation_integration_test.go
+310 loc · ccn 42 · commits (last 12mo) 4</title></rect>
+<rect x="873.63" y="487.79" width="25.29" height="23.54" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_scope_integration_test.go
+298 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="511.34" width="25.29" height="16.20" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/platform/db/health_test.go
+205 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="898.91" y="463.30" width="17.29" height="22.41" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_scope_test.go
+194 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="898.91" y="485.71" width="17.29" height="21.14" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_guard_test.go
+183 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="898.91" y="506.85" width="17.29" height="20.68" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/platform/db/interceptor_test.go
+179 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="916.21" y="463.30" width="16.21" height="17.01" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/db/pool.go
+138 loc · ccn 33 · commits (last 12mo) 2</title></rect>
+<rect x="932.41" y="463.30" width="15.85" height="17.01" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/db/health_example_test.go
+135 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="948.27" y="463.30" width="15.62" height="17.01" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_audit_test.go
+133 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="916.21" y="480.31" width="16.25" height="15.86" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/db/pool_test.go
+129 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="916.21" y="496.18" width="16.25" height="15.74" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>shared/platform/db/health.go
+128 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="916.21" y="511.92" width="16.25" height="15.62" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/db/guarded_pgx_pool_test.go
+127 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="932.45" y="480.31" width="16.69" height="14.36" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/db/transaction.go
+120 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="949.14" y="480.31" width="14.74" height="14.36" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>shared/platform/db/pool_leak_test.go
+106 loc · ccn 15 · commits (last 12mo) 4</title></rect>
+<rect x="932.45" y="494.68" width="17.74" height="11.38" fill="#ecdac2" stroke="white" stroke-width="0.5"><title>shared/platform/db/gorm_tenant_scope.go
+101 loc · ccn 22 · commits (last 12mo) 5</title></rect>
+<rect x="950.19" y="494.68" width="13.70" height="11.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/db/transaction_test.go
+78 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="932.45" y="506.05" width="12.65" height="11.69" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/platform/db/guarded_pgx_pool.go
+74 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="932.45" y="517.74" width="12.65" height="9.79" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_guard.go
+62 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="945.10" y="506.05" width="10.10" height="8.51" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/db/pgx_tenant_guard_test.go
+43 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="955.20" y="506.05" width="8.69" height="8.51" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>shared/platform/db/db.go
+37 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="945.10" y="514.56" width="10.47" height="6.49" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/db/db_test.go
+34 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="945.10" y="521.05" width="10.47" height="6.49" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>shared/platform/db/tenant_scope.go
+34 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="955.57" y="514.56" width="8.32" height="6.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/db/interceptor.go
+27 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="955.57" y="521.05" width="8.01" height="6.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/db/pgx_tenant_guard.go
+26 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="963.58" y="521.05" width="0.31" height="6.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/db/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="963.89" y="283.47" width="29.00" height="48.64" fill="#fdbe87" stroke="white" stroke-width="0.5"><title>shared/platform/audit/worker_test.go
+706 loc · ccn 90 · commits (last 12mo) 9</title></rect>
+<rect x="963.89" y="332.11" width="29.00" height="35.35" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/platform/audit/consumer_unit_test.go
+513 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="992.88" y="283.47" width="31.59" height="22.39" fill="#f2caa3" stroke="white" stroke-width="0.5"><title>shared/platform/audit/consumer.go
+354 loc · ccn 71 · commits (last 12mo) 6</title></rect>
+<rect x="1024.47" y="283.47" width="30.97" height="22.39" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>shared/platform/audit/hooks_test.go
+347 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="992.88" y="305.85" width="26.66" height="24.88" fill="#f2cfa8" stroke="white" stroke-width="0.5"><title>shared/platform/audit/worker.go
+332 loc · ccn 60 · commits (last 12mo) 6</title></rect>
+<rect x="992.88" y="330.73" width="26.66" height="18.51" fill="#eddfce" stroke="white" stroke-width="0.5"><title>shared/platform/audit/README.md
+247 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="992.88" y="349.24" width="26.66" height="18.21" fill="#ecd3b3" stroke="white" stroke-width="0.5"><title>shared/platform/audit/publisher.go
+243 loc · ccn 49 · commits (last 12mo) 5</title></rect>
+<rect x="1019.54" y="305.85" width="21.20" height="21.20" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/audit/publisher_test.go
+225 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1040.74" y="305.85" width="14.70" height="21.20" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>shared/platform/audit/hooks.go
+156 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="1019.54" y="327.06" width="19.05" height="15.41" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>shared/platform/audit/metrics.go
+147 loc · ccn 15 · commits (last 12mo) 4</title></rect>
+<rect x="1038.59" y="327.06" width="16.85" height="15.41" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>shared/platform/audit/worker_unit_test.go
+130 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="1019.54" y="342.47" width="17.75" height="12.94" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/audit/multi_tenant_worker.go
+115 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1019.54" y="355.41" width="17.75" height="12.04" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/audit/consumer_test.go
+107 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1037.29" y="342.47" width="9.68" height="14.86" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/platform/audit/context_test.go
+72 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="1046.97" y="342.47" width="8.47" height="14.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/audit/publisher_unit_test.go
+63 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1037.29" y="357.33" width="6.51" height="10.13" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>shared/platform/audit/metrics_test.go
+33 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1043.80" y="357.33" width="8.29" height="5.79" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>shared/platform/audit/context.go
+24 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="1043.80" y="363.12" width="8.29" height="4.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/audit/errors.go
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1052.09" y="357.33" width="3.35" height="9.53" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/audit/status.go
+16 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1052.09" y="366.86" width="3.35" height="0.60" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/platform/audit/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="963.89" y="367.46" width="28.39" height="19.21" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>shared/platform/events/topics/topics.yaml
+273 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="963.89" y="386.67" width="28.39" height="14.36" fill="#f2d5af" stroke="white" stroke-width="0.5"><title>shared/platform/events/topics/topics_test.go
+204 loc · ccn 45 · commits (last 12mo) 6</title></rect>
+<rect x="992.27" y="367.46" width="7.26" height="33.57" fill="#f2e2cc" stroke="white" stroke-width="0.5"><title>shared/platform/events/topics/topics.go
+122 loc · ccn 1 · commits (last 12mo) 6</title></rect>
+<rect x="963.89" y="401.03" width="35.65" height="26.00" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/platform/events/outbox_pgx_integration_test.go
+464 loc · ccn 45 · commits (last 12mo) 2</title></rect>
+<rect x="963.89" y="427.03" width="35.65" height="22.47" fill="#eccbab" stroke="white" stroke-width="0.5"><title>shared/platform/events/worker_test.go
+401 loc · ccn 72 · commits (last 12mo) 5</title></rect>
+<rect x="999.53" y="367.46" width="28.78" height="25.26" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>shared/platform/events/publisher_test.go
+364 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="1028.32" y="367.46" width="27.12" height="25.26" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>shared/platform/events/outbox_pgx.go
+343 loc · ccn 65 · commits (last 12mo) 4</title></rect>
+<rect x="999.53" y="392.72" width="28.16" height="19.51" fill="#e7d6c1" stroke="white" stroke-width="0.5"><title>shared/platform/events/outbox_test.go
+275 loc · ccn 32 · commits (last 12mo) 4</title></rect>
+<rect x="1027.69" y="392.72" width="27.75" height="19.51" fill="#ecd5b7" stroke="white" stroke-width="0.5"><title>shared/platform/events/worker.go
+271 loc · ccn 41 · commits (last 12mo) 5</title></rect>
+<rect x="999.53" y="412.23" width="27.55" height="19.43" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>shared/platform/events/worker_unit_test.go
+268 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="999.53" y="431.66" width="27.55" height="17.84" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/events/outbox_pgx_test.go
+246 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1027.09" y="412.23" width="28.36" height="14.87" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/events/outbox.go
+211 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="1027.09" y="427.10" width="17.03" height="13.96" fill="#e7d9c7" stroke="white" stroke-width="0.5"><title>shared/platform/events/publisher.go
+119 loc · ccn 19 · commits (last 12mo) 4</title></rect>
+<rect x="1027.09" y="441.06" width="17.03" height="8.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/events/metrics.go
+72 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1044.12" y="427.10" width="11.32" height="10.94" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/events/publisher_integration_test.go
+62 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1044.12" y="438.04" width="11.32" height="6.17" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/events/schema.sql
+35 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1044.12" y="444.21" width="10.95" height="5.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/events/metrics_test.go
+29 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1055.06" y="444.21" width="0.38" height="5.29" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/events/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="963.89" y="449.50" width="43.34" height="53.65" fill="#eaa286" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/cron_test.go
+1164 loc · ccn 154 · commits (last 12mo) 5</title></rect>
+<rect x="963.89" y="503.15" width="43.34" height="24.38" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/catchup_test.go
+529 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="1007.23" y="449.50" width="27.13" height="33.65" fill="#f2c49c" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/cron.go
+457 loc · ccn 87 · commits (last 12mo) 6</title></rect>
+<rect x="1034.36" y="449.50" width="21.08" height="33.65" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/execution_store_test.go
+355 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="1007.23" y="483.15" width="20.80" height="25.94" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/lifecycle_test.go
+270 loc · ccn 59 · commits (last 12mo) 2</title></rect>
+<rect x="1007.23" y="509.09" width="20.80" height="18.44" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/catchup.go
+192 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="1028.03" y="483.15" width="13.96" height="23.76" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/metrics_test.go
+166 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="1041.99" y="483.15" width="13.45" height="23.76" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/execution_store.go
+160 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="1028.03" y="506.91" width="11.82" height="20.62" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/metrics.go
+122 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="1039.84" y="506.91" width="15.60" height="13.83" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/lifecycle.go
+108 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="1039.84" y="520.74" width="10.30" height="6.79" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/metrics_config_test.go
+35 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1050.14" y="520.74" width="5.30" height="6.41" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/config.go
+17 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1050.14" y="527.16" width="5.30" height="0.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/scheduler/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1055.44" y="283.47" width="26.61" height="29.05" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/observability/tracing_test.go
+387 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1055.44" y="312.52" width="26.61" height="26.65" fill="#e7c7ae" stroke="white" stroke-width="0.5"><title>shared/platform/observability/logging_test.go
+355 loc · ccn 91 · commits (last 12mo) 4</title></rect>
+<rect x="1055.44" y="339.17" width="26.61" height="23.65" fill="#ecd5b7" stroke="white" stroke-width="0.5"><title>shared/platform/observability/grpc.go
+315 loc · ccn 41 · commits (last 12mo) 5</title></rect>
+<rect x="1082.05" y="283.47" width="30.23" height="19.96" fill="#f7cb9c" stroke="white" stroke-width="0.5"><title>shared/platform/observability/metrics_test.go
+302 loc · ccn 68 · commits (last 12mo) 7</title></rect>
+<rect x="1112.28" y="283.47" width="28.73" height="19.96" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/platform/observability/grpc_test.go
+287 loc · ccn 49 · commits (last 12mo) 1</title></rect>
+<rect x="1082.05" y="303.42" width="22.81" height="21.55" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/platform/observability/README.md
+246 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1104.86" y="303.42" width="21.42" height="21.55" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/observability/helpers_test.go
+231 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1126.27" y="303.42" width="14.74" height="21.55" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/observability/config_test.go
+159 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1082.05" y="324.97" width="16.26" height="19.42" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/platform/observability/logging.go
+158 loc · ccn 33 · commits (last 12mo) 3</title></rect>
+<rect x="1082.05" y="344.39" width="16.26" height="18.43" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>shared/platform/observability/tracing.go
+150 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="1098.31" y="324.97" width="14.89" height="19.06" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>shared/platform/observability/metrics.go
+142 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="1098.31" y="344.03" width="14.89" height="18.79" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>shared/platform/observability/semconv_integration_test.go
+140 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="1113.19" y="324.97" width="16.50" height="16.59" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>shared/platform/observability/helpers.go
+137 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="1129.69" y="324.97" width="11.32" height="16.59" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/observability/config.go
+94 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="1113.19" y="341.56" width="15.88" height="11.82" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/observability/propagation_test.go
+94 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1113.19" y="353.39" width="15.88" height="9.43" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/observability/logging_unit_test.go
+75 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1129.08" y="341.56" width="11.94" height="7.87" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/observability/tracing_integration_test.go
+47 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1129.08" y="349.43" width="11.94" height="6.70" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/observability/propagation.go
+40 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1129.08" y="356.13" width="11.64" height="6.70" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/observability/tracing_unit_test.go
+39 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1140.71" y="356.13" width="0.30" height="6.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/observability/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1141.01" y="283.47" width="29.05" height="40.98" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/rate_test.go
+596 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="1141.01" y="324.45" width="29.05" height="38.37" fill="#d6cdcb" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/quantity_test.go
+558 loc · ccn 101 · commits (last 12mo) 1</title></rect>
+<rect x="1170.06" y="283.47" width="29.69" height="30.15" fill="#dccec4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/value_test.go
+448 loc · ccn 76 · commits (last 12mo) 2</title></rect>
+<rect x="1199.75" y="283.47" width="26.71" height="30.15" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/instrument_test.go
+403 loc · ccn 67 · commits (last 12mo) 1</title></rect>
+<rect x="1170.06" y="313.61" width="20.79" height="26.43" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/attribute_bag_test.go
+275 loc · ccn 67 · commits (last 12mo) 2</title></rect>
+<rect x="1170.06" y="340.04" width="20.79" height="15.67" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/currency/currency_test.go
+163 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1170.06" y="355.71" width="20.79" height="7.11" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/currency/currency.go
+74 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1190.85" y="313.61" width="22.66" height="19.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/quantity.go
+224 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1213.51" y="313.61" width="12.95" height="19.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/asset_dimensions_test.go
+128 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1190.85" y="333.36" width="13.43" height="15.17" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/instrument.go
+102 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1190.85" y="348.54" width="13.43" height="14.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/parse_test.go
+96 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1204.28" y="333.36" width="11.90" height="14.77" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/attribute_bag.go
+88 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1216.18" y="333.36" width="10.28" height="14.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/interfaces.go
+76 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1204.28" y="348.14" width="10.34" height="14.68" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/rate.go
+76 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1214.62" y="348.14" width="11.84" height="5.91" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/dimension_test.go
+35 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1214.62" y="354.04" width="5.92" height="8.78" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/parse.go
+26 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1220.54" y="354.04" width="5.92" height="5.06" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/dimension.go
+15 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1220.54" y="359.11" width="5.38" height="3.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/value.go
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1225.92" y="359.11" width="0.54" height="3.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/quantity/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1055.44" y="362.82" width="30.35" height="32.72" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/dlq_test.go
+497 loc · ccn 57 · commits (last 12mo) 2</title></rect>
+<rect x="1085.79" y="362.82" width="21.13" height="32.72" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/dlq_admin_test.go
+346 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="1106.91" y="362.82" width="19.60" height="32.72" fill="#e7cab1" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/dlq_admin.go
+321 loc · ccn 82 · commits (last 12mo) 4</title></rect>
+<rect x="1055.44" y="395.54" width="21.62" height="25.60" fill="#f2cea7" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/consumer.go
+277 loc · ccn 62 · commits (last 12mo) 6</title></rect>
+<rect x="1055.44" y="421.14" width="21.62" height="25.50" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/config_unit_test.go
+276 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="1077.06" y="395.54" width="27.70" height="18.46" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/consumer_test.go
+256 loc · ccn 43 · commits (last 12mo) 4</title></rect>
+<rect x="1104.76" y="395.54" width="21.75" height="18.46" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/consumer_unit_test.go
+201 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1077.06" y="414.00" width="23.20" height="17.22" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/dlq.go
+200 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1077.06" y="431.22" width="23.20" height="15.42" fill="#ecd8be" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/producer_test.go
+179 loc · ccn 29 · commits (last 12mo) 5</title></rect>
+<rect x="1100.26" y="414.00" width="13.22" height="22.37" fill="#f2d9b8" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/producer.go
+148 loc · ccn 31 · commits (last 12mo) 6</title></rect>
+<rect x="1113.48" y="414.00" width="13.04" height="22.37" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/dlq_admin_unit_test.go
+146 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1100.26" y="436.37" width="14.00" height="10.27" fill="#e7dbcc" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/config.go
+72 loc · ccn 9 · commits (last 12mo) 4</title></rect>
+<rect x="1114.26" y="436.37" width="12.06" height="10.27" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/config_test.go
+62 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1126.32" y="436.37" width="0.19" height="10.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/kafka/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1055.44" y="446.64" width="71.08" height="42.33" fill="#fdc089" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/tenant_resolver_test.go
+1506 loc · ccn 87 · commits (last 12mo) 11</title></rect>
+<rect x="1055.44" y="488.97" width="20.46" height="38.56" fill="#fdc68f" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/tenant_resolver.go
+395 loc · ccn 75 · commits (last 12mo) 11</title></rect>
+<rect x="1075.90" y="488.97" width="19.69" height="38.56" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/provisioning_page.go
+380 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1095.59" y="488.97" width="30.93" height="20.48" fill="#e7d3bc" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/inmemory_cache_test.go
+317 loc · ccn 45 · commits (last 12mo) 4</title></rect>
+<rect x="1095.59" y="509.45" width="15.02" height="18.09" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/inmemory_cache.go
+136 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1110.61" y="509.45" width="15.91" height="12.18" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/provisioning_page_test.go
+97 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1110.61" y="521.63" width="15.57" height="5.90" fill="#e1d8cf" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/mocks_test.go
+46 loc · ccn 7 · commits (last 12mo) 3</title></rect>
+<rect x="1126.18" y="521.63" width="0.34" height="5.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/gateway/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1126.52" y="362.82" width="27.52" height="34.41" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/shutdown_test.go
+474 loc · ccn 62 · commits (last 12mo) 3</title></rect>
+<rect x="1126.52" y="397.23" width="27.52" height="21.92" fill="#dccec4" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/retry_test.go
+302 loc · ccn 77 · commits (last 12mo) 2</title></rect>
+<rect x="1154.04" y="362.82" width="18.51" height="29.78" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/bootstrap_test.go
+276 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1154.04" y="392.60" width="18.51" height="26.55" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/grpc_test.go
+246 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="1172.55" y="362.82" width="20.93" height="17.75" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/lazy_test.go
+186 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="1193.48" y="362.82" width="17.11" height="17.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/SHUTDOWN_USAGE.md
+152 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1210.59" y="362.82" width="15.87" height="17.75" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/auth_test.go
+141 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1172.55" y="380.57" width="14.19" height="19.85" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/retry.go
+141 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="1172.55" y="400.42" width="14.19" height="18.73" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/bootstrap.go
+133 loc · ccn 22 · commits (last 12mo) 3</title></rect>
+<rect x="1186.74" y="380.57" width="15.85" height="13.74" fill="#e7d8c6" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/shutdown.go
+109 loc · ccn 22 · commits (last 12mo) 4</title></rect>
+<rect x="1186.74" y="394.31" width="15.85" height="12.86" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/observability_test.go
+102 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1186.74" y="407.17" width="15.85" height="11.98" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/grpc.go
+95 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="1202.58" y="380.57" width="12.13" height="15.31" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/lazy.go
+93 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1214.72" y="380.57" width="11.74" height="15.31" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/example_shutdown_test.go
+90 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1202.58" y="395.89" width="13.40" height="12.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/auth.go
+85 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1202.58" y="408.56" width="13.40" height="10.59" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/logger_test.go
+71 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1215.98" y="395.89" width="10.48" height="11.82" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/observability.go
+62 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1215.98" y="407.71" width="10.48" height="8.20" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/README.md
+43 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1215.98" y="415.91" width="9.86" height="3.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/logger.go
+16 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1225.84" y="415.91" width="0.62" height="3.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/bootstrap/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1126.52" y="419.15" width="22.79" height="50.49" fill="#fdd49e" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/schema_validation_test.go
+576 loc · ccn 49 · commits (last 12mo) 14</title></rect>
+<rect x="1149.31" y="419.15" width="24.86" height="15.51" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/integration_test.go
+193 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1174.17" y="419.15" width="24.48" height="15.51" fill="#fdd9a9" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/pgx.go
+190 loc · ccn 37 · commits (last 12mo) 8</title></rect>
+<rect x="1149.31" y="434.66" width="15.53" height="17.75" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/unit_test.go
+138 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1149.31" y="452.41" width="15.53" height="17.24" fill="#e7d8c6" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/cockroachdb.go
+134 loc · ccn 22 · commits (last 12mo) 4</title></rect>
+<rect x="1164.84" y="434.66" width="18.75" height="13.53" fill="#e1d4c4" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/postgres.go
+127 loc · ccn 38 · commits (last 12mo) 3</title></rect>
+<rect x="1183.59" y="434.66" width="15.06" height="13.53" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/setup.go
+102 loc · ccn 25 · commits (last 12mo) 3</title></rect>
+<rect x="1164.84" y="448.19" width="15.74" height="11.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/setup_test.go
+87 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1164.84" y="459.24" width="15.74" height="10.41" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/tenant.go
+82 loc · ccn 6 · commits (last 12mo) 3</title></rect>
+<rect x="1180.58" y="448.19" width="11.33" height="13.93" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/shared.go
+79 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1191.90" y="448.19" width="6.74" height="13.93" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/audit_tables.go
+47 loc · ccn 3 · commits (last 12mo) 3</title></rect>
+<rect x="1180.58" y="462.13" width="8.77" height="7.52" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/cockroachdb_migration_test.go
+33 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="1189.34" y="462.13" width="5.05" height="7.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/context_test.go
+19 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1194.39" y="462.13" width="4.25" height="7.05" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/context.go
+15 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1194.39" y="469.17" width="4.25" height="0.47" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/testdb/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1198.64" y="419.15" width="27.81" height="43.89" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>shared/platform/env/env_test.go
+611 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="1198.64" y="463.04" width="27.51" height="6.61" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/platform/env/env.go
+91 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1226.16" y="463.04" width="0.30" height="6.61" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/env/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1126.52" y="469.64" width="18.79" height="31.04" fill="#ecc9a9" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/tenant_test.go
+292 loc · ccn 78 · commits (last 12mo) 5</title></rect>
+<rect x="1145.31" y="469.64" width="21.24" height="12.51" fill="#e1d6ca" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/context_test.go
+133 loc · ccn 20 · commits (last 12mo) 3</title></rect>
+<rect x="1145.31" y="482.15" width="16.82" height="9.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/tenant_id_test.go
+79 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1145.31" y="491.54" width="16.82" height="9.15" fill="#f2dcbf" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/context.go
+77 loc · ccn 21 · commits (last 12mo) 6</title></rect>
+<rect x="1162.13" y="482.15" width="4.42" height="13.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/tenant_id.go
+29 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1162.13" y="495.26" width="4.42" height="2.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/errors.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1162.13" y="497.97" width="3.68" height="2.71" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/keys.go
+5 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1165.81" y="497.97" width="0.74" height="2.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/tenant/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1126.52" y="500.69" width="20.69" height="26.85" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>shared/platform/ratelimit/interceptor_test.go
+278 loc · ccn 29 · commits (last 12mo) 3</title></rect>
+<rect x="1147.20" y="500.69" width="19.35" height="26.75" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/platform/ratelimit/interceptor.go
+259 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1147.20" y="527.43" width="19.35" height="0.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/ratelimit/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1166.55" y="469.64" width="17.93" height="29.09" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>shared/platform/redislock/lock_test.go
+261 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="1184.47" y="469.64" width="16.96" height="26.38" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/platform/redislock/lock.go
+224 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1184.47" y="496.02" width="16.23" height="2.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/redislock/config.go
+22 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1200.70" y="496.02" width="0.74" height="2.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/redislock/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1166.55" y="498.73" width="19.08" height="28.80" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/defaults/env_test.go
+275 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1185.62" y="498.73" width="15.81" height="14.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/platform/defaults/timeouts_test.go
+115 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1185.62" y="513.26" width="11.90" height="14.27" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/defaults/env.go
+85 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1197.52" y="513.26" width="3.92" height="13.76" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/defaults/timeouts.go
+27 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1197.52" y="527.02" width="3.92" height="0.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/defaults/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1201.44" y="469.64" width="25.02" height="12.46" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/memory_monitor_test.go
+156 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="1201.44" y="482.10" width="9.59" height="20.20" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/memory_monitor.go
+97 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1211.03" y="482.10" width="8.12" height="9.84" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/harden_test.go
+40 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1219.15" y="482.10" width="7.31" height="9.84" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/config.go
+36 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1211.03" y="491.94" width="6.17" height="10.36" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/validate_test.go
+32 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1217.20" y="491.94" width="9.26" height="6.47" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/config_test.go
+30 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1217.20" y="498.42" width="6.17" height="3.88" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/validate.go
+12 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1223.37" y="498.42" width="3.09" height="3.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/harden.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1223.37" y="501.65" width="3.09" height="0.65" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/sandbox/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1201.44" y="502.30" width="15.86" height="19.40" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/platform/await/await_test.go
+154 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1217.29" y="502.30" width="9.16" height="19.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/platform/await/await.go
+88 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1217.29" y="521.49" width="9.16" height="0.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/await/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1201.44" y="521.70" width="16.79" height="5.83" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>shared/platform/ports/ports_test.go
+49 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1218.23" y="521.70" width="7.88" height="5.83" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>shared/platform/ports/ports.go
+23 loc · ccn 1 · commits (last 12mo) 11</title></rect>
+<rect x="1226.11" y="521.70" width="0.34" height="5.83" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/platform/ports/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1226.46" y="283.47" width="51.29" height="31.08" fill="#d6cac8" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_test.go
+798 loc · ccn 129 · commits (last 12mo) 1</title></rect>
+<rect x="1226.46" y="314.55" width="25.67" height="38.21" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_boundary_test.go
+491 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="1252.13" y="314.55" width="25.62" height="38.21" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_arithmetic_rounding_test.go
+490 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="1226.46" y="352.76" width="25.73" height="36.73" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_proto_test.go
+473 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="1252.18" y="352.76" width="25.56" height="36.73" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/domain/money/PRECISION_GUARANTEES.md
+470 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1226.46" y="389.49" width="21.55" height="40.98" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_db_precision_test.go
+442 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1248.01" y="389.49" width="29.74" height="21.03" fill="#d6cfcc" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_performance_comparison_bench_test.go
+313 loc · ccn 85 · commits (last 12mo) 1</title></rect>
+<rect x="1248.01" y="410.52" width="18.53" height="19.95" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>shared/domain/money/money.go
+185 loc · ccn 42 · commits (last 12mo) 3</title></rect>
+<rect x="1266.53" y="410.52" width="11.22" height="19.95" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>shared/domain/money/money_bench_test.go
+112 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1226.46" y="430.47" width="28.27" height="44.87" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>shared/domain/models/financial_position_log_audit_test.go
+635 loc · ccn 45 · commits (last 12mo) 2</title></rect>
+<rect x="1254.73" y="430.47" width="23.02" height="44.87" fill="#e7d3bc" stroke="white" stroke-width="0.5"><title>shared/domain/models/audit_test.go
+517 loc · ccn 44 · commits (last 12mo) 4</title></rect>
+<rect x="1226.46" y="475.34" width="23.35" height="14.37" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>shared/domain/models/account_test.go
+168 loc · ccn 33 · commits (last 12mo) 3</title></rect>
+<rect x="1226.46" y="489.71" width="23.35" height="13.52" fill="#ecd7bc" stroke="white" stroke-width="0.5"><title>shared/domain/models/financial_position_log.go
+158 loc · ccn 32 · commits (last 12mo) 5</title></rect>
+<rect x="1249.81" y="475.34" width="15.90" height="16.83" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>shared/domain/models/customer_test.go
+134 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="1249.81" y="492.17" width="15.90" height="11.06" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>shared/domain/models/base_test.go
+88 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1265.71" y="475.34" width="12.03" height="7.47" fill="#edddc9" stroke="white" stroke-width="0.5"><title>shared/domain/models/account.go
+45 loc · ccn 8 · commits (last 12mo) 5</title></rect>
+<rect x="1265.71" y="482.81" width="12.03" height="7.30" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>shared/domain/models/base.go
+44 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="1265.71" y="490.11" width="12.03" height="6.64" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>shared/domain/models/audit.go
+40 loc · ccn 2 · commits (last 12mo) 4</title></rect>
+<rect x="1265.71" y="496.75" width="12.03" height="6.47" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>shared/domain/models/customer.go
+39 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="1226.46" y="503.23" width="23.42" height="19.79" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>shared/domain/primitives/identifiers_test.go
+232 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1249.88" y="503.23" width="15.45" height="19.79" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>shared/domain/primitives/identifiers_integration_test.go
+153 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1265.33" y="503.23" width="12.42" height="19.79" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>shared/domain/primitives/identifiers.go
+123 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="1226.46" y="523.02" width="30.51" height="4.52" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>shared/README.md
+69 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1256.97" y="523.02" width="20.78" height="4.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>shared/atlas/atlas.hcl
+47 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1277.75" y="0.00" width="70.79" height="88.72" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/001-universal-asset-system.md
+3144 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1277.75" y="88.72" width="70.79" height="66.63" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/011-valuation-service.md
+2361 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1277.75" y="155.35" width="70.79" height="58.58" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/026-operations-console-ui.md
+2076 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1277.75" y="213.93" width="70.79" height="48.09" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/006-starlark-saga-orchestration-core.md
+1704 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1348.54" y="0.00" width="55.65" height="53.02" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/prd/029-operational-gateway.md
+1477 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1404.19" y="0.00" width="55.16" height="53.02" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/004-market-information-management.md
+1464 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1459.35" y="0.00" width="50.79" height="53.02" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/039-meridian-vm.md
+1348 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1510.14" y="0.00" width="47.70" height="53.02" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/005-durable-execution-engine.md
+1266 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1557.84" y="0.00" width="42.16" height="53.02" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/008-starlark-service-bindings.md
+1119 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1348.54" y="53.02" width="50.02" height="43.89" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/013-reconciliation-service.md
+1099 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1348.54" y="96.92" width="50.02" height="42.85" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/prd/023-product-directory.md
+1073 loc · ccn 0 · commits (last 12mo) 16</title></rect>
+<rect x="1348.54" y="139.77" width="50.02" height="41.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/015-stripe-connect.md
+1050 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1348.54" y="181.70" width="50.02" height="40.34" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/014-control-plane.md
+1010 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1348.54" y="222.04" width="50.02" height="39.98" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/027-mcp-server.md
+1001 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1398.56" y="53.02" width="43.14" height="40.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/032-event-driven-valuation-saga.md
+875 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1441.70" y="53.02" width="41.76" height="40.52" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/prd/024-structured-inbound-mapping.md
+847 loc · ccn 0 · commits (last 12mo) 12</title></rect>
+<rect x="1483.46" y="53.02" width="39.83" height="40.52" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/002-internal-bank-account.md
+808 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1523.29" y="53.02" width="39.00" height="40.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/007-starlark-typed-service-clients.md
+791 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1562.29" y="53.02" width="37.71" height="40.52" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/009-production-readiness-review.md
+765 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1398.56" y="93.55" width="34.14" height="44.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/045-manifest-as-sole-source-of-truth.md
+752 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1398.56" y="137.55" width="34.14" height="43.71" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/025-real-time-event-streaming.md
+747 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1398.56" y="181.26" width="34.14" height="41.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/016-market-data-dynamic-pricing.md
+715 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1398.56" y="223.10" width="34.14" height="38.91" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/030-asyncapi-specification.md
+665 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1432.70" y="93.55" width="36.37" height="35.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/035-economy-cookbook.md
+642 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1469.07" y="93.55" width="33.99" height="35.26" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/034-frontend-service-alignment.md
+600 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1503.07" y="93.55" width="33.65" height="35.26" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>docs/prd/036-cookbook-browser.md
+594 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1536.72" y="93.55" width="31.73" height="35.26" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/031-identity-access-management.md
+560 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1568.44" y="93.55" width="31.56" height="35.26" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/prd/022-org-scoped-accounts.md
+557 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="1432.70" y="128.81" width="30.95" height="34.85" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/052-email-platform.md
+540 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1432.70" y="163.66" width="30.95" height="33.17" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/042-economy-ide.md
+514 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1432.70" y="196.83" width="30.95" height="32.72" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/038-manifest-business-model-visualization.md
+507 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1432.70" y="229.56" width="30.95" height="32.46" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/prd/049-codebase-consistency.md
+503 loc · ccn 0 · commits (last 12mo) 11</title></rect>
+<rect x="1463.66" y="128.81" width="31.57" height="27.59" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/010-starlark-testing-framework.md
+436 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1463.66" y="156.40" width="31.57" height="27.53" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/041-economy-generator.md
+435 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1463.66" y="183.93" width="31.57" height="27.08" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/017-reconciliation-grpc-wiring.md
+428 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1463.66" y="211.01" width="31.57" height="25.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/021-platform-scheduler.md
+408 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1463.66" y="236.83" width="31.57" height="25.19" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/046-economy-visualization-completeness.md
+398 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1495.23" y="128.81" width="28.18" height="28.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/040-handler-schema-alignment.md
+398 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1523.40" y="128.81" width="26.90" height="28.22" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/056-correspondence-service.md
+380 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1550.30" y="128.81" width="25.70" height="28.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/044-auth-flow-architecture.md
+363 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1576.00" y="128.81" width="24.00" height="28.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/043-mcp-manifest-tenant-isolation.md
+339 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1495.23" y="157.03" width="26.89" height="24.45" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/012-codebase-health-audit.md
+329 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1522.12" y="157.03" width="26.15" height="24.45" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/003-meridian-edge.md
+320 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1548.27" y="157.03" width="26.07" height="24.45" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/033-gateway-architecture.md
+319 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1574.34" y="157.03" width="25.66" height="24.45" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/prd/README.md
+314 loc · ccn 0 · commits (last 12mo) 32</title></rect>
+<rect x="1495.23" y="181.48" width="22.08" height="27.78" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/020-party-kyc-aml-provider-integration.md
+307 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1495.23" y="209.26" width="22.08" height="26.43" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/060-per-tenant-scheduled-execution.md
+292 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1495.23" y="235.68" width="22.08" height="26.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/057-convergent-manifest-apply.md
+291 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1517.30" y="181.48" width="21.06" height="27.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/047-security-audit.md
+289 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1517.30" y="208.89" width="21.06" height="26.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/051-party-navigation.md
+280 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1517.30" y="235.46" width="21.06" height="26.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/058-full-economy-visibility.md
+280 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1538.36" y="181.48" width="20.80" height="26.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/061-mcp-auth-session-unification.md
+278 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1559.16" y="181.48" width="20.42" height="26.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/059-asset-agnostic-posting-layer.md
+273 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1579.58" y="181.48" width="20.42" height="26.71" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/062-self-service-onboarding-readiness.md
+273 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1538.36" y="208.18" width="22.23" height="20.40" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/028-asset-agnostic-accounts.md
+227 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1538.36" y="228.58" width="22.23" height="17.08" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/018-current-account-withdrawal-persistence.md
+190 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1538.36" y="245.66" width="22.23" height="16.36" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/019-internal-bank-account-position-keeping-client.md
+182 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1560.59" y="208.18" width="19.82" height="18.05" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/053-auth-email-flows.md
+179 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1580.41" y="208.18" width="19.59" height="18.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/037-multi-asset-purity.md
+177 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1560.59" y="226.23" width="17.36" height="18.87" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/054-billing-ui.md
+164 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1560.59" y="245.10" width="17.36" height="16.92" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/prd/050-demo-sandbox.md
+147 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1577.95" y="226.23" width="22.05" height="12.96" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/prd/047-security-audit-status.md
+143 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1577.95" y="239.19" width="22.05" height="11.78" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/prd/055-tenant-branding.md
+130 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1577.95" y="250.96" width="22.05" height="11.05" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/prd/048-test-coverage-80.md
+122 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1277.75" y="262.02" width="46.64" height="42.15" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/adr/0017-temporal-quality-ladder.md
+984 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1324.39" y="262.02" width="38.25" height="42.15" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/adr/0018-settlement-reconciliation.md
+807 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1362.64" y="262.02" width="36.50" height="42.15" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>docs/adr/0004-event-schema-evolution.md
+770 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1399.14" y="262.02" width="35.26" height="42.15" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/adr/0028-starlark-saga-cel-valuation.md
+744 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1277.75" y="304.17" width="41.58" height="35.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0021-kyc-aml-verification-provider-architecture.md
+734 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1277.75" y="339.43" width="41.58" height="30.89" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/adr/0014-financial-instrument-reference-data.md
+643 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1277.75" y="370.33" width="41.58" height="30.37" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/adr/0013-generic-asset-quantity-types.md
+632 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1277.75" y="400.70" width="41.58" height="29.60" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/adr/0009-application-level-audit-logging.md
+616 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1319.33" y="304.17" width="41.63" height="28.89" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/adr/0005-adapter-pattern-layer-translation.md
+602 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1360.96" y="304.17" width="37.83" height="28.89" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/adr/0006-tilt-local-development.md
+547 loc · ccn 0 · commits (last 12mo) 15</title></rect>
+<rect x="1398.79" y="304.17" width="35.61" height="28.89" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/adr/0002-microservices-per-bian-domain.md
+515 loc · ccn 0 · commits (last 12mo) 11</title></rect>
+<rect x="1319.33" y="333.06" width="29.79" height="27.43" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/adr/0003-database-schema-migrations.md
+409 loc · ccn 0 · commits (last 12mo) 13</title></rect>
+<rect x="1319.33" y="360.48" width="29.79" height="25.75" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0022-instrument-successor-lineage.md
+384 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1319.33" y="386.23" width="29.79" height="22.47" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0008-defensive-testing-standards.md
+335 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1319.33" y="408.70" width="29.79" height="21.59" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0012-lien-based-fund-reservation.md
+322 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1349.12" y="333.06" width="23.45" height="26.33" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0027-market-information-management.md
+309 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1372.56" y="333.06" width="20.94" height="26.33" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0011-iso-20022-compliance-via-adapter-layer.md
+276 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1393.50" y="333.06" width="20.49" height="26.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0019-resilient-client-patterns.md
+270 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1413.99" y="333.06" width="20.41" height="26.33" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0033-event-triggered-sagas.md
+269 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1349.12" y="359.39" width="20.29" height="24.03" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0015-standard-service-directory-structure.md
+244 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1349.12" y="383.42" width="20.29" height="24.03" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0024-internal-bank-account-service.md
+244 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1349.12" y="407.44" width="20.29" height="22.85" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0010-grpc-client-side-load-balancing.md
+232 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1369.40" y="359.39" width="22.22" height="19.15" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0026-canonical-ingestion-contract.md
+213 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1391.62" y="359.39" width="22.12" height="19.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0016-tenant-id-naming-strategy.md
+212 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1413.74" y="359.39" width="20.66" height="19.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0037-scheduler-attribution-design.md
+198 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1369.40" y="378.53" width="19.22" height="18.08" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/adr/0020-per-service-audit-workers.md
+174 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1369.40" y="396.62" width="19.22" height="16.84" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/adr/README.md
+162 loc · ccn 0 · commits (last 12mo) 23</title></rect>
+<rect x="1369.40" y="413.46" width="19.22" height="16.84" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/adr/0032-vanguard-json-transcoding-gateway.md
+162 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1388.62" y="378.53" width="15.84" height="19.42" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/adr/0007-raw-yaml-over-helm-for-initial-development.md
+154 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1404.47" y="378.53" width="15.74" height="19.42" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/adr/0025-clearing-purpose-specialization.md
+153 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1420.20" y="378.53" width="14.20" height="19.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0023-balance-delegation-to-position-keeping.md
+138 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1388.62" y="397.95" width="16.31" height="16.41" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0036-embedded-dex-identity.md
+134 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1388.62" y="414.37" width="16.31" height="15.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0034-position-compaction-strategy.md
+130 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1404.93" y="397.95" width="15.32" height="15.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0030-kyc-aml-provider-selection.md
+118 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1420.25" y="397.95" width="14.15" height="15.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0035-multi-asset-purity.md
+109 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1404.93" y="413.34" width="11.20" height="16.95" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/adr/0029-settlement-scheduler-architecture.md
+95 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1416.13" y="413.34" width="14.03" height="8.69" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0031-getbalance-nil-guard-retention.md
+61 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1416.13" y="422.03" width="14.03" height="8.26" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/template.md
+58 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1430.16" y="413.34" width="4.24" height="16.95" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/adr/0001-record-architecture-decisions.md
+36 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1277.75" y="430.29" width="59.39" height="41.34" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/architecture/api-contracts/position-keeping-contract.md
+1229 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1277.75" y="471.63" width="35.49" height="55.90" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/architecture/api-contracts/financial-accounting-contract.md
+993 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1313.23" y="471.63" width="23.91" height="55.90" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>docs/architecture/api-contracts/current-account-contract.md
+669 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1337.14" y="430.29" width="53.58" height="56.52" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>docs/architecture/bian-service-boundaries.md
+1516 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1337.14" y="486.82" width="53.58" height="40.72" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/architecture/event-driven-architecture.md
+1092 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1390.72" y="430.29" width="43.68" height="43.09" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/architecture/data-model.md
+942 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1390.72" y="473.38" width="43.68" height="24.56" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/architecture/starlark-saga-architecture.md
+537 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1390.72" y="497.94" width="35.31" height="29.59" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/architecture/service-coupling-analysis.md
+523 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1426.03" y="497.94" width="8.37" height="22.67" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/architecture/boundary-migration-plan.md
+95 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1426.03" y="520.61" width="8.37" height="6.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/architecture/coupling-metrics.json
+29 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1434.40" y="262.02" width="51.31" height="52.64" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/guides/new-bian-service-checklist.md
+1352 loc · ccn 0 · commits (last 12mo) 20</title></rect>
+<rect x="1434.40" y="314.66" width="51.31" height="28.42" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/guides/starlark-style-guide.md
+730 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1485.71" y="262.02" width="38.42" height="29.53" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/multi-asset-integration.md
+568 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1485.71" y="291.55" width="38.42" height="26.98" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/adding-starlark-service-bindings.md
+519 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1485.71" y="318.54" width="38.42" height="24.54" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/guides/manifest-design-patterns.md
+472 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1524.14" y="262.02" width="29.43" height="30.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/ai-native-codebase-architecture.md
+445 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1553.57" y="262.02" width="27.91" height="30.21" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/guides/starlark-built-ins-reference.md
+422 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1581.48" y="262.02" width="18.52" height="30.21" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/guides/repository-conventions.md
+280 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1524.14" y="292.22" width="17.64" height="26.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/value-types.md
+237 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1524.14" y="319.07" width="17.64" height="24.01" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/guides/testcontainers-usage.md
+212 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1541.78" y="292.22" width="23.69" height="17.88" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/saga-validation.md
+212 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1541.78" y="310.10" width="23.69" height="16.78" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/guides/financial-accounting-proto.md
+199 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1541.78" y="326.88" width="23.69" height="16.19" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/error-conventions.md
+192 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1565.47" y="292.22" width="17.74" height="21.29" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/guides/calling-meridian-apis.md
+189 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1583.20" y="292.22" width="16.80" height="21.29" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/guides/circuit-breaker-usage.md
+179 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1565.47" y="313.51" width="17.50" height="15.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/coupling-analysis.md
+136 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1565.47" y="329.04" width="17.50" height="14.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/service-file-conventions.md
+123 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1582.97" y="313.51" width="17.03" height="13.73" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/cli-tools.md
+117 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1582.97" y="327.24" width="11.23" height="15.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/guides/proto-conventions.md
+89 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1594.20" y="327.24" width="5.80" height="15.84" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/guides/README.md
+46 loc · ccn 0 · commits (last 12mo) 10</title></rect>
+<rect x="1434.40" y="343.08" width="31.33" height="39.02" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/runbooks/internal-account-operations.md
+612 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1434.40" y="382.10" width="31.33" height="38.51" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/runbooks/production-deployment.md
+604 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1465.73" y="343.08" width="32.07" height="34.32" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/runbooks/troubleshooting-saga-handlers.md
+551 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1497.81" y="343.08" width="22.06" height="34.32" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/runbooks/market-information-operations.md
+379 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1519.87" y="343.08" width="20.90" height="34.32" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>docs/runbooks/disaster-recovery.md
+359 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1465.73" y="377.40" width="31.90" height="21.67" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/runbooks/event-router.md
+346 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1465.73" y="399.07" width="31.90" height="21.54" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/runbooks/saga-failure-recovery.md
+344 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1497.63" y="377.40" width="23.85" height="24.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/runbooks/party-kyc-verification.md
+292 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1521.48" y="377.40" width="19.28" height="24.46" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>docs/runbooks/incident-response.md
+236 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1497.63" y="401.85" width="19.28" height="18.76" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/runbooks/saga-validation-failure.md
+181 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1516.91" y="401.85" width="12.78" height="18.76" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/runbooks/README.md
+120 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="1529.69" y="401.85" width="11.08" height="18.76" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/runbooks/email-infrastructure.md
+104 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1540.76" y="343.08" width="33.80" height="27.96" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/archive/authentication-integration.md
+473 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1574.56" y="343.08" width="25.44" height="27.96" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/archive/panic-audit-inventory.md
+356 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1540.76" y="371.03" width="22.69" height="25.98" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/archive/database-per-service-migration.md
+295 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1540.76" y="397.01" width="22.69" height="23.60" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/archive/immutability-audit.md
+268 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1563.45" y="371.03" width="19.96" height="25.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/archive/ARCHITECTURE.md
+254 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1583.42" y="371.03" width="16.58" height="25.42" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/archive/audit-analysis-findings.md
+211 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1563.45" y="396.45" width="14.47" height="24.16" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/archive/rbac-testing-guide.md
+175 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1577.92" y="396.45" width="22.08" height="12.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/archive/DEMO_GUIDE.md
+138 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1577.92" y="408.94" width="16.94" height="11.67" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/archive/task-8-service-integration.md
+99 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1594.87" y="408.94" width="5.13" height="11.67" fill="#eddfce" stroke="white" stroke-width="0.5"><title>docs/archive/README.md
+30 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1434.40" y="420.61" width="42.13" height="27.74" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/reports/saga-handler-audit.md
+585 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1434.40" y="448.35" width="22.50" height="36.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/reports/market-information-integration.md
+416 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1456.90" y="448.35" width="19.63" height="36.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/reports/cockroachdb-migration-audit.md
+363 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1434.40" y="485.29" width="21.72" height="15.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/reports/market-information-go-live-readiness.md
+166 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1456.12" y="485.29" width="20.41" height="15.27" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/reports/market-information-traceability.md
+156 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1434.40" y="500.55" width="42.13" height="26.98" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/spec/saga-contract.md
+569 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1476.53" y="420.61" width="30.14" height="37.59" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/saga-handlers.schema.json
+567 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1476.53" y="458.20" width="30.14" height="18.63" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/testing/CHAOS_TESTING.md
+281 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1476.53" y="476.82" width="30.14" height="17.63" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/testing/COVERAGE_ANALYSIS.md
+266 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1476.53" y="494.46" width="30.14" height="33.08" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/saga-service-catalog.md
+499 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1506.67" y="420.61" width="33.47" height="25.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/architecture-layers.md
+435 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1540.14" y="420.61" width="30.31" height="25.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/development/audit-adding-new-service.md
+394 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1570.45" y="420.61" width="29.55" height="25.97" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/data-flows.md
+384 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1506.67" y="446.58" width="23.02" height="11.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/mapping-layer/examples.md
+136 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1506.67" y="458.38" width="13.63" height="17.01" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/mapping-layer/README.md
+116 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1520.30" y="458.38" width="9.40" height="17.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/mapping-layer/troubleshooting.md
+80 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1506.67" y="475.38" width="23.02" height="27.59" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/patterns.md
+318 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1506.67" y="502.98" width="23.02" height="24.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/audits/tenant-isolation-audit-2026-04-04.md
+283 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1529.70" y="446.58" width="24.36" height="22.22" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/secrets-management.md
+271 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1554.06" y="446.58" width="23.46" height="22.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/services/party/verification-guide.md
+261 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1577.52" y="446.58" width="22.48" height="22.22" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/api/saga-validation.md
+250 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1529.70" y="468.80" width="23.98" height="19.75" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/operations/audit-monitoring.md
+237 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1529.70" y="488.54" width="23.98" height="19.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/integrations/kyc-aml-providers.md
+234 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1529.70" y="508.04" width="16.29" height="19.50" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/audit/frontend-backend-gaps.md
+159 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1545.99" y="508.04" width="7.69" height="19.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/audit/multi-asset-purity.md
+75 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1553.67" y="468.80" width="25.23" height="17.90" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/demos/multi-organization-settlement.md
+226 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1578.90" y="468.80" width="21.10" height="17.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/analysis/cmd-coverage-assessment.md
+189 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1553.67" y="486.69" width="16.97" height="20.95" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/service-readme-template.md
+178 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1553.67" y="507.64" width="16.97" height="19.89" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/local-documentation.md
+169 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1570.65" y="486.69" width="15.96" height="20.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/saga-handler-loading.md
+161 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1586.61" y="486.69" width="13.39" height="20.15" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>docs/tilt-fast-startup.md
+135 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1570.65" y="506.84" width="16.99" height="10.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/security/pgx-tenant-audit.md
+93 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1570.65" y="517.78" width="16.99" height="9.76" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>docs/coupling-visualization-example.md
+83 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1587.64" y="506.84" width="12.36" height="10.51" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>docs/README.md
+65 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1587.64" y="517.35" width="12.36" height="10.18" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>docs/claude-code-skills.md
+63 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="873.63" y="527.53" width="24.99" height="47.82" fill="#d6c9c6" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/manifest-graph.test.tsx
+598 loc · ccn 141 · commits (last 12mo) 1</title></rect>
+<rect x="898.61" y="527.53" width="26.44" height="19.50" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/node-renderers.tsx
+258 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="925.05" y="527.53" width="18.85" height="19.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/graph-panels.tsx
+184 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="898.61" y="547.03" width="17.85" height="15.33" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/index.tsx
+137 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="898.61" y="562.37" width="17.85" height="12.98" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/graph-layout.ts
+116 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="916.46" y="547.03" width="17.11" height="12.38" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/use-manifest-graph-controller.ts
+106 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="933.57" y="547.03" width="10.33" height="12.38" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/use-visible-types.ts
+64 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="916.46" y="559.41" width="14.54" height="8.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/graph-layout.test.ts
+59 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="916.46" y="567.52" width="14.54" height="7.83" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/use-graph-highlight.ts
+57 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="931.00" y="559.41" width="12.91" height="7.58" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/node-navigation.test.ts
+49 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="931.00" y="566.99" width="6.93" height="8.36" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/use-graph-layout-effect.ts
+29 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="937.93" y="566.99" width="5.98" height="8.36" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-graph/node-navigation.ts
+25 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="575.35" width="36.73" height="32.04" fill="#e7d5bf" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-diff-graph.tsx
+589 loc · ccn 37 · commits (last 12mo) 4</title></rect>
+<rect x="910.35" y="575.35" width="33.55" height="32.04" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+538 loc · ccn 65 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="607.39" width="26.83" height="39.09" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/rollback-confirmation-dialog.test.tsx
+525 loc · ccn 56 · commits (last 12mo) 1</title></rect>
+<rect x="900.46" y="607.39" width="21.57" height="20.10" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/event-chain-panel.tsx
+217 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="900.46" y="627.49" width="21.57" height="18.99" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-diff-table.tsx
+205 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="922.03" y="607.39" width="21.87" height="15.07" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/event-chain-panel.test.tsx
+165 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="922.03" y="622.46" width="21.87" height="12.51" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/rollback-confirmation-dialog.tsx
+137 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="922.03" y="634.97" width="21.87" height="11.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/components/manifest-diff-table.test.tsx
+126 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="943.90" y="527.53" width="40.59" height="43.41" fill="#e6bca4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+882 loc · ccn 117 · commits (last 12mo) 4</title></rect>
+<rect x="984.49" y="527.53" width="20.99" height="43.41" fill="#f2c39b" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/manifest-graph-model.ts
+456 loc · ccn 89 · commits (last 12mo) 6</title></rect>
+<rect x="943.90" y="570.94" width="24.82" height="22.38" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/transitive-closure.test.ts
+278 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="943.90" y="593.32" width="24.82" height="18.27" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
+227 loc · ccn 39 · commits (last 12mo) 2</title></rect>
+<rect x="968.72" y="570.94" width="18.77" height="18.10" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/cel-filter-analyzer.ts
+170 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="987.48" y="570.94" width="17.99" height="18.10" fill="#e7d9c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/node-type-registry.test.ts
+163 loc · ccn 19 · commits (last 12mo) 4</title></rect>
+<rect x="968.72" y="589.04" width="13.46" height="22.55" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/transitive-closure.ts
+152 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="982.18" y="589.04" width="19.40" height="12.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/manifest-diff.test.ts
+123 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="982.18" y="601.71" width="19.40" height="9.89" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/node-type-registry.ts
+96 loc · ccn 6 · commits (last 12mo) 4</title></rect>
+<rect x="1001.58" y="589.04" width="3.90" height="22.55" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/lib/manifest-diff.ts
+44 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="943.90" y="611.60" width="28.98" height="20.26" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/pages/manifest-history-table.test.tsx
+294 loc · ccn 52 · commits (last 12mo) 3</title></rect>
+<rect x="943.90" y="631.86" width="28.98" height="14.61" fill="#f2d2ab" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/pages/manifest-history-table.tsx
+212 loc · ccn 52 · commits (last 12mo) 6</title></rect>
+<rect x="972.89" y="611.60" width="16.50" height="14.53" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/pages/manifest-diff-page.test.tsx
+120 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="972.89" y="626.13" width="16.50" height="11.26" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/pages/manifest-history-columns.tsx
+93 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="972.89" y="637.39" width="16.50" height="9.08" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/pages/manifest-diff-page.tsx
+75 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="989.38" y="611.60" width="16.10" height="9.68" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-manifest-graph.test.ts
+78 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="989.38" y="621.28" width="16.10" height="8.56" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-manifest-diff.test.ts
+69 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="989.38" y="629.84" width="10.86" height="9.93" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-event-chain.test.ts
+54 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1000.25" y="629.84" width="5.23" height="9.93" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-rollback-manifest.ts
+26 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="989.38" y="639.77" width="6.86" height="6.70" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-manifest-diff.ts
+23 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="996.24" y="639.77" width="6.56" height="6.70" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-manifest-graph.ts
+22 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1002.79" y="639.77" width="2.68" height="6.70" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/manifests/hooks/use-event-chain.ts
+9 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1005.48" y="527.53" width="37.63" height="23.57" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx
+444 loc · ccn 54 · commits (last 12mo) 3</title></rect>
+<rect x="1005.48" y="551.10" width="20.55" height="21.78" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/apply-resource-modal.test.tsx
+224 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1005.48" y="572.88" width="20.55" height="12.83" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/validation-panel.test.tsx
+132 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1026.03" y="551.10" width="17.09" height="11.11" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/conflict-resolution-modal.test.tsx
+95 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1026.03" y="562.21" width="17.09" height="9.94" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/apply-phases-stepper.test.tsx
+85 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1026.03" y="572.15" width="10.90" height="13.56" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/manifest-editor.test.tsx
+74 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1036.93" y="572.15" width="6.19" height="13.56" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/__tests__/path-to-line.test.ts
+42 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1043.11" y="527.53" width="21.63" height="39.06" fill="#f2d0a9" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/deploy-wizard.tsx
+423 loc · ccn 57 · commits (last 12mo) 6</title></rect>
+<rect x="1043.11" y="566.60" width="21.63" height="19.12" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/apply-resource-modal.tsx
+207 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1064.74" y="527.53" width="20.03" height="19.55" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/resources-panel.tsx
+196 loc · ccn 72 · commits (last 12mo) 1</title></rect>
+<rect x="1084.77" y="527.53" width="14.20" height="19.55" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/manifest-diff.tsx
+139 loc · ccn 20 · commits (last 12mo) 2</title></rect>
+<rect x="1098.98" y="527.53" width="12.57" height="19.55" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/manifest-diff.test.tsx
+123 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1064.74" y="547.08" width="16.55" height="14.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/gateway-panel.tsx
+120 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1064.74" y="561.57" width="16.55" height="13.28" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/config-panel.tsx
+110 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1064.74" y="574.85" width="16.55" height="10.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/conflict-resolution-modal.tsx
+90 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1081.29" y="547.08" width="15.94" height="11.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/validation-panel.tsx
+88 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1097.23" y="547.08" width="14.31" height="11.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/resource-form.tsx
+79 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1081.29" y="558.11" width="11.07" height="13.89" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/editor-graph-panel.test.tsx
+77 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1081.29" y="572.00" width="11.07" height="13.71" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/manifest-editor.tsx
+76 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1092.37" y="558.11" width="9.92" height="15.31" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/deploy-wizard.test.tsx
+76 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1102.28" y="558.11" width="9.26" height="15.31" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/apply-phases-stepper.tsx
+71 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1092.37" y="573.42" width="7.48" height="12.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/path-to-line.ts
+46 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1099.84" y="573.42" width="11.70" height="7.00" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/editor-graph-panel.tsx
+41 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1099.84" y="580.42" width="11.70" height="5.29" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/components/drift-warning-banner.tsx
+31 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1005.48" y="585.71" width="22.23" height="32.54" fill="#eccbab" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-explore-page.test.tsx
+362 loc · ccn 72 · commits (last 12mo) 5</title></rect>
+<rect x="1005.48" y="618.25" width="22.23" height="28.22" fill="#f2d0a8" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-overview-page.test.tsx
+314 loc · ccn 58 · commits (last 12mo) 6</title></rect>
+<rect x="1027.70" y="585.71" width="21.23" height="21.55" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-edit-page.test.tsx
+229 loc · ccn 40 · commits (last 12mo) 2</title></rect>
+<rect x="1048.93" y="585.71" width="19.28" height="21.55" fill="#f7d6ab" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-explore-page.tsx
+208 loc · ccn 41 · commits (last 12mo) 7</title></rect>
+<rect x="1027.70" y="607.27" width="18.50" height="20.74" fill="#f2d5b1" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-edit-page.tsx
+192 loc · ccn 42 · commits (last 12mo) 6</title></rect>
+<rect x="1027.70" y="628.01" width="18.50" height="18.47" fill="#fdd6a4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-overview-page.tsx
+171 loc · ccn 43 · commits (last 12mo) 9</title></rect>
+<rect x="1046.20" y="607.27" width="22.01" height="15.43" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-draft-page.test.tsx
+170 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1046.20" y="622.70" width="12.74" height="17.24" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-create-page.tsx
+110 loc · ccn 5 · commits (last 12mo) 4</title></rect>
+<rect x="1058.94" y="622.70" width="9.27" height="17.24" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-draft-page.tsx
+80 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1046.20" y="639.94" width="22.01" height="6.53" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/pages/economy-create-page.test.tsx
+72 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1068.21" y="585.71" width="21.12" height="18.82" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/handler-autocomplete.test.ts
+199 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="1068.21" y="604.54" width="21.12" height="17.69" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/resource-schema-registry.ts
+187 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1089.33" y="585.71" width="22.21" height="13.40" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/resource-schema-registry.test.ts
+149 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1089.33" y="599.11" width="22.21" height="11.96" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/draft-manager.test.ts
+133 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1089.33" y="611.07" width="9.67" height="11.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/draft-manager.ts
+54 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1099.01" y="611.07" width="7.88" height="11.15" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/handler-autocomplete.ts
+44 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1106.89" y="611.07" width="4.66" height="9.44" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/__tests__/version-conflict.test.ts
+22 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1106.89" y="620.51" width="4.66" height="1.72" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/lib/version-conflict.ts
+4 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1068.21" y="622.23" width="16.07" height="24.25" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/hooks/use-manifest-validate.test.ts
+195 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="1084.28" y="622.23" width="17.96" height="12.24" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/hooks/use-manifest-validate.ts
+110 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1084.28" y="634.46" width="17.96" height="12.01" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/hooks/use-manifest-plan.test.tsx
+108 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1102.24" y="622.23" width="7.83" height="14.29" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/hooks/use-manifest-plan.ts
+56 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1102.24" y="636.52" width="7.83" height="9.95" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/hooks/use-reconcile-manifest.ts
+39 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1110.06" y="622.23" width="1.48" height="24.25" fill="#f2e2cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/economy/index.ts
+18 loc · ccn 1 · commits (last 12mo) 6</title></rect>
+<rect x="1111.55" y="527.53" width="26.91" height="34.30" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/account-types/create-account-type-dialog.tsx
+462 loc · ccn 71 · commits (last 12mo) 2</title></rect>
+<rect x="1138.45" y="527.53" width="20.09" height="34.30" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/account-types/create-account-type-dialog.test.tsx
+345 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1111.55" y="561.83" width="26.10" height="21.51" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/account-types/index.test.tsx
+281 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="1137.65" y="561.83" width="20.90" height="21.51" fill="#f2d8b6" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/account-types/index.tsx
+225 loc · ccn 34 · commits (last 12mo) 6</title></rect>
+<rect x="1158.55" y="527.53" width="24.74" height="31.00" fill="#e7d4bd" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/instruments/index.test.tsx
+384 loc · ccn 41 · commits (last 12mo) 4</title></rect>
+<rect x="1183.29" y="527.53" width="19.07" height="31.00" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/instruments/register-instrument-dialog.tsx
+296 loc · ccn 56 · commits (last 12mo) 2</title></rect>
+<rect x="1158.55" y="558.54" width="23.12" height="24.80" fill="#f7d9b1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/instruments/index.tsx
+287 loc · ccn 34 · commits (last 12mo) 7</title></rect>
+<rect x="1181.66" y="558.54" width="20.70" height="24.80" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/instruments/register-instrument-dialog.test.tsx
+257 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1111.55" y="583.34" width="19.11" height="35.44" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/create-node-dialog.test.tsx
+339 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1130.66" y="583.34" width="26.95" height="19.35" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/create-node-dialog.tsx
+261 loc · ccn 38 · commits (last 12mo) 1</title></rect>
+<rect x="1130.66" y="602.69" width="26.95" height="16.09" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/index.test.tsx
+217 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="1157.60" y="583.34" width="20.97" height="16.58" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/index.tsx
+174 loc · ccn 25 · commits (last 12mo) 3</title></rect>
+<rect x="1157.60" y="599.92" width="13.13" height="18.86" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/key-value-editor.tsx
+124 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="1170.74" y="599.92" width="7.84" height="18.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/nodes/key-value-editor.test.tsx
+74 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1178.57" y="583.34" width="13.38" height="22.84" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/valuation-rules/index.tsx
+153 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1191.96" y="583.34" width="10.41" height="22.84" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/valuation-rules/index.test.tsx
+119 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1178.57" y="606.18" width="23.79" height="12.60" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/pages/index.tsx
+150 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="1111.55" y="618.78" width="26.26" height="27.70" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/create-valuation-feature-dialog.test.tsx
+364 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="1137.80" y="618.78" width="26.26" height="27.70" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/create-valuation-feature-dialog.tsx
+364 loc · ccn 66 · commits (last 12mo) 1</title></rect>
+<rect x="1164.06" y="618.78" width="22.72" height="15.56" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/execution-subgraph.tsx
+177 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="1164.06" y="634.34" width="22.72" height="12.13" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/execution-context-tab.tsx
+138 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1186.78" y="618.78" width="13.20" height="15.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/execution-context-tab.test.tsx
+101 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1186.78" y="634.07" width="12.88" height="12.41" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/execution-subgraph.test.tsx
+80 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1199.66" y="634.07" width="0.32" height="12.41" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/components/index.ts
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1199.98" y="618.78" width="2.38" height="23.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/lib/filter-subgraph.ts
+28 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1199.98" y="642.28" width="2.38" height="4.20" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reference-data/index.ts
+5 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="873.63" y="646.48" width="23.02" height="32.46" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
+374 loc · ccn 48 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="678.93" width="23.02" height="22.39" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/payment-methods-tab.test.tsx
+258 loc · ccn 51 · commits (last 12mo) 1</title></rect>
+<rect x="896.64" y="646.48" width="20.72" height="19.38" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/demographics-tab.test.tsx
+201 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="896.64" y="665.85" width="20.72" height="18.99" fill="#d6cfcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+197 loc · ccn 82 · commits (last 12mo) 1</title></rect>
+<rect x="896.64" y="684.84" width="20.72" height="16.48" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/overview-tab.test.tsx
+171 loc · ccn 36 · commits (last 12mo) 2</title></rect>
+<rect x="917.37" y="646.48" width="21.76" height="15.05" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/payment-methods-tab.tsx
+164 loc · ccn 19 · commits (last 12mo) 3</title></rect>
+<rect x="939.13" y="646.48" width="16.59" height="15.05" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
+125 loc · ccn 30 · commits (last 12mo) 4</title></rect>
+<rect x="917.37" y="661.53" width="14.27" height="16.10" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/demographics-tab.tsx
+115 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="931.64" y="661.53" width="12.16" height="16.10" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/accounts-tab.tsx
+98 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="943.81" y="661.53" width="11.92" height="16.10" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/accounts-tab.test.tsx
+96 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="917.37" y="677.63" width="15.00" height="12.52" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/internal-accounts-tab.tsx
+94 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="917.37" y="690.14" width="15.00" height="11.18" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/references-tab.test.tsx
+84 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="932.37" y="677.63" width="12.49" height="13.43" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/bank-relations-tab.test.tsx
+84 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="944.86" y="677.63" width="10.86" height="13.43" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/overview-tab.tsx
+73 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="932.37" y="691.06" width="6.42" height="10.27" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/associations-tab.tsx
+33 loc · ccn 3 · commits (last 12mo) 4</title></rect>
+<rect x="938.79" y="691.06" width="5.64" height="10.27" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/audit-trail-tab.test.tsx
+29 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="944.44" y="691.06" width="9.73" height="5.13" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/references-tab.tsx
+25 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="944.44" y="696.19" width="9.73" height="5.13" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/bank-relations-tab.tsx
+25 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="954.16" y="691.06" width="1.56" height="10.27" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/tabs/audit-trail-tab.tsx
+8 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="701.33" width="23.91" height="31.67" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-associations-dialog.test.tsx
+379 loc · ccn 66 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="732.99" width="23.91" height="27.32" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-party-dialog.test.tsx
+327 loc · ccn 64 · commits (last 12mo) 1</title></rect>
+<rect x="897.54" y="701.33" width="19.41" height="33.14" fill="#dccec5" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-associations-dialog.tsx
+322 loc · ccn 73 · commits (last 12mo) 2</title></rect>
+<rect x="916.95" y="701.33" width="16.76" height="33.14" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-party-type-dialog.test.tsx
+278 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="897.54" y="734.47" width="20.40" height="25.85" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-party-dialog.tsx
+264 loc · ccn 57 · commits (last 12mo) 1</title></rect>
+<rect x="917.94" y="734.47" width="15.77" height="25.85" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/dialogs/register-party-type-dialog.tsx
+204 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="933.71" y="701.33" width="15.46" height="18.60" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/components/party-header.test.tsx
+144 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="949.17" y="701.33" width="6.55" height="18.60" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/components/party-header.tsx
+61 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="933.71" y="719.93" width="22.01" height="13.16" fill="#e7d5bf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/[partyId].test.tsx
+145 loc · ccn 37 · commits (last 12mo) 4</title></rect>
+<rect x="933.71" y="733.09" width="22.01" height="11.25" fill="#f2dec4" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/index.tsx
+124 loc · ccn 13 · commits (last 12mo) 6</title></rect>
+<rect x="933.71" y="744.34" width="12.01" height="15.97" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/index.test.tsx
+96 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="945.71" y="744.34" width="10.01" height="15.97" fill="#fde4bf" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/pages/[partyId].tsx
+80 loc · ccn 11 · commits (last 12mo) 8</title></rect>
+<rect x="873.63" y="760.31" width="78.90" height="1.87" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/hooks/use-parties.ts
+74 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="952.52" y="760.31" width="1.07" height="1.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="953.59" y="760.31" width="2.13" height="1.87" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/parties/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="762.19" width="27.12" height="39.55" fill="#fcb07a" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/saga-flow.tsx
+537 loc · ccn 108 · commits (last 12mo) 13</title></rect>
+<rect x="873.63" y="801.74" width="27.12" height="29.02" fill="#ecb999" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/composition-graph.tsx
+394 loc · ccn 114 · commits (last 12mo) 5</title></rect>
+<rect x="900.75" y="762.19" width="25.16" height="24.93" fill="#ecd3b4" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/saga-flow.test.tsx
+314 loc · ccn 47 · commits (last 12mo) 5</title></rect>
+<rect x="925.91" y="762.19" width="15.31" height="24.93" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/filter-bar.test.tsx
+191 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="941.22" y="762.19" width="14.50" height="24.93" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/composition-graph.test.tsx
+181 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="900.75" y="787.12" width="19.27" height="14.83" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/linked-detail.test.tsx
+143 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="900.75" y="801.94" width="19.27" height="14.51" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/component-detail.tsx
+140 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="900.75" y="816.46" width="19.27" height="14.31" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/filter-bar.tsx
+138 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="920.02" y="787.12" width="19.06" height="13.21" fill="#ecd9c0" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/catalogue-grid.tsx
+126 loc · ccn 27 · commits (last 12mo) 5</title></rect>
+<rect x="939.08" y="787.12" width="16.64" height="13.21" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/filter-bar.test.ts
+110 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="920.02" y="800.32" width="13.19" height="15.75" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/component-detail.test.tsx
+104 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="920.02" y="816.07" width="13.19" height="14.69" fill="#e7d8c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/linked-detail.tsx
+97 loc · ccn 21 · commits (last 12mo) 4</title></rect>
+<rect x="933.21" y="800.32" width="11.76" height="13.93" fill="#e7dac9" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+82 loc · ccn 15 · commits (last 12mo) 4</title></rect>
+<rect x="944.97" y="800.32" width="10.75" height="13.93" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/preview-source-tabs.test.tsx
+75 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="933.21" y="814.26" width="8.59" height="16.51" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/manifest-viewer.tsx
+71 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="941.80" y="814.26" width="7.04" height="11.63" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/preview-source-tabs.tsx
+41 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="948.85" y="814.26" width="6.87" height="11.63" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/manifest-viewer.test.tsx
+40 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="941.80" y="825.88" width="13.92" height="4.88" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/components/saga-flow-sizing.ts
+34 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="830.76" width="25.31" height="25.18" fill="#fcad77" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/detail.tsx
+319 loc · ccn 112 · commits (last 12mo) 13</title></rect>
+<rect x="873.63" y="855.94" width="25.31" height="13.10" fill="#f7d4a5" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/detail.test.tsx
+166 loc · ccn 49 · commits (last 12mo) 7</title></rect>
+<rect x="898.94" y="830.76" width="13.47" height="16.01" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/patterns.test.tsx
+108 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="912.41" y="830.76" width="12.10" height="16.01" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/index.test.tsx
+97 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="898.94" y="846.78" width="13.82" height="12.00" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/components.test.tsx
+83 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="898.94" y="858.78" width="13.82" height="10.26" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/index.tsx
+71 loc · ccn 5 · commits (last 12mo) 4</title></rect>
+<rect x="912.76" y="846.78" width="11.75" height="10.37" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/graph.test.tsx
+61 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="912.76" y="857.15" width="6.00" height="7.99" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/graph.tsx
+24 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="918.76" y="857.15" width="5.75" height="7.99" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/patterns.tsx
+23 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="912.76" y="865.13" width="11.75" height="3.91" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/pages/components.tsx
+23 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="924.51" y="830.76" width="16.75" height="16.58" fill="#e7d6c1" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-pattern-files.test.ts
+139 loc · ccn 32 · commits (last 12mo) 4</title></rect>
+<rect x="941.26" y="830.76" width="14.46" height="16.58" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-filter-state.test.ts
+120 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="924.51" y="847.34" width="16.51" height="10.53" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-filter-state.test.tsx
+87 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="924.51" y="857.87" width="16.51" height="9.32" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-filter-state.ts
+77 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="941.02" y="847.34" width="14.70" height="7.61" fill="#ecdac3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-pattern-files.ts
+56 loc · ccn 21 · commits (last 12mo) 5</title></rect>
+<rect x="941.02" y="854.96" width="8.17" height="12.23" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-cookbook.ts
+50 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="949.19" y="854.96" width="6.53" height="12.23" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/hooks/use-cookbook.test.ts
+40 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="924.51" y="867.19" width="18.30" height="1.86" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/index.ts
+17 loc · ccn 1 · commits (last 12mo) 8</title></rect>
+<rect x="942.81" y="867.19" width="11.84" height="1.86" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/lib/star-parser.ts
+11 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="954.64" y="867.19" width="1.08" height="1.86" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/cookbook/lib/saga-mermaid.ts
+1 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="955.72" y="646.48" width="27.14" height="28.78" fill="#d6cfcc" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/payment-mutations.test.tsx
+391 loc · ccn 83 · commits (last 12mo) 1</title></rect>
+<rect x="955.72" y="675.26" width="27.14" height="19.43" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.test.tsx
+264 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="982.86" y="646.48" width="23.09" height="21.72" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/cancel-payment-dialog.test.tsx
+251 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1005.95" y="646.48" width="22.90" height="21.72" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/reverse-payment-dialog.test.tsx
+249 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="982.86" y="668.19" width="16.59" height="26.50" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx
+220 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="999.45" y="668.19" width="19.00" height="13.35" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/cancel-payment-dialog.tsx
+127 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="999.45" y="681.55" width="19.00" height="13.14" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/reverse-payment-dialog.tsx
+125 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1018.45" y="668.19" width="10.40" height="19.59" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/payment-mutations.ts
+102 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1018.45" y="687.78" width="8.96" height="6.91" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/payment-form-utils.test.ts
+31 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1027.41" y="687.78" width="1.45" height="5.53" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/index.ts
+4 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1027.41" y="693.31" width="1.45" height="1.38" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/dialogs/payment-form-utils.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="955.72" y="694.69" width="15.74" height="27.92" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payment-detail.test.tsx
+220 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="971.46" y="694.69" width="15.38" height="27.92" fill="#f2ddc2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payment-detail.tsx
+215 loc · ccn 16 · commits (last 12mo) 6</title></rect>
+<rect x="986.85" y="694.69" width="22.97" height="14.70" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payments-query.test.ts
+169 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="986.85" y="709.39" width="22.97" height="13.22" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payments-list.test.tsx
+152 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1009.82" y="694.69" width="19.03" height="9.87" fill="#eddecb" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/index.tsx
+94 loc · ccn 6 · commits (last 12mo) 5</title></rect>
+<rect x="1009.82" y="704.56" width="10.29" height="18.05" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payment-detail-query.test.ts
+93 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1020.11" y="704.56" width="8.74" height="9.83" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payments-query.ts
+43 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1020.11" y="714.38" width="8.74" height="8.23" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/pages/payment-detail-query.ts
+36 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1028.85" y="646.48" width="7.61" height="55.40" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/hooks/use-payments.test.tsx
+211 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="1028.85" y="701.87" width="7.61" height="19.95" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/hooks/use-payments.ts
+76 loc · ccn 53 · commits (last 12mo) 2</title></rect>
+<rect x="1028.85" y="721.82" width="7.61" height="0.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1028.85" y="722.09" width="7.61" height="0.53" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/payments/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="955.72" y="722.61" width="28.54" height="28.28" fill="#fcb982" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/[accountId].tsx
+404 loc · ccn 99 · commits (last 12mo) 8</title></rect>
+<rect x="955.72" y="750.89" width="28.54" height="25.06" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/create-lien-dialog.test.tsx
+358 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="955.72" y="775.95" width="28.54" height="21.91" fill="#e1cdbc" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/account-detail.test.tsx
+313 loc · ccn 74 · commits (last 12mo) 3</title></rect>
+<rect x="984.26" y="722.61" width="26.36" height="19.63" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/create-lien-dialog.tsx
+259 loc · ccn 52 · commits (last 12mo) 1</title></rect>
+<rect x="1010.62" y="722.61" width="20.66" height="19.63" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/withdraw-dialog.tsx
+203 loc · ccn 35 · commits (last 12mo) 1</title></rect>
+<rect x="984.26" y="742.24" width="17.41" height="22.60" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/create-account-dialog.tsx
+197 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1001.67" y="742.24" width="15.20" height="22.60" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/withdraw-dialog.test.tsx
+172 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1016.88" y="742.24" width="14.41" height="22.60" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/control-dialog.test.tsx
+163 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="984.26" y="764.84" width="19.00" height="16.72" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/accounts-list.test.tsx
+159 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="984.26" y="781.56" width="19.00" height="16.30" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/deposit-dialog.test.tsx
+155 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="1003.26" y="764.84" width="15.31" height="18.40" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/deposit-dialog.tsx
+141 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1018.58" y="764.84" width="12.71" height="18.40" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/control-dialog.tsx
+117 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1003.26" y="783.24" width="12.57" height="14.62" fill="#f2e0c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/index.tsx
+92 loc · ccn 9 · commits (last 12mo) 6</title></rect>
+<rect x="1015.84" y="783.24" width="8.47" height="14.62" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/account-form-utils.test.ts
+62 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1024.31" y="783.24" width="6.97" height="8.88" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/account-form-utils.ts
+31 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1024.31" y="792.12" width="6.97" height="5.73" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/pages/types.ts
+20 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1031.28" y="722.61" width="5.18" height="54.02" fill="#ecc9a9" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/hooks/use-accounts.ts
+140 loc · ccn 79 · commits (last 12mo) 5</title></rect>
+<rect x="1031.28" y="776.63" width="5.18" height="19.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/hooks/format-balance.test.ts
+51 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1031.28" y="796.31" width="5.18" height="0.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1031.28" y="796.70" width="5.18" height="1.16" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/accounts/index.ts
+3 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="955.72" y="797.86" width="25.04" height="32.39" fill="#e7c8af" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/detail.test.tsx
+406 loc · ccn 87 · commits (last 12mo) 4</title></rect>
+<rect x="980.76" y="797.86" width="18.32" height="32.39" fill="#ecd3b4" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/index.test.tsx
+297 loc · ccn 47 · commits (last 12mo) 5</title></rect>
+<rect x="955.72" y="830.25" width="26.26" height="21.07" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/create-saga-draft-dialog.tsx
+277 loc · ccn 49 · commits (last 12mo) 3</title></rect>
+<rect x="955.72" y="851.32" width="26.26" height="17.72" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/create-saga-draft-dialog.test.tsx
+233 loc · ccn 37 · commits (last 12mo) 2</title></rect>
+<rect x="981.98" y="830.25" width="17.10" height="25.24" fill="#fdcb95" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/detail.tsx
+216 loc · ccn 65 · commits (last 12mo) 8</title></rect>
+<rect x="981.98" y="855.49" width="17.10" height="13.56" fill="#fde2bb" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/pages/index.tsx
+116 loc · ccn 16 · commits (last 12mo) 9</title></rect>
+<rect x="999.08" y="797.86" width="19.00" height="26.19" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/cel-editor.test.tsx
+249 loc · ccn 66 · commits (last 12mo) 1</title></rect>
+<rect x="1018.08" y="797.86" width="18.39" height="26.19" fill="#e7d4bf" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/starlark-editor.tsx
+241 loc · ccn 38 · commits (last 12mo) 4</title></rect>
+<rect x="999.08" y="824.04" width="19.15" height="23.89" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/starlark-editor.test.tsx
+229 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="1018.23" y="824.04" width="18.23" height="23.89" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/cel-editor.tsx
+218 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="999.08" y="847.93" width="20.65" height="17.32" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/saga-timeline.test.tsx
+179 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1019.73" y="847.93" width="16.73" height="16.60" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/saga-timeline.tsx
+139 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1019.73" y="864.53" width="16.73" height="0.72" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/components/index.ts
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="999.08" y="865.25" width="35.27" height="3.79" fill="#e7d5c0" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/hooks/use-sagas.ts
+67 loc · ccn 35 · commits (last 12mo) 4</title></rect>
+<rect x="1034.35" y="865.25" width="0.53" height="3.79" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1034.88" y="865.25" width="1.58" height="3.79" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/sagas/index.ts
+3 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1036.46" y="646.48" width="36.53" height="29.64" fill="#f2cea7" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/detail.tsx
+542 loc · ccn 62 · commits (last 12mo) 6</title></rect>
+<rect x="1036.46" y="676.12" width="36.53" height="27.73" fill="#dbc0b7" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/detail.test.tsx
+507 loc · ccn 145 · commits (last 12mo) 2</title></rect>
+<rect x="1072.99" y="646.48" width="23.69" height="24.45" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/create-dispute-dialog.test.tsx
+290 loc · ccn 42 · commits (last 12mo) 1</title></rect>
+<rect x="1096.68" y="646.48" width="23.53" height="24.45" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/initiate-reconciliation-dialog.test.tsx
+288 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1072.99" y="670.93" width="30.77" height="17.14" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/create-dispute-dialog.tsx
+264 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="1072.99" y="688.07" width="30.77" height="15.78" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/initiate-reconciliation-dialog.tsx
+243 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1103.76" y="670.93" width="16.45" height="16.64" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/index.test.tsx
+137 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1103.76" y="687.57" width="16.45" height="16.27" fill="#edddc8" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/pages/index.tsx
+134 loc · ccn 12 · commits (last 12mo) 5</title></rect>
+<rect x="1120.21" y="646.48" width="15.53" height="23.80" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/hooks/use-reconciliation.test.tsx
+185 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1120.21" y="670.27" width="15.32" height="9.52" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/hooks/use-reconciliation.ts
+73 loc · ccn 43 · commits (last 12mo) 2</title></rect>
+<rect x="1135.54" y="670.27" width="0.21" height="9.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1120.21" y="679.79" width="15.53" height="12.99" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/components/variance-detail.test.tsx
+101 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1120.21" y="692.78" width="15.53" height="10.80" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/components/variance-detail.tsx
+84 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1120.21" y="703.59" width="15.53" height="0.26" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/reconciliation/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1135.74" y="646.48" width="31.29" height="26.43" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/create-internal-account-dialog.test.tsx
+414 loc · ccn 61 · commits (last 12mo) 1</title></rect>
+<rect x="1167.03" y="646.48" width="25.09" height="26.43" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/create-internal-account-dialog.tsx
+332 loc · ccn 70 · commits (last 12mo) 1</title></rect>
+<rect x="1135.74" y="672.91" width="18.66" height="30.93" fill="#ecd4b6" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/[accountId].tsx
+289 loc · ccn 44 · commits (last 12mo) 5</title></rect>
+<rect x="1154.41" y="672.91" width="18.47" height="30.93" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/[accountId].test.tsx
+286 loc · ccn 44 · commits (last 12mo) 1</title></rect>
+<rect x="1172.88" y="672.91" width="19.25" height="16.92" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/index.test.tsx
+163 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1172.88" y="689.83" width="19.25" height="14.01" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/pages/index.tsx
+135 loc · ccn 12 · commits (last 12mo) 4</title></rect>
+<rect x="1192.13" y="646.48" width="10.24" height="39.81" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/hooks/use-internal-accounts.test.ts
+204 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1192.13" y="686.28" width="10.24" height="16.98" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/hooks/use-internal-accounts.ts
+87 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="1192.13" y="703.26" width="10.24" height="0.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1192.13" y="703.45" width="10.24" height="0.39" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/internal-accounts/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1036.46" y="703.84" width="38.72" height="19.35" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/dialogs/create-mapping-dialog.test.tsx
+375 loc · ccn 31 · commits (last 12mo) 1</title></rect>
+<rect x="1036.46" y="723.19" width="25.17" height="21.82" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/dialogs/create-mapping-dialog.tsx
+275 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1061.63" y="723.19" width="13.55" height="17.55" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/dialogs/mapping-mutations.test.tsx
+119 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1061.63" y="740.74" width="13.55" height="4.28" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/dialogs/mapping-mutations.ts
+29 loc · ccn 3 · commits (last 12mo) 2</title></rect>
+<rect x="1075.18" y="703.84" width="19.51" height="41.17" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/[mappingId].tsx
+402 loc · ccn 56 · commits (last 12mo) 2</title></rect>
+<rect x="1036.46" y="745.01" width="24.39" height="18.18" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/[mappingId].test.tsx
+222 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="1060.85" y="745.01" width="18.35" height="18.18" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/index.test.tsx
+167 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="1079.20" y="745.01" width="15.49" height="18.18" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/pages/index.tsx
+141 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="1036.46" y="763.20" width="58.23" height="0.07" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/mappings/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1036.46" y="763.27" width="18.20" height="28.54" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/pages/invoice-detail.tsx
+260 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1054.66" y="763.27" width="21.07" height="14.79" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/pages/index.test.tsx
+156 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1054.66" y="778.06" width="21.07" height="13.75" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/pages/invoices.tsx
+145 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="1075.73" y="763.27" width="7.70" height="28.54" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/pages/index.tsx
+110 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1036.46" y="791.81" width="22.22" height="27.69" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/api/hooks.test.tsx
+308 loc · ccn 71 · commits (last 12mo) 1</title></rect>
+<rect x="1058.68" y="791.81" width="24.75" height="24.06" fill="#e1b9a9" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/api/hooks.ts
+298 loc · ccn 140 · commits (last 12mo) 3</title></rect>
+<rect x="1058.68" y="815.87" width="24.75" height="3.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/api/types.ts
+45 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1083.43" y="763.27" width="11.26" height="29.27" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/components/invoice-actions.tsx
+165 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1083.43" y="792.54" width="11.26" height="14.55" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/components/email-delivery-status-badge.tsx
+82 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1083.43" y="807.08" width="11.26" height="9.76" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/components/email-delivery-status-badge.test.tsx
+55 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1083.43" y="816.84" width="11.26" height="2.66" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/billing/index.ts
+15 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="1036.46" y="819.50" width="22.78" height="24.99" fill="#ecd6bb" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/[datasetCode].tsx
+285 loc · ccn 36 · commits (last 12mo) 5</title></rect>
+<rect x="1036.46" y="844.49" width="22.78" height="24.55" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/register-dataset-dialog.test.tsx
+280 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1059.24" y="819.50" width="18.45" height="27.61" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/register-dataset-dialog.tsx
+255 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="1077.70" y="819.50" width="13.97" height="27.61" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/index.test.tsx
+193 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1059.24" y="847.11" width="16.57" height="21.94" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/datasetCode.test.tsx
+182 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="1075.82" y="847.11" width="15.85" height="19.67" fill="#ecd9c1" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/index.tsx
+156 loc · ccn 24 · commits (last 12mo) 5</title></rect>
+<rect x="1075.82" y="866.77" width="15.85" height="2.27" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/pages/constants.ts
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1091.66" y="819.50" width="3.02" height="47.56" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/hooks/use-market-data.ts
+72 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1091.66" y="867.06" width="3.02" height="0.66" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1091.66" y="867.72" width="3.02" height="1.32" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/market-data/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1094.69" y="703.84" width="25.34" height="27.99" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/booking-log-detail.test.tsx
+355 loc · ccn 52 · commits (last 12mo) 2</title></rect>
+<rect x="1094.69" y="731.84" width="25.34" height="20.27" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/index.test.tsx
+257 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="1120.02" y="703.84" width="23.51" height="16.74" fill="#e7d2b9" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/booking-log-detail.tsx
+197 loc · ccn 51 · commits (last 12mo) 4</title></rect>
+<rect x="1120.02" y="720.58" width="12.96" height="12.49" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/index.tsx
+81 loc · ccn 5 · commits (last 12mo) 4</title></rect>
+<rect x="1132.98" y="720.58" width="10.56" height="12.49" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/balance-indicator.tsx
+66 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1120.02" y="733.07" width="10.92" height="11.35" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/booking-log-header.test.tsx
+62 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1120.02" y="744.41" width="10.92" height="7.69" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/booking-log-header.tsx
+42 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1130.94" y="733.07" width="6.57" height="10.94" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/balance-indicator.test.tsx
+36 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1137.51" y="733.07" width="6.02" height="10.94" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/types.ts
+33 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1130.94" y="744.01" width="6.67" height="8.09" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/direction-badge.test.tsx
+27 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1137.61" y="744.01" width="5.93" height="8.09" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/pages/direction-badge.tsx
+24 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1143.54" y="703.84" width="5.63" height="47.19" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/hooks/use-ledger.ts
+133 loc · ccn 84 · commits (last 12mo) 2</title></rect>
+<rect x="1143.54" y="751.04" width="5.63" height="0.35" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1143.54" y="751.39" width="5.63" height="0.71" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/ledger/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1149.17" y="703.84" width="28.77" height="33.12" fill="#eccbab" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/register-page.test.tsx
+477 loc · ccn 72 · commits (last 12mo) 5</title></rect>
+<rect x="1149.17" y="736.96" width="28.77" height="15.14" fill="#ecccac" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/register-page.tsx
+218 loc · ccn 70 · commits (last 12mo) 5</title></rect>
+<rect x="1177.94" y="703.84" width="24.38" height="15.73" fill="#e7d7c3" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/registration-helpers.tsx
+192 loc · ccn 28 · commits (last 12mo) 4</title></rect>
+<rect x="1177.94" y="719.57" width="14.45" height="19.91" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/registration-form.tsx
+144 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1192.39" y="719.57" width="9.93" height="19.91" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/use-provisioning-poll.ts
+99 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="1177.94" y="739.48" width="15.36" height="12.62" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/registration-utils.test.ts
+97 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1193.30" y="739.48" width="9.03" height="12.62" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/pages/registration-utils.ts
+57 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="1202.32" y="703.84" width="0.04" height="48.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/registration/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1094.69" y="752.10" width="16.08" height="25.72" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/pages/user-detail-page.tsx
+207 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="1110.77" y="752.10" width="14.14" height="25.72" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/pages/users-list-page.test.tsx
+182 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1094.69" y="777.82" width="17.78" height="19.44" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/pages/user-detail-page.test.tsx
+173 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1112.47" y="777.82" width="12.44" height="19.44" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/pages/users-list-page.tsx
+121 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="1124.90" y="752.10" width="13.03" height="19.94" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/components/role-management.tsx
+130 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1137.93" y="752.10" width="11.52" height="19.94" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/components/invite-dialog.tsx
+115 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1124.90" y="772.04" width="24.55" height="5.13" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/components/admin-only-route.test.tsx
+63 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1124.90" y="777.16" width="14.41" height="20.10" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/hooks/use-identities.ts
+145 loc · ccn 27 · commits (last 12mo) 2</title></rect>
+<rect x="1139.32" y="777.16" width="10.14" height="13.40" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/lib/roles.test.ts
+68 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1139.32" y="790.56" width="10.14" height="6.31" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/lib/roles.ts
+32 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1139.32" y="796.87" width="10.14" height="0.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/identity/index.ts
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1149.46" y="752.10" width="29.46" height="25.77" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>frontend/src/features/tenants/pages/tenant-detail-page.test.tsx
+380 loc · ccn 58 · commits (last 12mo) 2</title></rect>
+<rect x="1149.46" y="777.87" width="29.46" height="19.39" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>frontend/src/features/tenants/pages/[tenantId].tsx
+286 loc · ccn 49 · commits (last 12mo) 3</title></rect>
+<rect x="1178.92" y="752.10" width="23.36" height="23.09" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>frontend/src/features/tenants/pages/tenants-page.test.tsx
+270 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="1178.92" y="775.19" width="23.36" height="22.07" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>frontend/src/features/tenants/pages/index.tsx
+258 loc · ccn 33 · commits (last 12mo) 3</title></rect>
+<rect x="1202.28" y="752.10" width="0.09" height="45.16" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/tenants/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1094.69" y="797.26" width="24.56" height="20.90" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/index.test.tsx
+257 loc · ccn 35 · commits (last 12mo) 2</title></rect>
+<rect x="1094.69" y="818.16" width="24.56" height="17.73" fill="#eccfaf" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/index.tsx
+218 loc · ccn 60 · commits (last 12mo) 5</title></rect>
+<rect x="1119.25" y="797.26" width="18.15" height="16.29" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/mcp-connection-card.test.tsx
+148 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1137.40" y="797.26" width="16.19" height="16.29" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/mcp-connection-card.tsx
+132 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1119.25" y="813.55" width="16.99" height="11.76" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/activity-feed.tsx
+100 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="1119.25" y="825.31" width="16.99" height="10.58" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/stat-card.tsx
+90 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1136.24" y="813.55" width="10.03" height="12.55" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/stat-card.test.tsx
+63 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="1146.26" y="813.55" width="7.32" height="12.55" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/activity-feed.test.tsx
+46 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1136.24" y="826.11" width="9.18" height="9.79" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/quick-actions.tsx
+45 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1145.42" y="826.11" width="8.16" height="9.79" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/pages/quick-actions.test.tsx
+40 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1153.58" y="797.26" width="0.05" height="38.64" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/dashboard/index.ts
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1094.69" y="835.90" width="29.23" height="16.95" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/pages/detail.test.tsx
+248 loc · ccn 51 · commits (last 12mo) 3</title></rect>
+<rect x="1094.69" y="852.85" width="29.23" height="16.20" fill="#fdca94" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/pages/detail.tsx
+237 loc · ccn 69 · commits (last 12mo) 10</title></rect>
+<rect x="1123.92" y="835.90" width="20.37" height="19.61" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/pages/index.test.tsx
+200 loc · ccn 29 · commits (last 12mo) 2</title></rect>
+<rect x="1123.92" y="855.51" width="20.37" height="13.53" fill="#f2dfc5" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/pages/index.tsx
+138 loc · ccn 12 · commits (last 12mo) 6</title></rect>
+<rect x="1144.29" y="835.90" width="9.34" height="12.40" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/components/quality-ladder-badge.test.tsx
+58 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1144.29" y="848.30" width="9.34" height="11.12" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/components/quality-ladder-badge.tsx
+52 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="1144.29" y="859.42" width="9.34" height="0.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/components/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1144.29" y="859.63" width="9.12" height="8.98" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/hooks/use-positions.ts
+41 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1153.41" y="859.63" width="0.22" height="8.98" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/hooks/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1144.29" y="868.62" width="9.34" height="0.43" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/positions/index.ts
+2 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1153.63" y="797.26" width="24.54" height="15.95" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>frontend/src/features/mcp-config/pages/index.test.tsx
+196 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="1153.63" y="813.21" width="14.62" height="22.95" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>frontend/src/features/mcp-config/pages/index.tsx
+168 loc · ccn 11 · commits (last 12mo) 4</title></rect>
+<rect x="1168.26" y="813.21" width="9.92" height="22.95" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/mcp-config/pages/mcp-tools-section.tsx
+114 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1153.63" y="836.17" width="24.54" height="0.08" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/mcp-config/index.ts
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1178.18" y="797.26" width="24.19" height="19.66" fill="#f7d4a7" stroke="white" stroke-width="0.5"><title>frontend/src/features/audit/pages/index.tsx
+238 loc · ccn 48 · commits (last 12mo) 7</title></rect>
+<rect x="1178.18" y="816.92" width="24.19" height="17.84" fill="#e7d7c3" stroke="white" stroke-width="0.5"><title>frontend/src/features/audit/pages/index.test.tsx
+216 loc · ccn 28 · commits (last 12mo) 4</title></rect>
+<rect x="1178.18" y="834.76" width="22.84" height="1.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/audit/components/audit-empty-state.tsx
+17 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1201.02" y="834.76" width="1.34" height="1.49" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/audit/index.ts
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1153.63" y="836.25" width="26.25" height="19.25" fill="#ecd7bc" stroke="white" stroke-width="0.5"><title>frontend/src/features/forecasting/pages/index.tsx
+253 loc · ccn 33 · commits (last 12mo) 5</title></rect>
+<rect x="1153.63" y="855.50" width="26.25" height="13.47" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/forecasting/pages/index.test.tsx
+177 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1153.63" y="868.97" width="26.25" height="0.08" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/forecasting/index.ts
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1179.89" y="836.25" width="22.48" height="17.69" fill="#e7d0b7" stroke="white" stroke-width="0.5"><title>frontend/src/features/transactions/pages/index.tsx
+199 loc · ccn 59 · commits (last 12mo) 4</title></rect>
+<rect x="1179.89" y="853.93" width="22.48" height="15.02" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/features/transactions/pages/index.test.tsx
+169 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1179.89" y="868.96" width="22.48" height="0.09" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/features/transactions/index.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="869.04" width="16.73" height="31.29" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>frontend/src/test/architecture/imports.test.ts
+262 loc · ccn 51 · commits (last 12mo) 3</title></rect>
+<rect x="890.35" y="869.04" width="19.34" height="16.94" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>frontend/src/test/architecture/structure.test.ts
+164 loc · ccn 31 · commits (last 12mo) 2</title></rect>
+<rect x="890.35" y="885.98" width="19.34" height="14.35" fill="#fddaac" stroke="white" stroke-width="0.5"><title>frontend/src/test/architecture/size.test.ts
+139 loc · ccn 34 · commits (last 12mo) 9</title></rect>
+<rect x="909.70" y="869.04" width="25.67" height="31.29" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>frontend/src/test/page-structure.test.tsx
+402 loc · ccn 64 · commits (last 12mo) 2</title></rect>
+<rect x="935.36" y="869.04" width="23.05" height="31.29" fill="#dccfc6" stroke="white" stroke-width="0.5"><title>frontend/src/test/lib/error-handling.test.ts
+361 loc · ccn 66 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="900.34" width="24.54" height="29.39" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>frontend/src/test/data-table.test.tsx
+361 loc · ccn 53 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="929.72" width="12.48" height="14.08" fill="#f2dbbc" stroke="white" stroke-width="0.5"><title>frontend/src/test/api/context.test.tsx
+88 loc · ccn 25 · commits (last 12mo) 6</title></rect>
+<rect x="886.11" y="929.72" width="12.06" height="14.08" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>frontend/src/test/api/auth-interceptor.test.ts
+85 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="873.63" y="943.81" width="9.49" height="14.73" fill="#fde4bf" stroke="white" stroke-width="0.5"><title>frontend/src/test/api/clients.test.ts
+70 loc · ccn 11 · commits (last 12mo) 8</title></rect>
+<rect x="883.12" y="943.81" width="7.86" height="14.73" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>frontend/src/test/api/transport.test.ts
+58 loc · ccn 18 · commits (last 12mo) 3</title></rect>
+<rect x="890.98" y="943.81" width="7.19" height="14.73" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/src/test/api/config.test.ts
+53 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="873.63" y="958.54" width="24.54" height="17.67" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/test/session-expiry-warning.test.tsx
+217 loc · ccn 39 · commits (last 12mo) 1</title></rect>
+<rect x="898.17" y="900.34" width="20.64" height="20.13" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>frontend/src/test/heading-hierarchy.a11y.test.tsx
+208 loc · ccn 47 · commits (last 12mo) 2</title></rect>
+<rect x="918.81" y="900.34" width="20.45" height="20.13" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>frontend/src/test/error-boundary.test.tsx
+206 loc · ccn 31 · commits (last 12mo) 3</title></rect>
+<rect x="939.26" y="900.34" width="19.16" height="20.13" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/src/test/app-routing.test.tsx
+193 loc · ccn 14 · commits (last 12mo) 3</title></rect>
+<rect x="898.17" y="920.46" width="17.53" height="20.41" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>frontend/src/test/query-keys.test.ts
+179 loc · ccn 36 · commits (last 12mo) 2</title></rect>
+<rect x="898.17" y="940.87" width="17.53" height="18.47" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>frontend/src/test/status-badge.test.tsx
+162 loc · ccn 27 · commits (last 12mo) 3</title></rect>
+<rect x="898.17" y="959.34" width="17.53" height="16.87" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>frontend/src/test/money-display.test.tsx
+148 loc · ccn 42 · commits (last 12mo) 2</title></rect>
+<rect x="915.69" y="920.46" width="16.46" height="17.12" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/test/dialog.a11y.test.tsx
+141 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="932.15" y="920.46" width="13.77" height="17.12" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/src/test/data-table.a11y.test.tsx
+118 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="945.92" y="920.46" width="12.49" height="17.12" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/test/form-components.a11y.test.tsx
+107 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="915.69" y="937.58" width="14.79" height="13.64" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/test/tenant-subdomain-enforcer.test.tsx
+101 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="915.69" y="951.22" width="14.79" height="12.70" fill="#e7d8c5" stroke="white" stroke-width="0.5"><title>frontend/src/test/router.test.tsx
+94 loc · ccn 24 · commits (last 12mo) 4</title></rect>
+<rect x="915.69" y="963.92" width="14.79" height="12.29" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/test/msw-integration.test.tsx
+91 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="930.48" y="937.58" width="13.96" height="10.87" fill="#f2ddc2" stroke="white" stroke-width="0.5"><title>frontend/src/test/test-utils.tsx
+76 loc · ccn 16 · commits (last 12mo) 6</title></rect>
+<rect x="944.45" y="937.58" width="13.96" height="10.87" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/src/test/navigation.a11y.test.tsx
+76 loc · ccn 16 · commits (last 12mo) 3</title></rect>
+<rect x="930.48" y="948.45" width="9.86" height="14.38" fill="#fddfb6" stroke="white" stroke-width="0.5"><title>frontend/src/test/msw-handlers.ts
+71 loc · ccn 22 · commits (last 12mo) 8</title></rect>
+<rect x="930.48" y="962.84" width="9.86" height="13.37" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>frontend/src/test/jwt-helpers.ts
+66 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="940.34" y="948.45" width="10.20" height="11.94" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>frontend/src/test/status-badge.a11y.test.tsx
+61 loc · ccn 12 · commits (last 12mo) 3</title></rect>
+<rect x="950.55" y="948.45" width="7.86" height="11.94" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>frontend/src/test/query-client.test.ts
+47 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="940.34" y="960.40" width="10.36" height="7.91" fill="#eddeca" stroke="white" stroke-width="0.5"><title>frontend/src/test/App.test.tsx
+41 loc · ccn 7 · commits (last 12mo) 5</title></rect>
+<rect x="940.34" y="968.30" width="10.36" height="7.91" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/src/test/gen-stub.ts
+41 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="950.70" y="960.40" width="7.71" height="8.30" fill="#eddcc7" stroke="white" stroke-width="0.5"><title>frontend/src/test/setup.ts
+32 loc · ccn 13 · commits (last 12mo) 5</title></rect>
+<rect x="950.70" y="968.69" width="7.71" height="7.52" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/test/money-display.a11y.test.tsx
+29 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="958.41" y="869.04" width="31.67" height="31.16" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/dropdown-menu.test.tsx
+494 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="958.41" y="900.20" width="31.67" height="15.08" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/dropdown-menu.tsx
+239 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="990.08" y="869.04" width="18.01" height="18.08" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/command.tsx
+163 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1008.09" y="869.04" width="15.91" height="18.08" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/dialog.tsx
+144 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1024.01" y="869.04" width="11.49" height="18.08" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/table.tsx
+104 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="990.08" y="887.12" width="12.63" height="15.03" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/empty-state.test.tsx
+95 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="990.08" y="902.15" width="12.63" height="13.13" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/tabs.tsx
+83 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="1002.71" y="887.12" width="11.42" height="14.51" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/card.tsx
+83 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1002.71" y="901.64" width="11.42" height="13.64" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/popover.tsx
+78 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1014.14" y="887.12" width="10.94" height="11.32" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/empty-state.tsx
+62 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="1025.08" y="887.12" width="10.41" height="11.32" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/button.tsx
+59 loc · ccn 3 · commits (last 12mo) 5</title></rect>
+<rect x="1014.14" y="898.44" width="12.70" height="9.13" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/accordion.tsx
+58 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1014.14" y="907.57" width="12.70" height="7.71" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/tooltip.tsx
+49 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1026.84" y="898.44" width="8.66" height="9.92" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/badge.tsx
+43 loc · ccn 3 · commits (last 12mo) 3</title></rect>
+<rect x="1026.84" y="908.36" width="5.20" height="6.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/input.tsx
+18 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1032.03" y="908.36" width="3.46" height="6.92" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/ui/skeleton.tsx
+12 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="958.41" y="915.28" width="27.57" height="26.09" fill="#f7ce9f" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/sidebar.test.tsx
+360 loc · ccn 61 · commits (last 12mo) 7</title></rect>
+<rect x="985.98" y="915.28" width="24.50" height="26.09" fill="#dcd1c7" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/tenant-selector.test.tsx
+320 loc · ccn 54 · commits (last 12mo) 2</title></rect>
+<rect x="958.41" y="941.37" width="18.06" height="34.84" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/sidebar.tsx
+315 loc · ccn 1 · commits (last 12mo) 20</title></rect>
+<rect x="976.47" y="941.37" width="20.69" height="15.16" fill="#e7d9c7" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/app-shell.test.tsx
+157 loc · ccn 19 · commits (last 12mo) 4</title></rect>
+<rect x="997.17" y="941.37" width="13.31" height="15.16" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/tenant-selector.tsx
+101 loc · ccn 13 · commits (last 12mo) 3</title></rect>
+<rect x="976.47" y="956.53" width="16.44" height="11.18" fill="#e7d7c4" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/header.test.tsx
+92 loc · ccn 26 · commits (last 12mo) 4</title></rect>
+<rect x="976.47" y="967.70" width="16.44" height="8.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/theme-toggle.test.tsx
+70 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="992.92" y="956.53" width="11.19" height="11.60" fill="#f2e0c7" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/header.tsx
+65 loc · ccn 9 · commits (last 12mo) 6</title></rect>
+<rect x="1004.11" y="956.53" width="6.37" height="11.60" fill="#e7dcce" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/app-shell.tsx
+37 loc · ccn 4 · commits (last 12mo) 4</title></rect>
+<rect x="992.92" y="968.13" width="8.41" height="8.08" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/build-info.tsx
+34 loc · ccn 17 · commits (last 12mo) 3</title></rect>
+<rect x="1001.33" y="968.13" width="8.16" height="8.08" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/theme-toggle.tsx
+33 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1009.49" y="968.13" width="0.99" height="8.08" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/components/layout/index.ts
+4 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1010.48" y="915.28" width="17.80" height="21.32" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/components/dev/theme-preview-panel.tsx
+190 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="1028.28" y="915.28" width="7.21" height="21.32" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/dev/theme-preview-panel.test.tsx
+77 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1010.48" y="936.60" width="15.09" height="19.32" fill="#e7d9c8" stroke="white" stroke-width="0.5"><title>frontend/src/components/error-boundary.tsx
+146 loc · ccn 18 · commits (last 12mo) 4</title></rect>
+<rect x="1025.57" y="936.60" width="9.92" height="19.32" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/feature-guard.test.tsx
+96 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1010.48" y="955.92" width="16.84" height="10.20" fill="#f2d9b9" stroke="white" stroke-width="0.5"><title>frontend/src/components/routing.tsx
+86 loc · ccn 29 · commits (last 12mo) 6</title></rect>
+<rect x="1010.48" y="966.13" width="9.11" height="10.08" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/components/auth/provider-button.tsx
+46 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1019.59" y="966.13" width="7.73" height="7.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/components/auth/provider-icons.tsx
+28 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1019.59" y="973.36" width="7.73" height="2.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/auth/auth-divider.tsx
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1027.32" y="955.92" width="8.18" height="16.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/consent-card.tsx
+68 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1027.32" y="972.54" width="8.18" height="3.67" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/components/feature-guard.tsx
+15 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1035.50" y="869.04" width="40.16" height="21.59" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/star-parser.ts
+434 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="1035.50" y="890.64" width="24.38" height="34.83" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/star-parser.test.ts
+425 loc · ccn 67 · commits (last 12mo) 4</title></rect>
+<rect x="1059.88" y="890.64" width="15.78" height="19.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/saga-mermaid.test.ts
+154 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1059.88" y="910.14" width="9.13" height="15.32" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/graph-layout.ts
+70 loc · ccn 8 · commits (last 12mo) 3</title></rect>
+<rect x="1069.00" y="910.14" width="6.65" height="13.22" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/saga-mermaid.ts
+44 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1069.00" y="923.36" width="5.70" height="2.10" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/index.ts
+6 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1074.70" y="923.36" width="0.95" height="2.10" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/lib/visualization/constants.ts
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1075.65" y="869.04" width="16.70" height="21.53" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>frontend/src/lib/__tests__/tenant-ui-config.test.ts
+180 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="1092.35" y="869.04" width="11.04" height="21.53" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/lib/__tests__/theme-utils.test.ts
+119 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1103.39" y="869.04" width="12.06" height="9.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/lib/__tests__/query-client.test.ts
+56 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1103.39" y="878.32" width="12.06" height="9.11" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/lib/__tests__/tenant-utils.test.ts
+55 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1103.39" y="887.43" width="12.06" height="3.15" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/lib/__tests__/widget-registry.test.ts
+19 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1075.65" y="890.58" width="13.34" height="19.31" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/lib/error-handling.ts
+129 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="1075.65" y="909.89" width="13.34" height="15.57" fill="#fdd09a" stroke="white" stroke-width="0.5"><title>frontend/src/lib/query-keys.ts
+104 loc · ccn 56 · commits (last 12mo) 10</title></rect>
+<rect x="1089.00" y="890.58" width="14.02" height="12.69" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/lib/use-theme.ts
+89 loc · ccn 28 · commits (last 12mo) 1</title></rect>
+<rect x="1103.01" y="890.58" width="12.44" height="12.69" fill="#f2ddc1" stroke="white" stroke-width="0.5"><title>frontend/src/lib/router.tsx
+79 loc · ccn 18 · commits (last 12mo) 6</title></rect>
+<rect x="1089.00" y="903.26" width="11.61" height="11.53" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/src/lib/tenant-ui-config.ts
+67 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1089.00" y="914.79" width="11.61" height="10.67" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/lib/theme-utils.ts
+62 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1100.61" y="903.26" width="9.05" height="11.71" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/lib/analytics.test.ts
+53 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1109.65" y="903.26" width="5.80" height="11.71" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>frontend/src/lib/query-client.ts
+34 loc · ccn 4 · commits (last 12mo) 3</title></rect>
+<rect x="1100.61" y="914.97" width="6.09" height="10.49" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/lib/analytics.ts
+32 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1106.70" y="914.97" width="8.76" height="6.16" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/src/lib/tenant-utils.ts
+27 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="1106.70" y="921.13" width="4.61" height="4.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/lib/widget-registry.ts
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1111.31" y="921.13" width="4.15" height="4.33" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/lib/utils.ts
+9 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1035.50" y="925.46" width="24.64" height="26.02" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>frontend/src/shared/data-table.tsx
+321 loc · ccn 34 · commits (last 12mo) 3</title></rect>
+<rect x="1035.50" y="951.48" width="24.64" height="24.72" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/shared/handler-reference.test.tsx
+305 loc · ccn 36 · commits (last 12mo) 1</title></rect>
+<rect x="1060.14" y="925.46" width="24.96" height="18.49" fill="#e1d2c2" stroke="white" stroke-width="0.5"><title>frontend/src/shared/audit-trail.tsx
+231 loc · ccn 46 · commits (last 12mo) 3</title></rect>
+<rect x="1060.14" y="943.95" width="24.96" height="16.33" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>frontend/src/shared/audit-trail.test.tsx
+204 loc · ccn 36 · commits (last 12mo) 3</title></rect>
+<rect x="1060.14" y="960.28" width="24.96" height="15.93" fill="#e7d5bf" stroke="white" stroke-width="0.5"><title>frontend/src/shared/handler-reference.tsx
+199 loc · ccn 37 · commits (last 12mo) 4</title></rect>
+<rect x="1085.10" y="925.46" width="15.83" height="10.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/shared/time-display.test.tsx
+85 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1100.93" y="925.46" width="14.52" height="10.73" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/src/shared/money-display.tsx
+78 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="1085.10" y="936.19" width="12.24" height="11.91" fill="#eddecb" stroke="white" stroke-width="0.5"><title>frontend/src/shared/status-badge.tsx
+73 loc · ccn 5 · commits (last 12mo) 5</title></rect>
+<rect x="1097.34" y="936.19" width="9.56" height="11.91" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/shared/use-account-resolver.ts
+57 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1106.90" y="936.19" width="8.55" height="11.91" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/detail-skeleton.tsx
+51 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1085.10" y="948.10" width="10.02" height="10.17" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>frontend/src/shared/time-display.tsx
+51 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="1085.10" y="958.27" width="10.02" height="8.97" fill="#e7d9c9" stroke="white" stroke-width="0.5"><title>frontend/src/shared/entity-link.tsx
+45 loc · ccn 16 · commits (last 12mo) 4</title></rect>
+<rect x="1085.10" y="967.24" width="10.02" height="8.97" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/shared/handler-template.test.ts
+45 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1095.12" y="948.10" width="10.71" height="7.27" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/breadcrumbs.tsx
+39 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1105.84" y="948.10" width="9.62" height="7.27" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/shared/error-state.test.tsx
+35 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1095.12" y="955.38" width="7.29" height="9.04" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/shared/direction-badge.test.tsx
+33 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1102.42" y="955.38" width="6.85" height="9.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/shared/page-header.test.tsx
+31 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1109.27" y="955.38" width="6.19" height="9.04" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/error-state.tsx
+28 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1095.12" y="964.42" width="8.13" height="6.63" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/shared/direction-badge.tsx
+27 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="1095.12" y="971.05" width="8.13" height="5.16" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/src/shared/index.ts
+21 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1103.26" y="964.42" width="6.44" height="6.52" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/page-header.tsx
+21 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1103.26" y="970.93" width="6.44" height="5.28" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/page-shell.test.tsx
+17 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1109.69" y="964.42" width="5.76" height="5.20" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/handler-template.ts
+15 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1109.69" y="969.62" width="5.76" height="4.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/page-shell.tsx
+13 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1109.69" y="974.13" width="5.76" height="2.08" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/shared/account-entity-type.ts
+6 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1115.45" y="869.04" width="25.98" height="24.76" fill="#e1cdbb" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-event-stream.test.tsx
+322 loc · ccn 76 · commits (last 12mo) 3</title></rect>
+<rect x="1141.44" y="869.04" width="20.01" height="12.78" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/__tests__/use-tenant-features.test.ts
+128 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1141.44" y="881.82" width="20.01" height="11.98" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/__tests__/use-tenant-layout.test.ts
+120 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1115.45" y="893.80" width="14.93" height="24.35" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-auth.test.tsx
+182 loc · ccn 55 · commits (last 12mo) 1</title></rect>
+<rect x="1115.45" y="918.15" width="14.93" height="19.00" fill="#e1d4c6" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-event-stream.ts
+142 loc · ccn 32 · commits (last 12mo) 3</title></rect>
+<rect x="1130.39" y="893.80" width="19.01" height="12.93" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenants.test.tsx
+123 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1149.39" y="893.80" width="12.05" height="12.93" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-context.test.tsx
+78 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1130.39" y="906.73" width="12.48" height="11.85" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant.ts
+74 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="1130.39" y="918.58" width="12.48" height="10.09" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-oauth-flow.test.tsx
+63 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1130.39" y="928.67" width="12.48" height="8.49" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-info.test.ts
+53 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1142.86" y="906.73" width="10.65" height="8.06" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-auth-providers.test.ts
+43 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1153.52" y="906.73" width="7.93" height="8.06" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-features.ts
+32 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1142.86" y="914.79" width="9.60" height="6.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-layout.ts
+31 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1152.46" y="914.79" width="8.98" height="6.45" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-auth-providers.ts
+29 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1142.86" y="921.24" width="6.91" height="8.10" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-info.ts
+28 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1142.86" y="929.34" width="6.91" height="7.81" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-authenticated-fetch.ts
+27 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1149.77" y="921.24" width="5.98" height="7.01" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenants.ts
+21 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1155.75" y="921.24" width="5.70" height="7.01" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-auth.ts
+20 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1149.77" y="928.26" width="7.19" height="4.45" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-tenant-context.ts
+16 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1149.77" y="932.71" width="7.19" height="4.45" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-document-title.ts
+16 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1156.95" y="928.26" width="4.49" height="4.45" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-page-title.ts
+10 loc · ccn 4 · commits (last 12mo) 2</title></rect>
+<rect x="1156.95" y="932.71" width="4.49" height="4.45" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>frontend/src/hooks/use-oauth-flow.ts
+10 loc · ccn 2 · commits (last 12mo) 3</title></rect>
+<rect x="1161.45" y="869.04" width="40.92" height="36.57" fill="#f7dbb4" stroke="white" stroke-width="0.5"><title>frontend/src/contexts/auth-context.test.tsx
+749 loc · ccn 30 · commits (last 12mo) 7</title></rect>
+<rect x="1161.45" y="905.61" width="18.05" height="31.54" fill="#fdbe87" stroke="white" stroke-width="0.5"><title>frontend/src/contexts/auth-context.tsx
+285 loc · ccn 90 · commits (last 12mo) 15</title></rect>
+<rect x="1179.50" y="905.61" width="22.87" height="24.11" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>frontend/src/contexts/tenant-context.test.tsx
+276 loc · ccn 71 · commits (last 12mo) 2</title></rect>
+<rect x="1179.50" y="929.73" width="22.87" height="7.43" fill="#fddeb4" stroke="white" stroke-width="0.5"><title>frontend/src/contexts/tenant-context.tsx
+85 loc · ccn 25 · commits (last 12mo) 8</title></rect>
+<rect x="1115.45" y="937.15" width="23.84" height="21.45" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>frontend/src/pages/login.test.tsx
+256 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="1115.45" y="958.61" width="23.84" height="17.60" fill="#e1d5c8" stroke="white" stroke-width="0.5"><title>frontend/src/pages/login.tsx
+210 loc · ccn 26 · commits (last 12mo) 3</title></rect>
+<rect x="1139.29" y="937.15" width="20.67" height="15.08" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>frontend/src/pages/oauth-consent.test.tsx
+156 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1139.29" y="952.23" width="20.67" height="10.34" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>frontend/src/pages/oauth-consent.tsx
+107 loc · ccn 34 · commits (last 12mo) 1</title></rect>
+<rect x="1139.29" y="962.58" width="12.90" height="13.63" fill="#dcd5ce" stroke="white" stroke-width="0.5"><title>frontend/src/pages/callback.test.tsx
+88 loc · ccn 19 · commits (last 12mo) 2</title></rect>
+<rect x="1152.19" y="962.58" width="7.77" height="13.63" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>frontend/src/pages/callback.tsx
+53 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1159.96" y="937.15" width="29.11" height="19.84" fill="#fdbe87" stroke="white" stroke-width="0.5"><title>frontend/src/App.tsx
+289 loc · ccn 91 · commits (last 12mo) 66</title></rect>
+<rect x="1159.96" y="956.99" width="11.02" height="13.42" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/src/api/interceptors/auth-interceptor.test.ts
+74 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1159.96" y="970.41" width="7.23" height="5.80" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>frontend/src/api/interceptors/auth-interceptor.ts
+21 loc · ccn 6 · commits (last 12mo) 4</title></rect>
+<rect x="1167.19" y="970.41" width="3.79" height="5.80" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/src/api/interceptors/tenant-interceptor.ts
+11 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1170.98" y="956.99" width="9.40" height="11.27" fill="#eddcc7" stroke="white" stroke-width="0.5"><title>frontend/src/api/config.ts
+53 loc · ccn 13 · commits (last 12mo) 5</title></rect>
+<rect x="1180.38" y="956.99" width="8.69" height="11.27" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>frontend/src/api/clients.ts
+49 loc · ccn 1 · commits (last 12mo) 8</title></rect>
+<rect x="1170.98" y="968.26" width="10.30" height="7.95" fill="#eddecc" stroke="white" stroke-width="0.5"><title>frontend/src/api/context.tsx
+41 loc · ccn 4 · commits (last 12mo) 5</title></rect>
+<rect x="1181.28" y="968.26" width="7.79" height="7.95" fill="#fde7c7" stroke="white" stroke-width="0.5"><title>frontend/src/api/transport.ts
+31 loc · ccn 2 · commits (last 12mo) 8</title></rect>
+<rect x="1189.06" y="937.15" width="13.30" height="34.70" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>frontend/src/index.css
+231 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1189.06" y="971.85" width="7.80" height="4.36" fill="#f2e2cc" stroke="white" stroke-width="0.5"><title>frontend/src/vite-env.d.ts
+17 loc · ccn 1 · commits (last 12mo) 6</title></rect>
+<rect x="1196.86" y="971.85" width="5.04" height="4.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/main.tsx
+11 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1201.91" y="971.85" width="0.46" height="4.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/src/assets/react.svg
+1 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="873.63" y="976.21" width="29.89" height="23.79" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>frontend/e2e/admin-users.spec.ts
+356 loc · ccn 50 · commits (last 12mo) 2</title></rect>
+<rect x="903.52" y="976.21" width="17.63" height="23.79" fill="#fdd7a5" stroke="white" stroke-width="0.5"><title>frontend/e2e/specs/parties.spec.ts
+210 loc · ccn 41 · commits (last 12mo) 9</title></rect>
+<rect x="921.15" y="976.21" width="11.92" height="23.79" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/e2e/specs/party-account-flow.spec.ts
+142 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="933.08" y="976.21" width="21.58" height="23.79" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>frontend/e2e/payments.spec.ts
+257 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="954.66" y="976.21" width="21.08" height="23.79" fill="#f2cfa7" stroke="white" stroke-width="0.5"><title>frontend/e2e/admin-config.spec.ts
+251 loc · ccn 61 · commits (last 12mo) 6</title></rect>
+<rect x="975.73" y="976.21" width="16.96" height="23.79" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/onboarding.spec.ts
+202 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="992.69" y="976.21" width="14.69" height="23.79" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>frontend/e2e/reconciliation.spec.ts
+175 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="1007.39" y="976.21" width="12.60" height="23.79" fill="#e7ceb5" stroke="white" stroke-width="0.5"><title>frontend/e2e/economy.spec.ts
+150 loc · ccn 67 · commits (last 12mo) 4</title></rect>
+<rect x="1019.98" y="976.21" width="12.34" height="23.79" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/visual-consistency.spec.ts
+147 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1032.33" y="976.21" width="12.18" height="23.79" fill="#e1d7cb" stroke="white" stroke-width="0.5"><title>frontend/e2e/ledger.spec.ts
+145 loc · ccn 19 · commits (last 12mo) 3</title></rect>
+<rect x="1044.50" y="976.21" width="21.66" height="12.45" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/e2e/accounts.spec.ts
+135 loc · ccn 15 · commits (last 12mo) 3</title></rect>
+<rect x="1044.50" y="988.66" width="21.66" height="11.34" fill="#e7d9c8" stroke="white" stroke-width="0.5"><title>frontend/e2e/navigation.spec.ts
+123 loc · ccn 17 · commits (last 12mo) 4</title></rect>
+<rect x="1066.17" y="976.21" width="17.63" height="13.48" fill="#e1d7cc" stroke="white" stroke-width="0.5"><title>frontend/e2e/positions.spec.ts
+119 loc · ccn 16 · commits (last 12mo) 3</title></rect>
+<rect x="1066.17" y="989.69" width="17.63" height="10.31" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/auth-flows.spec.ts
+91 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1083.80" y="976.21" width="13.60" height="13.36" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/tenant-branding.spec.ts
+91 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1083.80" y="989.57" width="10.92" height="10.43" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>frontend/e2e/helpers/seed-data.ts
+57 loc · ccn 12 · commits (last 12mo) 2</title></rect>
+<rect x="1094.72" y="989.57" width="2.68" height="10.43" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/helpers/parties.ts
+14 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1097.40" y="976.21" width="8.59" height="16.06" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/e2e/login-redirect.spec.ts
+69 loc · ccn 18 · commits (last 12mo) 1</title></rect>
+<rect x="1105.99" y="976.21" width="8.46" height="16.06" fill="#ecdbc4" stroke="white" stroke-width="0.5"><title>frontend/e2e/dashboard.spec.ts
+68 loc · ccn 19 · commits (last 12mo) 5</title></rect>
+<rect x="1097.40" y="992.26" width="14.20" height="7.74" fill="#e7dacb" stroke="white" stroke-width="0.5"><title>frontend/e2e/fixtures.ts
+55 loc · ccn 11 · commits (last 12mo) 4</title></rect>
+<rect x="1111.61" y="992.26" width="2.84" height="7.74" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/e2e/smoke.spec.ts
+11 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1114.45" y="976.21" width="15.53" height="12.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>frontend/vite-plugins/cookbook-bundler.test.ts
+99 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1114.45" y="988.94" width="15.53" height="11.06" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>frontend/vite-plugins/cookbook-bundler.ts
+86 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1129.98" y="976.21" width="14.44" height="23.79" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/docs/tenant-subdomain-routing.md
+172 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1144.43" y="976.21" width="14.11" height="14.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/eslint-rules/require-page-structure.test.cjs
+101 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1144.43" y="990.51" width="14.11" height="9.49" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>frontend/eslint-rules/require-page-structure.cjs
+67 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1158.53" y="976.21" width="15.79" height="12.28" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>frontend/package.json
+97 loc · ccn 0 · commits (last 12mo) 28</title></rect>
+<rect x="1158.53" y="988.48" width="15.79" height="11.52" fill="#fde4bf" stroke="white" stroke-width="0.5"><title>frontend/vitest.config.ts
+91 loc · ccn 11 · commits (last 12mo) 12</title></rect>
+<rect x="1174.32" y="976.21" width="10.58" height="11.90" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>frontend/eslint.config.js
+63 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1174.32" y="988.10" width="10.58" height="6.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/.stylelintrc.json
+32 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1174.32" y="994.15" width="10.58" height="5.85" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>frontend/vite.config.ts
+31 loc · ccn 1 · commits (last 12mo) 8</title></rect>
+<rect x="1184.90" y="976.21" width="9.50" height="6.52" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/tsconfig.app.json
+31 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1194.40" y="976.21" width="7.97" height="6.52" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>frontend/playwright.config.ts
+26 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="1184.90" y="982.73" width="8.10" height="5.92" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>frontend/tsconfig.node.json
+24 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1184.90" y="988.65" width="8.10" height="5.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/README.md
+23 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1184.90" y="994.32" width="8.10" height="5.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/components.json
+23 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1193.00" y="982.73" width="9.37" height="4.90" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>frontend/scripts/check-ts-prune.sh
+23 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1193.00" y="987.63" width="5.62" height="7.46" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>frontend/index.html
+21 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1198.62" y="987.63" width="3.75" height="7.46" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>frontend/public/favicon.svg
+14 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1193.00" y="995.10" width="5.30" height="4.90" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>frontend/tsconfig.json
+13 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1198.29" y="995.10" width="4.07" height="4.90" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>frontend/buf.gen.yaml
+10 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1202.36" y="527.53" width="24.25" height="33.11" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/pipeline_test.go
+402 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="560.65" width="24.25" height="29.90" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/instrument.go
+363 loc · ccn 65 · commits (last 12mo) 1</title></rect>
+<rect x="1226.62" y="527.53" width="20.19" height="25.73" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/pipeline.go
+260 loc · ccn 51 · commits (last 12mo) 2</title></rect>
+<rect x="1246.81" y="527.53" width="17.55" height="25.73" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/fields_test.go
+226 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1264.36" y="527.53" width="17.24" height="25.73" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/schema_test.go
+222 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1226.62" y="553.26" width="20.95" height="18.69" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/duplicate.go
+196 loc · ccn 30 · commits (last 12mo) 1</title></rect>
+<rect x="1226.62" y="571.95" width="20.95" height="18.59" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/schema.go
+195 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1247.57" y="553.26" width="17.11" height="20.67" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/instrument_test.go
+177 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1264.68" y="553.26" width="16.92" height="20.67" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/fields.go
+175 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="1247.57" y="573.93" width="15.15" height="16.62" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/duplicate_test.go
+126 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1262.72" y="573.93" width="13.10" height="16.62" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/errors.go
+109 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1275.82" y="573.93" width="5.77" height="16.62" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/validation/types.go
+48 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="590.55" width="25.80" height="23.39" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/progress_test.go
+302 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="613.93" width="25.80" height="16.88" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/tenant_test.go
+218 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="1228.16" y="590.55" width="19.05" height="21.81" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/progress.go
+208 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="1228.16" y="612.36" width="19.05" height="18.46" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/cel_evaluator_test.go
+176 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1247.21" y="590.55" width="17.54" height="17.32" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/audit.go
+152 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1264.75" y="590.55" width="16.84" height="17.32" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/batch_inserter_test.go
+146 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1247.21" y="607.86" width="18.37" height="11.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/audit_test.go
+108 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1247.21" y="619.61" width="18.37" height="11.20" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/batch_inserter.go
+103 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1265.58" y="607.86" width="16.02" height="12.35" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/tenant.go
+99 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1265.58" y="620.21" width="15.83" height="10.60" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/cel_evaluator.go
+84 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1281.40" y="620.21" width="0.19" height="10.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/infra/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1281.59" y="527.53" width="38.94" height="26.78" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/adapters/csv/parser_test.go
+522 loc · ccn 63 · commits (last 12mo) 3</title></rect>
+<rect x="1281.59" y="554.32" width="23.41" height="35.76" fill="#e1cbba" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/adapters/csv/parser.go
+419 loc · ccn 85 · commits (last 12mo) 3</title></rect>
+<rect x="1305.00" y="554.32" width="15.53" height="28.56" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/adapters/csv/attribute_extractor_test.go
+222 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1305.00" y="582.87" width="15.53" height="7.20" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/adapters/csv/attribute_extractor.go
+56 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1320.53" y="527.53" width="38.59" height="23.09" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/exporter/exporter_test.go
+446 loc · ccn 26 · commits (last 12mo) 1</title></rect>
+<rect x="1320.53" y="550.62" width="38.59" height="21.33" fill="#e1cbba" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/exporter/exporter.go
+412 loc · ccn 81 · commits (last 12mo) 3</title></rect>
+<rect x="1320.53" y="571.95" width="22.49" height="18.12" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/exporter/csv_writer_test.go
+204 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1343.02" y="571.95" width="16.10" height="18.12" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/exporter/csv_writer.go
+146 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="1281.59" y="590.07" width="21.23" height="40.74" fill="#dcd0c7" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/checkpoint/manager_test.go
+433 loc · ccn 58 · commits (last 12mo) 2</title></rect>
+<rect x="1302.83" y="590.07" width="25.55" height="29.32" fill="#e7d2b9" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/checkpoint/manager.go
+375 loc · ccn 52 · commits (last 12mo) 4</title></rect>
+<rect x="1302.83" y="619.40" width="25.37" height="11.42" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/checkpoint/manager_helpers.go
+145 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1328.20" y="619.40" width="0.17" height="11.42" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/checkpoint/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1328.37" y="590.07" width="30.75" height="22.55" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/rebucket/executor.go
+347 loc · ccn 46 · commits (last 12mo) 2</title></rect>
+<rect x="1328.37" y="612.62" width="30.75" height="18.19" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/internal/rebucket/executor_test.go
+280 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1359.12" y="527.53" width="25.69" height="41.38" fill="#e1cebd" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/rebucket.go
+532 loc · ccn 69 · commits (last 12mo) 3</title></rect>
+<rect x="1384.81" y="527.53" width="24.62" height="41.38" fill="#f7c595" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/import.go
+510 loc · ccn 81 · commits (last 12mo) 7</title></rect>
+<rect x="1359.12" y="568.91" width="21.83" height="27.64" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/export.go
+302 loc · ccn 41 · commits (last 12mo) 1</title></rect>
+<rect x="1380.95" y="568.91" width="22.19" height="14.22" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/import_resume_integration_test.go
+158 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1380.95" y="583.13" width="22.19" height="13.41" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/root.go
+149 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1403.14" y="568.91" width="6.29" height="27.64" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/position-tool/cmd/import_registry.go
+87 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1359.12" y="596.55" width="42.32" height="34.27" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>cmd/position-tool/integration_test.go
+726 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="1401.44" y="596.55" width="7.99" height="25.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/testdata/valid.csv
+100 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1401.44" y="621.56" width="7.99" height="5.25" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/testdata/with_errors.csv
+21 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1401.44" y="626.81" width="7.99" height="2.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/testdata/with_duplicates.csv
+11 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1401.44" y="629.56" width="7.99" height="1.25" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/position-tool/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="630.82" width="24.57" height="15.70" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/pipeline_test.go
+193 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1226.93" y="630.82" width="21.38" height="15.70" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/schema_validator_test.go
+168 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="646.51" width="17.81" height="16.04" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/pipeline.go
+143 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="1202.36" y="662.55" width="17.81" height="14.35" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/schema_validator.go
+128 loc · ccn 33 · commits (last 12mo) 1</title></rect>
+<rect x="1220.18" y="646.51" width="14.36" height="13.78" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/fields_test.go
+99 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1234.54" y="646.51" width="13.78" height="13.78" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/errors.go
+95 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1220.18" y="660.29" width="10.46" height="16.62" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/dataset_checker_test.go
+87 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1230.64" y="660.29" width="9.38" height="16.62" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/dataset_checker.go
+78 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1240.02" y="660.29" width="8.30" height="12.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/fields.go
+50 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1240.02" y="672.33" width="8.30" height="4.58" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/validation/types.go
+19 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="676.90" width="15.49" height="29.91" fill="#d6d2d0" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/grpc_client.go
+232 loc · ccn 37 · commits (last 12mo) 1</title></rect>
+<rect x="1217.86" y="676.90" width="13.62" height="15.69" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/batch_inserter.go
+107 loc · ccn 16 · commits (last 12mo) 1</title></rect>
+<rect x="1217.86" y="692.59" width="13.62" height="14.22" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/batch_inserter_test.go
+97 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1231.48" y="676.90" width="16.83" height="11.04" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/cel_preview.go
+93 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1231.48" y="687.94" width="9.26" height="14.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/cel_preview_test.go
+66 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1240.74" y="687.94" width="7.57" height="14.24" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/checkpoint_adapter.go
+54 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1231.48" y="702.19" width="16.40" height="4.63" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/checkpoint_adapter_test.go
+38 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1247.88" y="702.19" width="0.43" height="4.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/infra/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1248.31" y="630.82" width="30.23" height="27.29" fill="#dccec5" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/adapters/csv/parser.go
+413 loc · ccn 73 · commits (last 12mo) 2</title></rect>
+<rect x="1248.31" y="658.11" width="30.23" height="16.52" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/adapters/csv/parser_test.go
+250 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1248.31" y="674.63" width="30.23" height="25.77" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/checkpoint/checkpoint.go
+390 loc · ccn 54 · commits (last 12mo) 1</title></rect>
+<rect x="1248.31" y="700.41" width="30.23" height="6.41" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/internal/checkpoint/checkpoint_test.go
+97 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="706.82" width="25.57" height="37.34" fill="#e1cfbe" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/cmd/import.go
+478 loc · ccn 63 · commits (last 12mo) 3</title></rect>
+<rect x="1227.94" y="706.82" width="15.55" height="27.75" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/cmd/schema.go
+216 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1243.49" y="706.82" width="15.48" height="27.75" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/cmd/validate.go
+215 loc · ccn 25 · commits (last 12mo) 2</title></rect>
+<rect x="1227.94" y="734.57" width="31.03" height="9.59" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/cmd/root.go
+149 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1258.96" y="706.82" width="19.58" height="36.83" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/integration_test.go
+361 loc · ccn 32 · commits (last 12mo) 2</title></rect>
+<rect x="1258.96" y="743.65" width="19.58" height="0.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/market-data-tool/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1278.54" y="630.82" width="31.88" height="27.01" fill="#fdca94" stroke="white" stroke-width="0.5"><title>cmd/meridian/main.go
+431 loc · ccn 69 · commits (last 12mo) 64</title></rect>
+<rect x="1278.54" y="657.82" width="31.88" height="23.87" fill="#f2d5b1" stroke="white" stroke-width="0.5"><title>cmd/meridian/wire_grpc.go
+381 loc · ccn 41 · commits (last 12mo) 6</title></rect>
+<rect x="1278.54" y="681.70" width="31.88" height="22.68" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>cmd/meridian/mcp_oauth_wiring_test.go
+362 loc · ccn 22 · commits (last 12mo) 1</title></rect>
+<rect x="1310.42" y="630.82" width="24.99" height="21.51" fill="#fdd9a9" stroke="white" stroke-width="0.5"><title>cmd/meridian/gateway.go
+269 loc · ccn 37 · commits (last 12mo) 12</title></rect>
+<rect x="1335.41" y="630.82" width="23.13" height="21.51" fill="#ecd7bd" stroke="white" stroke-width="0.5"><title>cmd/meridian/registration_wiring_test.go
+249 loc · ccn 31 · commits (last 12mo) 5</title></rect>
+<rect x="1310.42" y="652.32" width="24.93" height="17.23" fill="#ecd5b8" stroke="white" stroke-width="0.5"><title>cmd/meridian/connections.go
+215 loc · ccn 40 · commits (last 12mo) 5</title></rect>
+<rect x="1335.35" y="652.32" width="23.19" height="17.23" fill="#fdddb2" stroke="white" stroke-width="0.5"><title>cmd/meridian/wire_services.go
+200 loc · ccn 27 · commits (last 12mo) 12</title></rect>
+<rect x="1310.42" y="669.55" width="17.38" height="20.23" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>cmd/meridian/wire_gateway.go
+176 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="1310.42" y="689.78" width="17.38" height="14.60" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/meridian/lock_test.go
+127 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1327.80" y="669.55" width="16.97" height="10.59" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/meridian/party_email_resolver_test.go
+90 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1344.78" y="669.55" width="13.77" height="10.59" fill="#fde6c3" stroke="white" stroke-width="0.5"><title>cmd/meridian/gateway_test.go
+73 loc · ccn 7 · commits (last 12mo) 8</title></rect>
+<rect x="1327.80" y="680.14" width="8.74" height="13.03" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>cmd/meridian/descriptors_test.go
+57 loc · ccn 7 · commits (last 12mo) 4</title></rect>
+<rect x="1327.80" y="693.18" width="8.74" height="11.20" fill="#fde6c5" stroke="white" stroke-width="0.5"><title>cmd/meridian/Dockerfile
+49 loc · ccn 6 · commits (last 12mo) 10</title></rect>
+<rect x="1336.54" y="680.14" width="11.48" height="8.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/meridian/wire_adapters.go
+48 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1348.02" y="680.14" width="10.52" height="8.35" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/meridian/connections_test.go
+44 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1336.54" y="688.49" width="10.56" height="8.13" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>cmd/meridian/lock.go
+43 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1336.54" y="696.63" width="10.56" height="7.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/meridian/party_wrapper.go
+41 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1347.10" y="688.49" width="11.44" height="6.81" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/meridian/party_email_resolver.go
+39 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1347.10" y="695.30" width="5.50" height="9.08" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/meridian/wire_identity.go
+25 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1352.60" y="695.30" width="5.94" height="7.06" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>cmd/meridian/compilation_test.go
+21 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1352.60" y="702.36" width="5.94" height="2.02" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/meridian/descriptors.go
+6 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1278.54" y="704.38" width="29.08" height="39.78" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/register_test.go
+579 loc · ccn 61 · commits (last 12mo) 1</title></rect>
+<rect x="1307.62" y="704.38" width="13.81" height="19.96" fill="#e7d7c4" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/list.go
+138 loc · ccn 27 · commits (last 12mo) 4</title></rect>
+<rect x="1307.62" y="724.34" width="13.81" height="19.82" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/register.go
+137 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="1321.43" y="704.38" width="15.16" height="15.68" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/get.go
+119 loc · ccn 23 · commits (last 12mo) 2</title></rect>
+<rect x="1336.60" y="704.38" width="13.76" height="15.68" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/list_test.go
+108 loc · ccn 7 · commits (last 12mo) 1</title></rect>
+<rect x="1321.43" y="720.06" width="16.41" height="12.78" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/status.go
+105 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1321.43" y="732.84" width="16.41" height="11.32" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/root.go
+93 loc · ccn 14 · commits (last 12mo) 2</title></rect>
+<rect x="1337.84" y="720.06" width="12.52" height="13.25" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/root_test.go
+83 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1337.84" y="733.31" width="12.52" height="10.85" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/cmd/deprovision.go
+68 loc · ccn 10 · commits (last 12mo) 1</title></rect>
+<rect x="1350.36" y="704.38" width="8.19" height="24.16" fill="#eddcc6" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/client/tenant_client.go
+99 loc · ccn 14 · commits (last 12mo) 5</title></rect>
+<rect x="1350.36" y="728.54" width="8.19" height="14.40" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/client/tenant_client_test.go
+59 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1350.36" y="742.94" width="8.19" height="1.22" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/tenantctl/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1358.55" y="630.82" width="28.33" height="31.53" fill="#ecc6a6" stroke="white" stroke-width="0.5"><title>cmd/seed-dev/cmd/fixtures.go
+447 loc · ccn 87 · commits (last 12mo) 5</title></rect>
+<rect x="1386.87" y="630.82" width="22.56" height="31.53" fill="#fdce98" stroke="white" stroke-width="0.5"><title>cmd/seed-dev/cmd/root.go
+356 loc · ccn 61 · commits (last 12mo) 10</title></rect>
+<rect x="1358.55" y="662.34" width="33.99" height="19.87" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>cmd/seed-dev/cmd/payg_fixtures.go
+338 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="1392.54" y="662.34" width="16.89" height="19.87" fill="#e7d6c3" stroke="white" stroke-width="0.5"><title>cmd/seed-dev/cmd/root_test.go
+168 loc · ccn 29 · commits (last 12mo) 4</title></rect>
+<rect x="1358.55" y="682.21" width="50.89" height="0.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/seed-dev/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1358.55" y="682.40" width="28.49" height="33.80" fill="#dccdc3" stroke="white" stroke-width="0.5"><title>cmd/instrument-cli/cmd/simulate.go
+482 loc · ccn 85 · commits (last 12mo) 2</title></rect>
+<rect x="1387.03" y="682.40" width="22.10" height="24.86" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>cmd/instrument-cli/cmd/simulate_test.go
+275 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1387.03" y="707.26" width="22.10" height="8.95" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>cmd/instrument-cli/cmd/root.go
+99 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1409.14" y="682.40" width="0.30" height="33.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/instrument-cli/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1358.55" y="716.21" width="27.59" height="16.44" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/meridian-cli/cmd/saga_validate_test.go
+227 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1358.55" y="732.65" width="20.60" height="11.15" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>cmd/meridian-cli/cmd/saga_validate.go
+115 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1379.15" y="732.65" width="6.99" height="8.29" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>cmd/meridian-cli/cmd/root.go
+29 loc · ccn 2 · commits (last 12mo) 1</title></rect>
+<rect x="1379.15" y="740.94" width="6.99" height="2.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/meridian-cli/cmd/saga.go
+10 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1358.55" y="743.80" width="27.59" height="0.36" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cmd/meridian-cli/main.go
+5 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1386.13" y="716.21" width="23.30" height="22.72" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>cmd/ibactl/cmd/provision_defaults.go
+265 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="1386.13" y="738.93" width="23.30" height="4.80" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>cmd/ibactl/cmd/root.go
+56 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1386.13" y="743.73" width="23.30" height="0.43" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>cmd/ibactl/main.go
+5 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1409.43" y="527.53" width="54.32" height="30.89" fill="#dccfc5" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/manifest_test.go
+840 loc · ccn 71 · commits (last 12mo) 2</title></rect>
+<rect x="1409.43" y="558.43" width="14.56" height="19.62" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/examples/saas_billing.manifest.json
+143 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1423.99" y="558.43" width="13.24" height="19.62" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/examples/carbon_credits.manifest.json
+130 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1409.43" y="578.05" width="14.02" height="16.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/examples/energy_trading.manifest.json
+114 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1423.45" y="578.05" width="13.78" height="16.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/examples/precious_metals.manifest.json
+112 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1437.23" y="558.43" width="26.52" height="35.86" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/manifest.proto
+476 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1409.43" y="594.29" width="17.96" height="22.47" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/manifest_history_service.proto
+202 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1427.39" y="594.29" width="12.80" height="22.47" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/admin.proto
+144 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1440.19" y="594.29" width="19.38" height="12.78" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/apply_manifest_service.proto
+124 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1440.19" y="607.07" width="19.38" height="9.69" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/economy_generator_service.proto
+94 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1459.57" y="594.29" width="4.18" height="14.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/saga_execution_service.proto
+30 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1459.57" y="608.63" width="4.18" height="8.13" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/control_plane/v1/auth.proto
+17 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1409.43" y="616.76" width="31.74" height="39.65" fill="#e7c5ac" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/financial_accounting_events_test.go
+630 loc · ccn 100 · commits (last 12mo) 4</title></rect>
+<rect x="1441.18" y="616.76" width="22.57" height="39.65" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/current_account_events.proto
+448 loc · ccn 3 · commits (last 12mo) 5</title></rect>
+<rect x="1409.43" y="656.41" width="25.45" height="26.69" fill="#f2e2cb" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/financial_accounting_events.proto
+340 loc · ccn 3 · commits (last 12mo) 6</title></rect>
+<rect x="1409.43" y="683.10" width="25.45" height="21.90" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/payment_order_events.proto
+279 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1434.88" y="656.41" width="28.87" height="15.57" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/position_keeping_events.proto
+225 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1434.88" y="671.98" width="16.96" height="20.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/reconciliation_events.proto
+171 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1451.85" y="671.98" width="11.90" height="20.14" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/party_events.proto
+120 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1434.88" y="692.12" width="16.61" height="12.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/operational_gateway_events.proto
+107 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1451.49" y="692.12" width="12.26" height="9.13" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/internal_account_events.proto
+56 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1451.49" y="701.25" width="12.26" height="3.75" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/events/v1/deposit_event.proto
+23 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1463.75" y="527.53" width="51.59" height="38.26" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>api/proto/meridian/market_information/v1/market_information_test.go
+988 loc · ccn 50 · commits (last 12mo) 1</title></rect>
+<rect x="1463.75" y="565.79" width="51.59" height="22.38" fill="#e1d9d1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/market_information/v1/market_information.proto
+578 loc · ccn 1 · commits (last 12mo) 3</title></rect>
+<rect x="1515.34" y="527.53" width="43.81" height="37.48" fill="#fde6c5" stroke="white" stroke-width="0.5"><title>api/proto/meridian/current_account/v1/current_account.proto
+822 loc · ccn 6 · commits (last 12mo) 30</title></rect>
+<rect x="1515.34" y="565.01" width="43.81" height="23.16" fill="#fdd09a" stroke="white" stroke-width="0.5"><title>api/proto/meridian/current_account/v1/current_account_test.go
+508 loc · ccn 56 · commits (last 12mo) 8</title></rect>
+<rect x="1559.15" y="527.53" width="37.85" height="31.61" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>api/proto/meridian/reference_data/v1/instrument_test.go
+599 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="1559.15" y="559.15" width="17.34" height="29.03" fill="#e1d8ce" stroke="white" stroke-width="0.5"><title>api/proto/meridian/reference_data/v1/account_type.proto
+252 loc · ccn 9 · commits (last 12mo) 3</title></rect>
+<rect x="1576.50" y="559.15" width="20.51" height="17.83" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/reference_data/v1/instrument.proto
+183 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1576.50" y="576.97" width="20.51" height="11.20" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/reference_data/v1/node.proto
+115 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1463.75" y="588.18" width="26.87" height="41.70" fill="#fdc993" stroke="white" stroke-width="0.5"><title>api/proto/meridian/financial_accounting/v1/financial_accounting_test.go
+561 loc · ccn 70 · commits (last 12mo) 8</title></rect>
+<rect x="1490.62" y="588.18" width="16.48" height="41.70" fill="#fde7c7" stroke="white" stroke-width="0.5"><title>api/proto/meridian/financial_accounting/v1/financial_accounting.proto
+344 loc · ccn 3 · commits (last 12mo) 15</title></rect>
+<rect x="1463.75" y="629.88" width="30.74" height="40.23" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>api/proto/meridian/position_keeping/v1/position_keeping.proto
+619 loc · ccn 1 · commits (last 12mo) 19</title></rect>
+<rect x="1494.49" y="629.88" width="12.61" height="40.23" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>api/proto/meridian/position_keeping/v1/position_keeping_test.go
+254 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="1463.75" y="670.11" width="43.35" height="34.88" fill="#fee8c8" stroke="white" stroke-width="0.5"><title>api/proto/meridian/party/v1/party.proto
+757 loc · ccn 1 · commits (last 12mo) 11</title></rect>
+<rect x="1507.10" y="588.18" width="31.32" height="38.02" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>api/proto/meridian/internal_account/v1/internal_account.proto
+596 loc · ccn 4 · commits (last 12mo) 3</title></rect>
+<rect x="1538.42" y="588.18" width="31.26" height="38.02" fill="#eddfcd" stroke="white" stroke-width="0.5"><title>api/proto/meridian/reconciliation/v1/reconciliation.proto
+595 loc · ccn 1 · commits (last 12mo) 5</title></rect>
+<rect x="1569.68" y="588.18" width="27.32" height="38.02" fill="#e1d9d0" stroke="white" stroke-width="0.5"><title>api/proto/meridian/operational_gateway/v1/operational_gateway.proto
+520 loc · ccn 3 · commits (last 12mo) 3</title></rect>
+<rect x="1507.10" y="626.20" width="34.78" height="27.85" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>api/proto/meridian/identity/v1/identity.proto
+485 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1507.10" y="654.05" width="32.56" height="26.94" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>api/proto/meridian/quantity/v1/quantity_test.go
+439 loc · ccn 43 · commits (last 12mo) 1</title></rect>
+<rect x="1539.66" y="654.05" width="2.23" height="26.94" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/quantity/v1/quantity.proto
+30 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1507.10" y="680.99" width="34.78" height="24.01" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/billing/v1/billing.proto
+418 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1541.89" y="626.20" width="29.79" height="24.14" fill="#f2e1ca" stroke="white" stroke-width="0.5"><title>api/proto/meridian/payment_order/v1/payment_order.proto
+360 loc · ccn 4 · commits (last 12mo) 6</title></rect>
+<rect x="1571.68" y="626.20" width="21.85" height="24.14" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/saga/v1/saga_registry.proto
+264 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1593.53" y="626.20" width="3.48" height="24.14" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/saga/v1/saga_admin.proto
+42 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1541.89" y="650.34" width="20.65" height="15.09" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>api/proto/meridian/common/v1/types_validation_test.go
+156 loc · ccn 18 · commits (last 12mo) 2</title></rect>
+<rect x="1541.89" y="665.43" width="9.36" height="13.45" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>api/proto/meridian/common/v1/types.proto
+63 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1551.25" y="665.43" width="11.29" height="9.38" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/common/v1/error.proto
+53 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1551.25" y="674.81" width="11.29" height="4.07" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/common/v1/health.proto
+23 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1541.89" y="678.87" width="20.65" height="26.12" fill="#fde6c3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/tenant/v1/tenant.proto
+270 loc · ccn 7 · commits (last 12mo) 9</title></rect>
+<rect x="1562.54" y="650.34" width="18.13" height="26.78" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/mapping/v1/mapping.proto
+243 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1580.67" y="650.34" width="16.34" height="26.78" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/correspondence/v1/correspondence.proto
+219 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1562.54" y="677.12" width="18.34" height="16.55" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/meridian/financial_gateway/v1/financial_gateway.proto
+152 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1562.54" y="693.67" width="11.11" height="11.33" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/audit/v1/audit_events.proto
+63 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1573.65" y="693.67" width="7.23" height="11.33" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/audit/v1/audit_service.proto
+41 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1580.88" y="677.12" width="16.12" height="11.03" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/valuation_feature/v1/valuation_feature.proto
+89 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1580.88" y="688.14" width="16.12" height="10.04" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/financial_gateway_events/v1/events.proto
+81 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1580.88" y="698.18" width="8.50" height="6.82" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/proto/meridian/forecasting/v1/forecasting.proto
+29 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1589.38" y="698.18" width="7.62" height="6.82" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>api/proto/meridian/platform/v1/idempotency.proto
+26 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1597.01" y="527.53" width="2.99" height="148.77" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>api/proto/README.md
+223 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1597.01" y="676.31" width="2.99" height="28.69" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/proto/buf.yaml
+43 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1409.43" y="704.99" width="26.37" height="39.17" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/position-keeping.yaml
+517 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1435.80" y="704.99" width="22.60" height="39.17" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/payment-order.yaml
+443 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1458.40" y="704.99" width="30.40" height="22.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/reconciliation.yaml
+348 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1458.40" y="727.86" width="30.40" height="16.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/current-account.yaml
+248 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1488.80" y="704.99" width="23.62" height="15.31" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/party.yaml
+181 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1488.80" y="720.31" width="16.01" height="15.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/internal-account.yaml
+122 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1504.81" y="720.31" width="7.61" height="15.23" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/audit.yaml
+58 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1488.80" y="735.53" width="11.81" height="8.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/financial-accounting.yaml
+51 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1500.61" y="735.53" width="11.81" height="8.63" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>api/asyncapi/market-information.yaml
+51 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1512.42" y="704.99" width="81.31" height="39.17" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>api/jsonschema/manifest.v1.schema.json
+1594 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1593.73" y="704.99" width="6.27" height="39.17" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>api/openapi/swagger-ui.html
+123 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1202.36" y="744.16" width="37.08" height="32.81" fill="#ecd1b1" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/infra_test.go
+609 loc · ccn 54 · commits (last 12mo) 5</title></rect>
+<rect x="1202.36" y="776.97" width="37.08" height="31.35" fill="#dccbc1" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/repositories_test.go
+582 loc · ccn 96 · commits (last 12mo) 2</title></rect>
+<rect x="1239.45" y="744.16" width="33.52" height="30.70" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/phase2_features_test.go
+515 loc · ccn 22 · commits (last 12mo) 2</title></rect>
+<rect x="1272.97" y="744.16" width="26.36" height="30.70" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/grpc_errors_test.go
+405 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1239.45" y="774.86" width="26.80" height="18.04" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/settlement_lifecycle_test.go
+242 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1239.45" y="792.89" width="26.80" height="15.43" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/balance_assertion_test.go
+207 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1266.25" y="774.86" width="16.96" height="23.80" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/settlement_grpc_test.go
+202 loc · ccn 8 · commits (last 12mo) 1</title></rect>
+<rect x="1283.21" y="774.86" width="16.12" height="23.80" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/events_test.go
+192 loc · ccn 5 · commits (last 12mo) 3</title></rect>
+<rect x="1266.25" y="798.65" width="32.87" height="9.66" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/dispute_workflow_test.go
+159 loc · ccn 5 · commits (last 12mo) 3</title></rect>
+<rect x="1299.12" y="798.65" width="0.21" height="9.66" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>tests/reconciliation-e2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1299.33" y="744.16" width="31.79" height="47.14" fill="#f7b384" stroke="white" stroke-width="0.5"><title>tests/integration/balance_ownership_test.go
+750 loc · ccn 110 · commits (last 12mo) 7</title></rect>
+<rect x="1331.11" y="744.16" width="31.36" height="47.14" fill="#e7cbb3" stroke="white" stroke-width="0.5"><title>tests/integration/stress_test.go
+740 loc · ccn 75 · commits (last 12mo) 4</title></rect>
+<rect x="1299.33" y="791.30" width="63.03" height="17.02" fill="#e1cebd" stroke="white" stroke-width="0.5"><title>tests/integration/error_handling_test.go
+537 loc · ccn 69 · commits (last 12mo) 3</title></rect>
+<rect x="1362.36" y="791.30" width="0.12" height="17.02" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>tests/integration/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1202.36" y="808.32" width="28.24" height="31.34" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/infra_test.go
+443 loc · ccn 35 · commits (last 12mo) 3</title></rect>
+<rect x="1202.36" y="839.66" width="28.24" height="21.72" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/payment_settlement_test.go
+307 loc · ccn 13 · commits (last 12mo) 3</title></rect>
+<rect x="1230.60" y="808.32" width="19.69" height="29.32" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/error_handling_test.go
+289 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="1250.30" y="808.32" width="17.24" height="29.32" fill="#dcd6d0" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/multi_asset_test.go
+253 loc · ccn 10 · commits (last 12mo) 2</title></rect>
+<rect x="1230.60" y="837.64" width="18.85" height="23.74" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/withdrawal_flow_test.go
+224 loc · ccn 8 · commits (last 12mo) 2</title></rect>
+<rect x="1249.45" y="837.64" width="18.09" height="23.63" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/deposit_flow_test.go
+214 loc · ccn 15 · commits (last 12mo) 2</title></rect>
+<rect x="1249.45" y="861.27" width="18.09" height="0.11" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>tests/clearinge2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1202.36" y="861.38" width="32.93" height="46.29" fill="#ecbe9e" stroke="white" stroke-width="0.5"><title>tests/multi_tenant/e2e_test.go
+763 loc · ccn 105 · commits (last 12mo) 5</title></rect>
+<rect x="1235.30" y="861.38" width="32.24" height="46.29" fill="#e6bda5" stroke="white" stroke-width="0.5"><title>tests/multi_tenant/isolation_test.go
+747 loc · ccn 114 · commits (last 12mo) 4</title></rect>
+<rect x="1267.54" y="808.32" width="28.83" height="23.35" fill="#e1d2c1" stroke="white" stroke-width="0.5"><title>tests/proto/validation_test.go
+337 loc · ccn 47 · commits (last 12mo) 3</title></rect>
+<rect x="1267.54" y="831.67" width="28.83" height="14.00" fill="#e1d3c4" stroke="white" stroke-width="0.5"><title>tests/proto/serialization_test.go
+202 loc · ccn 40 · commits (last 12mo) 3</title></rect>
+<rect x="1296.37" y="808.32" width="19.74" height="16.09" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>tests/proto/grpc_interfaces_test.go
+159 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1296.37" y="824.41" width="19.74" height="12.35" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>tests/proto/validation_bench_test.go
+122 loc · ccn 26 · commits (last 12mo) 2</title></rect>
+<rect x="1296.37" y="836.76" width="19.74" height="8.91" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>tests/proto/compilation_test.go
+88 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1316.10" y="808.32" width="29.63" height="19.69" fill="#dcccc2" stroke="white" stroke-width="0.5"><title>tests/architecture/naming_test.go
+292 loc · ccn 94 · commits (last 12mo) 2</title></rect>
+<rect x="1316.10" y="828.01" width="29.63" height="17.66" fill="#fdcd97" stroke="white" stroke-width="0.5"><title>tests/architecture/layers_test.go
+262 loc · ccn 62 · commits (last 12mo) 12</title></rect>
+<rect x="1345.73" y="808.32" width="16.74" height="15.16" fill="#fddcb0" stroke="white" stroke-width="0.5"><title>tests/architecture/size_test.go
+127 loc · ccn 30 · commits (last 12mo) 28</title></rect>
+<rect x="1345.73" y="823.48" width="16.74" height="14.08" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>tests/architecture/structure_test.go
+118 loc · ccn 27 · commits (last 12mo) 1</title></rect>
+<rect x="1345.73" y="837.56" width="16.74" height="8.11" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>tests/architecture/helpers_test.go
+68 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1267.54" y="845.67" width="49.08" height="31.18" fill="#dcccc3" stroke="white" stroke-width="0.5"><title>tests/mapping-e2e/mapping_e2e_test.go
+766 loc · ccn 87 · commits (last 12mo) 2</title></rect>
+<rect x="1267.54" y="876.85" width="31.06" height="30.81" fill="#dcd3cc" stroke="white" stroke-width="0.5"><title>tests/identity-e2e/auth_flow_test.go
+479 loc · ccn 30 · commits (last 12mo) 2</title></rect>
+<rect x="1298.59" y="876.85" width="18.02" height="30.70" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>tests/identity-e2e/bff_auth_flow_test.go
+277 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1298.59" y="907.56" width="18.02" height="0.11" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>tests/identity-e2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1316.62" y="845.67" width="34.46" height="29.28" fill="#e1d4c5" stroke="white" stroke-width="0.5"><title>tests/audit-e2e/audit_writer_e2e_test.go
+505 loc · ccn 37 · commits (last 12mo) 3</title></rect>
+<rect x="1351.08" y="845.67" width="11.40" height="29.10" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>tests/audit-e2e/README.md
+166 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1351.08" y="874.77" width="11.40" height="0.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>tests/audit-e2e/doc.go
+1 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1316.62" y="874.95" width="39.14" height="32.72" fill="#ecc6a6" stroke="white" stroke-width="0.5"><title>tests/load/bucket_cardinality_test.go
+641 loc · ccn 88 · commits (last 12mo) 5</title></rect>
+<rect x="1355.76" y="874.95" width="6.72" height="32.72" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>tests/contracts/aaa_contract_test.go
+110 loc · ccn 16 · commits (last 12mo) 2</title></rect>
+<rect x="1202.36" y="907.67" width="39.42" height="56.40" fill="#f1b28b" stroke="white" stroke-width="0.5"><title>scripts/demo.sh
+1113 loc · ccn 118 · commits (last 12mo) 6</title></rect>
+<rect x="1202.36" y="964.07" width="39.42" height="35.93" fill="#fdc891" stroke="white" stroke-width="0.5"><title>scripts/doctor.sh
+709 loc · ccn 73 · commits (last 12mo) 8</title></rect>
+<rect x="1241.79" y="907.67" width="30.07" height="25.51" fill="#d6cdcb" stroke="white" stroke-width="0.5"><title>scripts/analyze-coupling.sh
+384 loc · ccn 105 · commits (last 12mo) 1</title></rect>
+<rect x="1241.79" y="933.17" width="30.07" height="22.85" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>scripts/gen-asyncapi.sh
+344 loc · ccn 44 · commits (last 12mo) 1</title></rect>
+<rect x="1241.79" y="956.03" width="12.93" height="22.72" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>scripts/kafka-tests/failover-test.sh
+147 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1254.71" y="956.03" width="17.15" height="14.10" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>scripts/kafka-tests/README.md
+121 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1254.71" y="970.12" width="17.15" height="8.62" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>scripts/kafka-tests/cluster-health.sh
+74 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1241.79" y="978.74" width="30.07" height="21.26" fill="#e1d8cd" stroke="white" stroke-width="0.5"><title>scripts/demo-cross-org-settlement.sh
+320 loc · ccn 11 · commits (last 12mo) 3</title></rect>
+<rect x="1271.86" y="907.67" width="24.92" height="24.69" fill="#dcd1c8" stroke="white" stroke-width="0.5"><title>scripts/demo-validation.sh
+308 loc · ccn 49 · commits (last 12mo) 2</title></rect>
+<rect x="1296.78" y="907.67" width="23.30" height="24.69" fill="#e7d0b8" stroke="white" stroke-width="0.5"><title>scripts/verify-service-conventions.sh
+288 loc · ccn 56 · commits (last 12mo) 4</title></rect>
+<rect x="1320.08" y="907.67" width="21.28" height="24.69" fill="#dcd4ce" stroke="white" stroke-width="0.5"><title>scripts/keycloak-setup.sh
+263 loc · ccn 21 · commits (last 12mo) 2</title></rect>
+<rect x="1341.36" y="907.67" width="21.12" height="24.69" fill="#d6d1ce" stroke="white" stroke-width="0.5"><title>scripts/service-coverage.ts
+261 loc · ccn 53 · commits (last 12mo) 1</title></rect>
+<rect x="1271.86" y="932.36" width="18.19" height="27.12" fill="#e7d7c5" stroke="white" stroke-width="0.5"><title>scripts/demo-seed-data.sh
+247 loc · ccn 25 · commits (last 12mo) 4</title></rect>
+<rect x="1271.86" y="959.48" width="18.19" height="22.07" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>scripts/doctor_test.sh
+201 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1271.86" y="981.55" width="18.19" height="18.45" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>scripts/generate-coupling-mermaid.sh
+168 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1290.05" y="932.36" width="18.55" height="17.88" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>scripts/README.md
+166 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1290.05" y="950.24" width="18.55" height="17.23" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>scripts/migrate-all-orgs.sh
+160 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1290.05" y="967.47" width="18.55" height="16.37" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/demo-provision-organizations.sh
+152 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1290.05" y="983.84" width="18.55" height="16.16" fill="#d6d0ce" stroke="white" stroke-width="0.5"><title>scripts/lint-multi-asset-purity.sh
+150 loc · ccn 61 · commits (last 12mo) 1</title></rect>
+<rect x="1308.60" y="932.36" width="18.98" height="15.58" fill="#e1d5c7" stroke="white" stroke-width="0.5"><title>scripts/test-database-setup.sh
+148 loc · ccn 30 · commits (last 12mo) 3</title></rect>
+<rect x="1327.59" y="932.36" width="17.57" height="15.58" fill="#edddc9" stroke="white" stroke-width="0.5"><title>scripts/reset-develop.sh
+137 loc · ccn 8 · commits (last 12mo) 5</title></rect>
+<rect x="1345.16" y="932.36" width="17.32" height="15.58" fill="#f2e0c7" stroke="white" stroke-width="0.5"><title>scripts/reset-demo.sh
+135 loc · ccn 8 · commits (last 12mo) 6</title></rect>
+<rect x="1308.60" y="947.93" width="13.35" height="18.40" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>scripts/calculate-coupling-metrics.sh
+123 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1308.60" y="966.34" width="13.35" height="17.50" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/test-coupling-metrics.sh
+117 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1308.60" y="983.84" width="13.35" height="16.16" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/backfill-tenant-reference-data.sh
+108 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1321.96" y="947.93" width="14.50" height="14.05" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>scripts/verify-valuation-readonly.sh
+102 loc · ccn 13 · commits (last 12mo) 2</title></rect>
+<rect x="1336.46" y="947.93" width="13.36" height="14.05" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>scripts/check-service-coverage.sh
+94 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1349.82" y="947.93" width="12.65" height="14.05" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/test-mermaid-generation.sh
+89 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1321.96" y="961.99" width="11.98" height="14.17" fill="#fde2bd" stroke="white" stroke-width="0.5"><title>scripts/init-database.sh
+85 loc · ccn 14 · commits (last 12mo) 10</title></rect>
+<rect x="1321.96" y="976.16" width="11.98" height="12.50" fill="#dcd5d0" stroke="white" stroke-width="0.5"><title>scripts/smoke-test-get-balance.sh
+75 loc · ccn 11 · commits (last 12mo) 2</title></rect>
+<rect x="1321.96" y="988.66" width="11.98" height="11.34" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>scripts/lint-service-readmes.sh
+68 loc · ccn 17 · commits (last 12mo) 1</title></rect>
+<rect x="1333.94" y="961.99" width="9.78" height="12.67" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>scripts/validate-tiltfile.sh
+62 loc · ccn 4 · commits (last 12mo) 1</title></rect>
+<rect x="1343.71" y="961.99" width="9.62" height="12.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/validate-manifest-jsonschema.sh
+61 loc · ccn 9 · commits (last 12mo) 1</title></rect>
+<rect x="1353.33" y="961.99" width="9.14" height="12.67" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/lint-bucket-id.sh
+58 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1333.94" y="974.66" width="8.51" height="13.61" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>scripts/split-swagger.sh
+58 loc · ccn 5 · commits (last 12mo) 2</title></rect>
+<rect x="1333.94" y="988.27" width="8.51" height="11.73" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>scripts/check-cross-service-imports.sh
+50 loc · ccn 12 · commits (last 12mo) 1</title></rect>
+<rect x="1342.45" y="974.66" width="10.01" height="9.18" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>scripts/reconcile_degraded_valuations.sql
+46 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1352.46" y="974.66" width="10.01" height="9.18" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>scripts/validate-semconv-versions.sh
+46 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1342.45" y="983.84" width="8.90" height="8.31" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>scripts/reset-local-migrations.sh
+37 loc · ccn 6 · commits (last 12mo) 1</title></rect>
+<rect x="1342.45" y="992.14" width="8.90" height="7.86" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>scripts/codecov-exclude-pattern.sh
+35 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1351.35" y="983.84" width="6.20" height="9.34" fill="#e1d9cf" stroke="white" stroke-width="0.5"><title>scripts/setup-local-secrets.sh
+29 loc · ccn 5 · commits (last 12mo) 3</title></rect>
+<rect x="1357.55" y="983.84" width="4.92" height="9.34" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>scripts/kafka-watch.sh
+23 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1351.35" y="993.18" width="6.44" height="6.82" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>scripts/check-deadcode.sh
+22 loc · ccn 5 · commits (last 12mo) 1</title></rect>
+<rect x="1357.79" y="993.18" width="4.68" height="6.82" fill="#e7dbcd" stroke="white" stroke-width="0.5"><title>scripts/seed-dev-tenant.sh
+16 loc · ccn 7 · commits (last 12mo) 4</title></rect>
+<rect x="1362.47" y="744.16" width="32.40" height="35.95" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/retry_test.go
+583 loc · ccn 88 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="780.11" width="32.40" height="31.69" fill="#d6cecc" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit_test.go
+514 loc · ccn 92 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="811.80" width="32.40" height="29.54" fill="#dcd2c9" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/preflight_test.go
+479 loc · ccn 44 · commits (last 12mo) 2</title></rect>
+<rect x="1394.87" y="744.16" width="30.02" height="29.81" fill="#d6d1d0" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/main_test.go
+448 loc · ccn 40 · commits (last 12mo) 1</title></rect>
+<rect x="1424.90" y="744.16" width="29.22" height="29.81" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit_orders_test.go
+436 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1454.12" y="744.16" width="26.87" height="29.81" fill="#dcd3ca" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/sabotage_test.go
+401 loc · ccn 38 · commits (last 12mo) 2</title></rect>
+<rect x="1394.87" y="773.97" width="22.66" height="34.65" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/report_test.go
+393 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1394.87" y="808.62" width="22.66" height="32.71" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit_lien_test.go
+371 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1417.53" y="773.97" width="32.01" height="21.15" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/clients_test.go
+339 loc · ccn 46 · commits (last 12mo) 1</title></rect>
+<rect x="1449.54" y="773.97" width="31.45" height="21.15" fill="#e7d2ba" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/main.go
+333 loc · ccn 49 · commits (last 12mo) 4</title></rect>
+<rect x="1417.53" y="795.13" width="20.71" height="23.25" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit.go
+241 loc · ccn 29 · commits (last 12mo) 1</title></rect>
+<rect x="1417.53" y="818.38" width="20.71" height="22.96" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/sabotage.go
+238 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="1438.24" y="795.13" width="21.82" height="17.94" fill="#dcd4cd" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/retry.go
+196 loc · ccn 24 · commits (last 12mo) 2</title></rect>
+<rect x="1460.06" y="795.13" width="20.93" height="17.94" fill="#e1d3c3" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/clients.go
+188 loc · ccn 43 · commits (last 12mo) 3</title></rect>
+<rect x="1438.24" y="813.07" width="24.38" height="15.08" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit_orders.go
+184 loc · ccn 24 · commits (last 12mo) 1</title></rect>
+<rect x="1438.24" y="828.15" width="24.38" height="13.19" fill="#e1d6c9" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/preflight.go
+161 loc · ccn 23 · commits (last 12mo) 3</title></rect>
+<rect x="1462.62" y="813.07" width="18.37" height="16.42" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/audit_lien.go
+151 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1462.62" y="829.49" width="18.37" height="11.85" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>utilities/horizon-demo/report.go
+109 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1480.99" y="744.16" width="5.04" height="60.69" fill="#f8e1c2" stroke="white" stroke-width="0.5"><title>utilities/atlas-loader/main_test.go
+153 loc · ccn 11 · commits (last 12mo) 7</title></rect>
+<rect x="1480.99" y="804.85" width="5.04" height="36.49" fill="#fde4bf" stroke="white" stroke-width="0.5"><title>utilities/atlas-loader/main.go
+92 loc · ccn 11 · commits (last 12mo) 9</title></rect>
+<rect x="1486.03" y="744.16" width="11.73" height="10.05" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/payment-order/kustomization.yaml
+59 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1497.76" y="744.16" width="11.73" height="10.05" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/current-account/kustomization.yaml
+59 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1486.03" y="754.21" width="11.73" height="9.36" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/tenant/kustomization.yaml
+55 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1486.03" y="763.57" width="11.73" height="9.36" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/position-keeping/kustomization.yaml
+55 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1497.76" y="754.21" width="11.73" height="9.36" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/party/kustomization.yaml
+55 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1497.76" y="763.57" width="11.73" height="9.36" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/overlays/financial-accounting/kustomization.yaml
+55 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1509.49" y="744.16" width="20.48" height="17.17" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/deployment.yaml
+176 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1509.49" y="761.33" width="7.57" height="11.61" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/hpa.yaml
+44 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1517.07" y="761.33" width="8.78" height="6.60" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/kustomization.yaml
+29 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1517.07" y="767.93" width="8.78" height="5.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/configmap.yaml
+22 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1525.84" y="761.33" width="4.13" height="8.22" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/service.yaml
+17 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1525.84" y="769.55" width="4.13" height="3.39" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/base/serviceaccount.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1529.97" y="744.16" width="9.44" height="28.78" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/audit-consumer/README.md
+136 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1486.03" y="772.94" width="30.42" height="32.97" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>deployments/k8s/observability/grafana-stack.yaml
+502 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1516.45" y="772.94" width="19.88" height="12.96" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/policies/tests/README.md
+129 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1536.33" y="772.94" width="3.08" height="12.96" fill="#d6d3d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/policies/tests/run_tests.sh
+20 loc · ccn 3 · commits (last 12mo) 1</title></rect>
+<rect x="1516.45" y="785.90" width="19.97" height="10.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/policies/gateway-dev-mode-block.yaml
+100 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1516.45" y="795.90" width="19.97" height="10.00" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/policies/auth-enabled-block.yaml
+100 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1536.42" y="785.90" width="3.00" height="20.01" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/policies/monitoring-namespace.yaml
+30 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1486.03" y="805.90" width="18.66" height="14.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/local/kafka.yaml
+136 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1486.03" y="820.46" width="9.46" height="15.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/local/keycloak.yaml
+75 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1495.48" y="820.46" width="9.20" height="15.84" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/local/cockroachdb.yaml
+73 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1486.03" y="836.31" width="18.66" height="5.03" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/local/redis.yaml
+47 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1504.69" y="805.90" width="10.84" height="18.06" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>deployments/k8s/overlays/production/kustomization.yaml
+98 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1515.53" y="805.90" width="8.41" height="18.06" fill="#eddfce" stroke="white" stroke-width="0.5"><title>deployments/k8s/overlays/production/networkpolicy.yaml
+76 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1523.93" y="805.90" width="15.48" height="9.42" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/overlays/dev/kustomization.yaml
+73 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1523.93" y="815.32" width="15.48" height="8.64" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/overlays/staging/kustomization.yaml
+67 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1504.69" y="823.97" width="16.44" height="17.37" fill="#eddfce" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/deployment.yaml
+143 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1521.13" y="823.97" width="9.31" height="11.15" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/networkpolicy-template.yaml
+52 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1521.13" y="835.12" width="9.31" height="6.22" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/kustomization.yaml
+29 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1530.45" y="823.97" width="4.48" height="8.46" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/service.yaml
+19 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1534.93" y="823.97" width="4.48" height="8.46" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/configmap.yaml
+19 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1530.45" y="832.43" width="7.18" height="4.73" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/role.yaml
+17 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1530.45" y="837.16" width="7.18" height="4.18" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/rolebinding.yaml
+15 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1537.62" y="832.43" width="1.79" height="8.91" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deployments/k8s/base/serviceaccount.yaml
+8 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1539.42" y="744.16" width="60.58" height="45.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/grafana/dashboards/production-readiness.json
+1384 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1539.42" y="789.80" width="49.00" height="36.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/grafana/dashboards/organization-monitoring.json
+884 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1588.42" y="789.80" width="11.58" height="36.04" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/grafana/dashboards/event-router-saga-dispatch.json
+209 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1539.42" y="825.84" width="25.91" height="15.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/prometheus/alerts/production-readiness.yml
+201 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1565.33" y="825.84" width="14.69" height="15.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/prometheus/alerts/organization-monitoring.yml
+114 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1580.02" y="825.84" width="12.37" height="15.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/prometheus/alerts/event-router-saga-dispatch.yml
+96 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1592.39" y="825.84" width="7.61" height="15.50" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deployments/prometheus/alerts/tenant-provisioning.yml
+59 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="841.34" width="34.93" height="30.71" fill="#fdc08a" stroke="white" stroke-width="0.5"><title>cookbook/patterns/patterns_test.go
+537 loc · ccn 86 · commits (last 12mo) 8</title></rect>
+<rect x="1397.41" y="841.34" width="15.16" height="15.69" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/payg-energy/manifest-fragment.yaml
+119 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1397.41" y="857.02" width="15.16" height="15.03" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/payg-energy/pattern.json
+114 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="872.05" width="11.54" height="13.68" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/saas-billing/manifest-fragment.yaml
+79 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1374.01" y="872.05" width="7.30" height="13.68" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/saas-billing/pattern.json
+50 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1381.31" y="872.05" width="9.05" height="13.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/tote-betting/manifest-fragment.yaml
+62 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1390.37" y="872.05" width="8.76" height="13.68" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/tote-betting/pattern.json
+60 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1399.13" y="872.05" width="13.43" height="7.58" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/precious-metals/manifest-fragment.yaml
+51 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1399.13" y="879.63" width="13.43" height="6.10" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/precious-metals/pattern.json
+41 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1362.47" y="885.73" width="12.73" height="8.16" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/carbon-offset/manifest-fragment.yaml
+52 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="893.89" width="12.73" height="5.49" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/carbon-offset/pattern.json
+35 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1362.47" y="899.38" width="12.73" height="6.75" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/energy-settlement/manifest-fragment.yaml
+43 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="906.13" width="12.73" height="6.43" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/energy-settlement/pattern.json
+41 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1362.47" y="912.56" width="7.96" height="11.30" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>cookbook/patterns/payment-gateway-stripe/pattern.json
+45 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1370.43" y="912.56" width="4.77" height="11.30" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/payment-gateway-stripe/manifest-fragment.yaml
+27 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1375.21" y="885.73" width="9.63" height="8.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-deposit/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1375.21" y="894.03" width="9.63" height="3.73" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-deposit/manifest-fragment.yaml
+18 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1384.84" y="885.73" width="9.63" height="8.30" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-withdrawal/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1384.84" y="894.03" width="9.63" height="3.73" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-withdrawal/manifest-fragment.yaml
+18 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1394.47" y="885.73" width="9.30" height="8.59" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/time-of-use-pricing/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1394.47" y="894.33" width="9.30" height="3.44" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/time-of-use-pricing/manifest-fragment.yaml
+16 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1403.76" y="885.73" width="8.80" height="9.31" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/kyc-compliance/pattern.json
+41 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1403.76" y="895.04" width="8.80" height="2.72" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/kyc-compliance/manifest-fragment.yaml
+12 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1375.21" y="897.76" width="8.65" height="9.24" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/dynamic-capacity-pricing/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1383.85" y="897.76" width="2.38" height="9.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/dynamic-capacity-pricing/manifest-fragment.yaml
+11 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1375.21" y="907.01" width="9.87" height="8.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-stripe-payment/pattern.json
+43 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1385.08" y="907.01" width="1.15" height="8.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-stripe-payment/manifest-fragment.yaml
+5 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1375.21" y="915.71" width="10.04" height="8.16" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/entity-distribution/pattern.json
+41 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1385.25" y="915.71" width="0.98" height="8.16" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/entity-distribution/manifest-fragment.yaml
+4 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1386.23" y="897.76" width="9.14" height="8.96" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/phantom-cost-basis/pattern.json
+41 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1395.37" y="897.76" width="0.89" height="8.96" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/patterns/phantom-cost-basis/manifest-fragment.yaml
+4 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1386.23" y="906.73" width="9.33" height="8.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dividend-distribution/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1395.56" y="906.73" width="0.70" height="8.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dividend-distribution/manifest-fragment.yaml
+3 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1386.23" y="915.30" width="9.33" height="8.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-payment-execution/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1395.56" y="915.30" width="0.70" height="8.57" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-payment-execution/manifest-fragment.yaml
+3 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1396.26" y="897.76" width="8.15" height="9.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dunning-unfreeze/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1396.26" y="907.57" width="8.15" height="0.74" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dunning-unfreeze/manifest-fragment.yaml
+3 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1404.41" y="897.76" width="8.15" height="9.80" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-reconciliation-adjustment/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1404.41" y="907.57" width="8.15" height="0.74" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-reconciliation-adjustment/manifest-fragment.yaml
+3 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1396.26" y="908.30" width="10.15" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dunning-escalation/pattern.json
+40 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1406.41" y="908.30" width="0.76" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/default-dunning-escalation/manifest-fragment.yaml
+3 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1396.26" y="916.17" width="9.09" height="7.69" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>cookbook/patterns/base-fiat-gbp/pattern.json
+35 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1405.35" y="916.17" width="1.82" height="7.69" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/base-fiat-gbp/manifest-fragment.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1407.17" y="908.30" width="5.39" height="12.97" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>cookbook/patterns/base-fiat-usd/pattern.json
+35 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1407.17" y="921.27" width="5.39" height="2.59" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/patterns/base-fiat-usd/manifest-fragment.yaml
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="841.34" width="38.10" height="22.81" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>cookbook/schema/schema_test.go
+435 loc · ccn 32 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="864.15" width="18.81" height="20.92" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/schema/registry-item.json
+197 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1431.37" y="864.15" width="19.29" height="15.23" fill="#d6d2d2" stroke="white" stroke-width="0.5"><title>cookbook/schema/ui_components_test.go
+147 loc · ccn 23 · commits (last 12mo) 1</title></rect>
+<rect x="1431.37" y="879.38" width="19.29" height="5.70" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/schema/registry.json
+55 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1450.66" y="841.34" width="26.95" height="27.72" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>cookbook/docs/authoring-patterns.md
+374 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1450.66" y="869.06" width="26.95" height="16.01" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/docs/authoring-components.md
+216 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1412.56" y="885.07" width="8.41" height="8.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/breadcrumbs/component.json
+36 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1420.97" y="885.07" width="8.17" height="8.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/data-table/component.json
+35 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1429.14" y="885.07" width="7.47" height="8.56" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/time-display/component.json
+32 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="893.63" width="8.10" height="7.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/status-badge/component.json
+31 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1420.67" y="893.63" width="8.10" height="7.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/audit-trail/component.json
+31 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1428.77" y="893.63" width="7.84" height="7.64" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/entity-link/component.json
+30 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="901.27" width="7.16" height="8.09" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/detail-skeleton/component.json
+29 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="909.36" width="7.16" height="7.81" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/money-display/component.json
+28 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1412.56" y="917.17" width="7.16" height="6.69" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>cookbook/ui/handler-reference/component.json
+24 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1419.72" y="901.27" width="5.82" height="6.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/quick-actions/component.json
+20 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1425.55" y="901.27" width="5.53" height="6.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/stat-card/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1431.08" y="901.27" width="5.53" height="6.86" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/quality-ladder-badge/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1419.72" y="908.13" width="7.24" height="5.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/direction-badge/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1419.72" y="913.37" width="7.24" height="5.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/balance-indicator/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1419.72" y="918.62" width="7.24" height="5.24" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/cel-editor/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1426.96" y="908.13" width="4.83" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/create-valuation-feature-dialog/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1431.79" y="908.13" width="4.83" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/activity-feed/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1426.96" y="916.00" width="4.83" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/starlark-editor/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1431.79" y="916.00" width="4.83" height="7.87" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/ui/saga-timeline/component.json
+19 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1436.61" y="885.07" width="21.63" height="38.79" fill="#dcd0c6" stroke="white" stroke-width="0.5"><title>cookbook/schema_validation_test.go
+420 loc · ccn 64 · commits (last 12mo) 2</title></rect>
+<rect x="1458.25" y="885.07" width="19.37" height="30.54" fill="#d6d0cd" stroke="white" stroke-width="0.5"><title>cookbook/validation_test.go
+296 loc · ccn 68 · commits (last 12mo) 1</title></rect>
+<rect x="1458.25" y="915.61" width="11.62" height="8.25" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>cookbook/registry.json
+48 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1469.86" y="915.61" width="7.75" height="7.48" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/README.md
+29 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1469.86" y="923.09" width="7.75" height="0.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>cookbook/embed.go
+3 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1362.47" y="923.86" width="22.41" height="28.62" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/deploy-develop.yml
+321 loc · ccn 0 · commits (last 12mo) 19</title></rect>
+<rect x="1362.47" y="952.48" width="22.41" height="26.66" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/deploy-demo.yml
+299 loc · ccn 0 · commits (last 12mo) 45</title></rect>
+<rect x="1362.47" y="979.14" width="22.41" height="20.86" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/e2e.yml
+234 loc · ccn 0 · commits (last 12mo) 19</title></rect>
+<rect x="1384.88" y="923.86" width="20.19" height="21.67" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/security.yml
+219 loc · ccn 0 · commits (last 12mo) 52</title></rect>
+<rect x="1405.08" y="923.86" width="18.81" height="21.67" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/quality.yml
+204 loc · ccn 0 · commits (last 12mo) 24</title></rect>
+<rect x="1423.89" y="923.86" width="18.16" height="21.67" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/migrations.yml
+197 loc · ccn 0 · commits (last 12mo) 22</title></rect>
+<rect x="1442.05" y="923.86" width="17.80" height="21.67" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/test.yml
+193 loc · ccn 0 · commits (last 12mo) 37</title></rect>
+<rect x="1384.88" y="945.53" width="19.91" height="18.76" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/control-plane-ci.yml
+187 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1384.88" y="964.29" width="19.91" height="18.46" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>.github/workflows/validate-manifests.yml
+184 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1384.88" y="982.75" width="19.91" height="17.25" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>.github/workflows/kafka-integration-tests.yml
+172 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1404.80" y="945.53" width="14.60" height="18.75" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/build.yml
+137 loc · ccn 0 · commits (last 12mo) 47</title></rect>
+<rect x="1404.80" y="964.28" width="14.60" height="17.93" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/saga-validation.yml
+131 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1404.80" y="982.21" width="14.60" height="17.79" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/nightly.yml
+130 loc · ccn 0 · commits (last 12mo) 25</title></rect>
+<rect x="1419.39" y="945.53" width="13.76" height="16.69" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/frontend.yml
+115 loc · ccn 0 · commits (last 12mo) 10</title></rect>
+<rect x="1433.16" y="945.53" width="13.76" height="16.69" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/markdown.yml
+115 loc · ccn 0 · commits (last 12mo) 11</title></rect>
+<rect x="1446.92" y="945.53" width="12.93" height="16.69" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>.github/workflows/security-defaults.yml
+108 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1419.39" y="962.22" width="13.38" height="14.63" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/proto.yml
+98 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1419.39" y="976.85" width="13.38" height="11.95" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/benchmarks.yml
+80 loc · ccn 0 · commits (last 12mo) 15</title></rect>
+<rect x="1419.39" y="988.80" width="13.38" height="11.20" fill="#eddfce" stroke="white" stroke-width="0.5"><title>.github/workflows/asyncapi.yml
+75 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1432.77" y="962.22" width="14.02" height="10.40" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>.github/workflows/claude-review.yml
+73 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1446.79" y="962.22" width="13.06" height="10.40" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/schema-validation.yml
+68 loc · ccn 0 · commits (last 12mo) 13</title></rect>
+<rect x="1432.77" y="972.62" width="13.84" height="9.81" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/claude.yml
+68 loc · ccn 0 · commits (last 12mo) 18</title></rect>
+<rect x="1446.62" y="972.62" width="13.23" height="9.81" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.github/workflows/codeql.yml
+65 loc · ccn 0 · commits (last 12mo) 18</title></rect>
+<rect x="1432.77" y="982.44" width="13.65" height="9.37" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>.github/workflows/conventions.yml
+64 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1432.77" y="991.80" width="13.65" height="8.20" fill="#eddfce" stroke="white" stroke-width="0.5"><title>.github/workflows/demo-reset.yml
+56 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1446.42" y="982.44" width="13.42" height="8.04" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>.github/workflows/deploy-gate.yml
+54 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1446.42" y="990.48" width="5.45" height="9.52" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>.github/workflows/tag-develop.yml
+26 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1451.88" y="990.48" width="7.97" height="5.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>.github/workflows/cla.yml
+22 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1451.88" y="995.99" width="7.97" height="4.01" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>.github/workflows/service-readme-lint.yml
+16 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1459.85" y="923.86" width="17.76" height="70.07" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>.github/claude-review-instructions.md
+623 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1459.85" y="993.93" width="17.76" height="6.07" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>.github/dependabot.yml
+54 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1477.61" y="841.34" width="28.35" height="29.31" fill="#fdbd86" stroke="white" stroke-width="0.5"><title>internal/migrations/runner.go
+416 loc · ccn 93 · commits (last 12mo) 12</title></rect>
+<rect x="1505.96" y="841.34" width="18.88" height="29.31" fill="#e1d1c0" stroke="white" stroke-width="0.5"><title>internal/migrations/runner_test.go
+277 loc · ccn 54 · commits (last 12mo) 3</title></rect>
+<rect x="1477.61" y="870.65" width="21.73" height="18.48" fill="#dcd5cf" stroke="white" stroke-width="0.5"><title>internal/migrations/driver_test.go
+201 loc · ccn 17 · commits (last 12mo) 2</title></rect>
+<rect x="1499.34" y="870.65" width="19.67" height="18.48" fill="#dcd3cb" stroke="white" stroke-width="0.5"><title>internal/migrations/runner_postgres_test.go
+182 loc · ccn 34 · commits (last 12mo) 2</title></rect>
+<rect x="1519.01" y="870.65" width="5.84" height="16.09" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>internal/migrations/adapt_test.go
+47 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1519.01" y="886.74" width="5.84" height="2.40" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>internal/migrations/export_test.go
+7 loc · ccn 2 · commits (last 12mo) 2</title></rect>
+<rect x="1524.84" y="841.34" width="17.93" height="23.73" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>internal/bootstrap/platform_manifest.json
+213 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1524.84" y="865.07" width="17.93" height="16.93" fill="#ecd8bf" stroke="white" stroke-width="0.5"><title>internal/bootstrap/master_tenant.go
+152 loc · ccn 28 · commits (last 12mo) 5</title></rect>
+<rect x="1524.84" y="882.00" width="17.93" height="7.13" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>internal/bootstrap/master_tenant_test.go
+64 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1542.78" y="841.34" width="26.08" height="47.79" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>examples/manifests/payg-energy.manifest.json
+624 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1568.86" y="841.34" width="15.74" height="28.68" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>examples/manifests/volterra-energy-demo.json
+226 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1584.60" y="841.34" width="15.40" height="28.68" fill="#eddfce" stroke="white" stroke-width="0.5"><title>examples/manifests/energy.json
+221 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1568.86" y="870.02" width="15.99" height="19.12" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>examples/manifests/platform.json
+153 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1584.85" y="870.02" width="15.15" height="11.08" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>examples/manifests/saas.json
+84 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1584.85" y="881.09" width="15.15" height="8.04" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>examples/manifests/carbon.json
+61 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1477.61" y="889.13" width="21.43" height="21.72" fill="#dcd2ca" stroke="white" stroke-width="0.5"><title>deploy/demo/provision.sh
+233 loc · ccn 41 · commits (last 12mo) 2</title></rect>
+<rect x="1499.04" y="889.13" width="20.14" height="21.72" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deploy/demo/README.md
+219 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1477.61" y="910.85" width="27.71" height="15.21" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deploy/demo/cloudflare-setup-checklist.md
+211 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1477.61" y="926.06" width="27.71" height="15.21" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deploy/demo/pg-migration-compatibility-report.md
+211 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1505.32" y="910.85" width="13.86" height="14.85" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>deploy/demo/docker-compose.yml
+103 loc · ccn 0 · commits (last 12mo) 23</title></rect>
+<rect x="1505.32" y="925.70" width="13.86" height="9.80" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>deploy/demo/dex-identity-migration-plan.md
+68 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1505.32" y="935.51" width="7.97" height="5.77" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>deploy/demo/dex.yaml
+23 loc · ccn 0 · commits (last 12mo) 9</title></rect>
+<rect x="1513.29" y="935.51" width="5.20" height="5.77" fill="#f8e5ca" stroke="white" stroke-width="0.5"><title>deploy/demo/init-databases.sql
+15 loc · ccn 1 · commits (last 12mo) 7</title></rect>
+<rect x="1518.49" y="935.51" width="0.69" height="5.77" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>deploy/demo/pg-pre-migration.sql
+2 loc · ccn 1 · commits (last 12mo) 1</title></rect>
+<rect x="1477.61" y="941.27" width="21.91" height="10.67" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>deploy/dev/docker-compose.yml
+117 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="1499.52" y="941.27" width="16.85" height="10.67" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>deploy/develop/docker-compose.develop.yml
+90 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1516.37" y="941.27" width="2.81" height="10.67" fill="#e7dccf" stroke="white" stroke-width="0.5"><title>deploy/develop/init-databases-develop.sql
+15 loc · ccn 1 · commits (last 12mo) 4</title></rect>
+<rect x="1477.61" y="951.94" width="19.38" height="32.77" fill="#dcd2c8" stroke="white" stroke-width="0.5"><title>tools/saga-doc-gen/generator.go
+318 loc · ccn 48 · commits (last 12mo) 2</title></rect>
+<rect x="1496.99" y="951.94" width="22.19" height="24.67" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>tools/saga-doc-gen/generator_test.go
+274 loc · ccn 9 · commits (last 12mo) 2</title></rect>
+<rect x="1496.99" y="976.61" width="22.19" height="8.10" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>tools/saga-doc-gen/main.go
+90 loc · ccn 20 · commits (last 12mo) 1</title></rect>
+<rect x="1477.61" y="984.72" width="41.57" height="15.28" fill="#d6d1cf" stroke="white" stroke-width="0.5"><title>tools/gen-event-publishers/main.go
+318 loc · ccn 45 · commits (last 12mo) 1</title></rect>
+<rect x="1519.18" y="889.13" width="44.53" height="40.02" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>CONTRIBUTING.md
+892 loc · ccn 0 · commits (last 12mo) 15</title></rect>
+<rect x="1563.71" y="889.13" width="20.12" height="19.27" fill="#d6d2d1" stroke="white" stroke-width="0.5"><title>gen/events/position_keeping/publisher.go
+194 loc · ccn 25 · commits (last 12mo) 1</title></rect>
+<rect x="1583.82" y="889.13" width="16.18" height="19.27" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>gen/events/payment_order/publisher.go
+156 loc · ccn 21 · commits (last 12mo) 1</title></rect>
+<rect x="1563.71" y="908.40" width="13.19" height="20.75" fill="#d6d3d2" stroke="white" stroke-width="0.5"><title>gen/events/reconciliation/publisher.go
+137 loc · ccn 19 · commits (last 12mo) 1</title></rect>
+<rect x="1576.90" y="908.40" width="17.23" height="11.48" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>gen/events/current_account/publisher.go
+99 loc · ccn 15 · commits (last 12mo) 1</title></rect>
+<rect x="1576.90" y="919.88" width="17.23" height="9.28" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>gen/events/party/publisher.go
+80 loc · ccn 13 · commits (last 12mo) 1</title></rect>
+<rect x="1594.13" y="908.40" width="5.87" height="20.75" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>gen/events/internal_account/publisher.go
+61 loc · ccn 11 · commits (last 12mo) 1</title></rect>
+<rect x="1519.18" y="929.15" width="25.29" height="36.57" fill="#fdc892" stroke="white" stroke-width="0.5"><title>Makefile
+463 loc · ccn 72 · commits (last 12mo) 31</title></rect>
+<rect x="1519.18" y="965.72" width="25.29" height="34.28" fill="#dcd7d3" stroke="white" stroke-width="0.5"><title>CLAUDE.md
+434 loc · ccn 0 · commits (last 12mo) 2</title></rect>
+<rect x="1544.48" y="929.15" width="31.99" height="20.29" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.golangci.yml
+325 loc · ccn 0 · commits (last 12mo) 21</title></rect>
+<rect x="1576.47" y="929.15" width="23.53" height="20.29" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>codecov.yml
+239 loc · ccn 0 · commits (last 12mo) 10</title></rect>
+<rect x="1544.48" y="949.45" width="17.19" height="17.20" fill="#fdd8a8" stroke="white" stroke-width="0.5"><title>.githooks/pre-commit
+148 loc · ccn 39 · commits (last 12mo) 15</title></rect>
+<rect x="1544.48" y="966.65" width="13.79" height="9.41" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>.githooks/README.md
+65 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1558.27" y="966.65" width="3.40" height="9.41" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>.githooks/install.sh
+16 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1544.48" y="976.06" width="17.19" height="23.94" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>SECURITY.md
+206 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1561.67" y="949.45" width="20.98" height="18.19" fill="#d6d3d3" stroke="white" stroke-width="0.5"><title>dev
+191 loc · ccn 14 · commits (last 12mo) 1</title></rect>
+<rect x="1582.65" y="949.45" width="17.35" height="18.19" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>README.md
+158 loc · ccn 0 · commits (last 12mo) 45</title></rect>
+<rect x="1561.67" y="967.64" width="12.41" height="16.26" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>CHANGELOG.md
+101 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1561.67" y="983.90" width="12.41" height="14.17" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>http/README.md
+88 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1561.67" y="998.07" width="12.41" height="1.93" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>http/http-client.env.json
+12 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1574.07" y="967.64" width="14.06" height="9.09" fill="#eddfce" stroke="white" stroke-width="0.5"><title>LICENSE
+64 loc · ccn 0 · commits (last 12mo) 5</title></rect>
+<rect x="1588.14" y="967.64" width="11.86" height="9.09" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>CODE_OF_CONDUCT.md
+54 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1574.07" y="976.73" width="10.90" height="8.80" fill="#dcd6d1" stroke="white" stroke-width="0.5"><title>setup-hooks.sh
+48 loc · ccn 6 · commits (last 12mo) 2</title></rect>
+<rect x="1574.07" y="985.52" width="10.90" height="7.51" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>.dockerignore
+41 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1574.07" y="993.04" width="10.90" height="6.96" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>buf.yaml
+38 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="1584.98" y="976.73" width="8.09" height="8.64" fill="#fee8ca" stroke="white" stroke-width="0.5"><title>.markdownlint-cli2.jsonc
+35 loc · ccn 0 · commits (last 12mo) 8</title></rect>
+<rect x="1593.07" y="976.73" width="6.93" height="8.64" fill="#dcd6d2" stroke="white" stroke-width="0.5"><title>.gitleaks.toml
+30 loc · ccn 1 · commits (last 12mo) 2</title></rect>
+<rect x="1584.98" y="985.37" width="6.83" height="7.61" fill="#f8e5cb" stroke="white" stroke-width="0.5"><title>package.json
+26 loc · ccn 0 · commits (last 12mo) 7</title></rect>
+<rect x="1584.98" y="992.98" width="6.83" height="7.02" fill="#fde7c6" stroke="white" stroke-width="0.5"><title>Dockerfile
+24 loc · ccn 4 · commits (last 12mo) 16</title></rect>
+<rect x="1591.81" y="985.37" width="8.19" height="4.14" fill="#e7dcd0" stroke="white" stroke-width="0.5"><title>buf.gen.yaml
+17 loc · ccn 0 · commits (last 12mo) 4</title></rect>
+<rect x="1591.81" y="989.52" width="8.19" height="4.14" fill="#f2e2cd" stroke="white" stroke-width="0.5"><title>.coderabbit.yaml
+17 loc · ccn 0 · commits (last 12mo) 6</title></rect>
+<rect x="1591.81" y="993.66" width="5.99" height="3.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>buf.gen.jsonschema.yaml
+10 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+<rect x="1591.81" y="997.00" width="5.99" height="3.00" fill="#e1dad1" stroke="white" stroke-width="0.5"><title>CLA.md
+9 loc · ccn 0 · commits (last 12mo) 3</title></rect>
+<rect x="1597.79" y="993.66" width="2.21" height="6.34" fill="#d6d4d4" stroke="white" stroke-width="0.5"><title>AGENTS.md
+7 loc · ccn 0 · commits (last 12mo) 1</title></rect>
+</svg>


### PR DESCRIPTION
## Summary

Pairs the existing sanitized `/assess` hero SVGs with post-action-sweep snapshots of the **same** ~650k-LOC monorepo, told side-by-side in the README. The narrative: an already-good AI-native repo, then the same repo after its maintainers worked through the Top 3 Actions from the `/assess` report - it gets measurably cleaner.

## Changes Made

- **New assets**: `docs/example-doc-graph-after.svg`, `docs/example-heatmap-after.svg` (fetched from `meridianhub/meridian` `.assess/` on `develop`; provenance confirmed same repo, pre/post sweep).
- **README**: restructured the `What /assess produces` hero section into a before/after HTML `<table>` (2 view types x before/after), with a "measurable win" callout and a condensed legend. Existing files retained as the **before** side (no rename), so all references stay valid.
- **Docs tree listing**: refreshed to cover all four SVGs.
- **Version**: bumped `1.16.0` -> `1.16.1` (doc-only change = PATCH per the repo's versioning table).

## The measurable win (doc-navigability graph)

| Metric | Before | After |
|--------|--------|-------|
| Reachable from entry point | 30% | 89% |
| Orphaned docs | 24% | 11% |
| Disconnected islands | 43 | 20 |
| Broken links | 15 | 0 |

Both SVG pairs share matching `viewBox` dimensions, so the table columns align.

## Sanitization gate (issue #56 lesson)

Scanned both new SVGs for IPs, SSH/host details, credentials, private keys, and absolute home-directory paths:

```
grep -nE '/Users/|/home/|([0-9]{1,3}\.){3}[0-9]{1,3}|ssh|password|secret|token|BEGIN [A-Z ]*PRIVATE KEY' <files>
```

Only matches were **filenames** within the public meridian repo (e.g. `k8s/secret.yaml` manifests, `password.go`, `token.go`, `secrets-management.md`). No IPs, no home-directory paths, no credential values. meridian is public, so these path labels are acceptable per the issue.

## Risk Assessment

Documentation-only. Touches `README.md`, `docs/*.svg`, and `plugin.json` version. No skill/command behaviour change, no executable code touched. Isolated from the rest of the assess-feedback batch.

Closes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `/assess` documentation with visual "Before/After" examples illustrating feature results.
  * Added explanations for interpreting documentation navigability graphs and complexity heatmaps.
  * Updated documentation assets with new example visuals.

* **Chores**
  * Bumped plugin version to 1.16.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->