### PR TITLE
fix(assess): exclude test fixtures from doc graph and liveness scans

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -211,7 +211,7 @@ Full list in `complexity-treemap.py`'s `EXCLUDE_DIRS` and `EXCLUDE_FILE_PATTERNS
 
    No section header is needed - the file is already namespaced by living under `.assess/`. Missing or malformed files degrade silently to no extra excludes; the assessment never blocks on a broken config.
 
-The script's own output directory `.assess/` is excluded automatically - prior runs' `run-context.json` and SVGs never feed the next run's heatmap, the doc graph, or the dead-code scan.
+The script's own output directory `.assess/` is excluded automatically - prior runs' `run-context.json` and SVGs never feed the next run's heatmap, the doc graph, or the dead-code scan. Test fixtures under `**/tests/fixtures/**` are likewise excluded automatically - they are inputs that exercise the scanners (sample `CLAUDE.md` / monolithic-instruction files), not navigational docs or live code, so counting them would inflate the orphan rate and depress the Layer 0 navigability read.
 
 **If the script fails** (no `uv`, no scoreable files, etc.), record the error in the report under "Hotspot snapshot" as "could not be generated - <reason>" and continue with the layered assessment. The treemap is additive; assessment still runs without it.
 

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -66,6 +66,39 @@ EXCLUDE_DIRS = {
     ".assess",
 }
 
+# Path-segment *sequences* (not single dir names) that mark non-navigational
+# trees. Test fixtures live at `**/tests/fixtures/**`: they are inputs to the
+# scanners (sample CLAUDE.md / monolithic-instruction files that exist only to
+# exercise the detectors), never repo docs. Counting them inflates the orphan
+# rate and depresses the Layer 0 navigability read (issue #83). Matching the
+# consecutive sequence - rather than the bare `fixtures` dir name - avoids
+# over-excluding an unrelated top-level `fixtures/` of real content.
+EXCLUDE_PATH_SEQUENCES: tuple[tuple[str, ...], ...] = (
+    ("tests", "fixtures"),
+)
+
+
+def _contains_sequence(parts: tuple[str, ...], seq: tuple[str, ...]) -> bool:
+    """True if `seq` appears as consecutive elements anywhere in `parts`."""
+    n = len(seq)
+    if n == 0 or n > len(parts):
+        return False
+    return any(parts[i:i + n] == seq for i in range(len(parts) - n + 1))
+
+
+def is_excluded_path(rel: Path) -> bool:
+    """True if `rel` lies under a built-in non-navigational tree.
+
+    Combines the single-segment `EXCLUDE_DIRS` match (`.assess`, `node_modules`,
+    ...) with the multi-segment `EXCLUDE_PATH_SEQUENCES` match (`tests/fixtures`).
+    This is the built-in default, applied by every scan; user-supplied
+    `config.toml` / `--exclude` excludes layer on top via `is_user_excluded`.
+    """
+    parts = rel.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    return any(_contains_sequence(parts, seq) for seq in EXCLUDE_PATH_SEQUENCES)
+
 # Entry-doc basenames: legitimately have no inbound links (they are where a
 # reader starts), so they are excluded from the orphan count and used as the
 # roots for reachability.
@@ -220,7 +253,7 @@ def discover_doc_files(
             rel = path.relative_to(repo_root)
         except ValueError:
             continue
-        if any(part in EXCLUDE_DIRS for part in rel.parts):
+        if is_excluded_path(rel):
             continue
         if is_user_excluded(rel, extra_dirs, extra_pats):
             continue

--- a/skills/assess/scripts/lib/doc_staleness.py
+++ b/skills/assess/scripts/lib/doc_staleness.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from lib.doc_graph import CODE_EXTENSIONS, DOC_EXTENSIONS, EXCLUDE_DIRS, is_repo_file
+from lib.doc_graph import (
+    CODE_EXTENSIONS,
+    DOC_EXTENSIONS,
+    is_excluded_path,
+    is_repo_file,
+)
 from lib.git_churn import (
     file_last_commit_days,
     git_churn_scores,
@@ -94,7 +99,7 @@ def _discover(repo_root: Path, exts: set[str],
             rel = path.relative_to(repo_root)
         except ValueError:
             continue
-        if any(part in EXCLUDE_DIRS for part in rel.parts):
+        if is_excluded_path(rel):
             continue
         if is_user_excluded(rel, extra_dirs, extra_pats):
             continue

--- a/skills/assess/scripts/lib/liveness_scan.py
+++ b/skills/assess/scripts/lib/liveness_scan.py
@@ -34,7 +34,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from lib.doc_graph import EXCLUDE_DIRS
+from lib.doc_graph import EXCLUDE_DIRS, EXCLUDE_PATH_SEQUENCES, is_excluded_path
 
 DEAD_CODE_TIMEOUT = 60  # seconds; a slow tool degrades rather than hangs the run
 MAX_CANDIDATES = 50     # cap so a pathological repo can't bloat run-context.json
@@ -58,7 +58,7 @@ def _has_ext(repo_root: Path, exts: set[str],
         if not path.is_file() or path.suffix.lower() not in exts:
             continue
         rel = path.relative_to(repo_root)
-        if any(part in EXCLUDE_DIRS for part in rel.parts):
+        if is_excluded_path(rel):
             continue
         if is_user_excluded(rel, extra_dirs, extra_pats):
             continue
@@ -141,7 +141,9 @@ def _vulture_excludes(extra_exclude_dirs: set[str] | None = None) -> str:
     skipped at scan time, not just filtered after.
     """
     extras = extra_exclude_dirs or set()
-    return ",".join(f"*/{d}/*" for d in sorted(EXCLUDE_DIRS | extras))
+    dir_globs = [f"*/{d}/*" for d in sorted(EXCLUDE_DIRS | extras)]
+    seq_globs = ["*/" + "/".join(seq) + "/*" for seq in EXCLUDE_PATH_SEQUENCES]
+    return ",".join(dir_globs + seq_globs)
 
 
 # language -> ordered tool preference. Each tool: cmd builder, parser, and a
@@ -185,8 +187,7 @@ def _under_excluded(path_str: str,
     matches a user-supplied exclude. Used to filter dead-code-tool output
     so candidates from `regulatory-raw/` reference data don't surface."""
     from lib.assess_config import is_user_excluded
-    parts = Path(path_str).parts
-    if any(part in EXCLUDE_DIRS for part in parts):
+    if is_excluded_path(Path(path_str)):
         return True
     if extra_exclude_dirs or extra_exclude_patterns:
         return is_user_excluded(
@@ -375,7 +376,7 @@ def _iter_files(repo_root: Path, exts: set[str] | None = None,
         if not path.is_file():
             continue
         rel = path.relative_to(repo_root)
-        if any(part in EXCLUDE_DIRS for part in rel.parts):
+        if is_excluded_path(rel):
             continue
         if is_user_excluded(rel, extra_dirs, extra_pats):
             continue

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -187,6 +187,44 @@ def test_excludes_assess_and_vendor_dirs(tmp_path: Path) -> None:
     assert r.doc_count == 1
 
 
+def test_excludes_test_fixtures_and_orphan_rate_reflects_it(tmp_path: Path) -> None:
+    """Markdown under `**/tests/fixtures/**` is a scanner input, not a repo
+    doc, so it must not count toward the doc graph or inflate the orphan rate
+    (issue #83). One linked entry doc -> 0% orphans; without the exclusion the
+    fixture files would be unreachable orphans and the rate would spike."""
+    _write(tmp_path, "README.md", "see [guide](./guide.md)\n")
+    _write(tmp_path, "guide.md", "the guide\n")
+    # Fixtures that exist only to exercise the detectors - never navigation.
+    _write(tmp_path, "skills/assess/tests/fixtures/lean/CLAUDE.md", "fixture")
+    _write(tmp_path, "tests/fixtures/monolithic_instructions.md", "fixture")
+
+    r = build_doc_graph(tmp_path)
+    assert r.doc_count == 2
+    assert not any("fixtures" in o for o in r.orphans)
+    assert r.orphan_rate == 0.0
+
+
+def test_unrelated_top_level_fixtures_dir_not_excluded(tmp_path: Path) -> None:
+    """Only the `tests/fixtures` *sequence* is excluded - a top-level
+    `fixtures/` of real content (not preceded by `tests`) still counts."""
+    _write(tmp_path, "README.md", "real doc")
+    _write(tmp_path, "fixtures/data-model.md", "real architecture doc")
+    r = build_doc_graph(tmp_path)
+    assert r.doc_count == 2
+
+
+def test_is_excluded_path_helper() -> None:
+    from lib.doc_graph import is_excluded_path
+
+    assert is_excluded_path(Path("a/tests/fixtures/x.md"))
+    assert is_excluded_path(Path("tests/fixtures/x.md"))
+    assert is_excluded_path(Path(".assess/log.md"))
+    # `fixtures` not preceded by `tests`, and `tests` not followed by `fixtures`.
+    assert not is_excluded_path(Path("src/fixtures/x.md"))
+    assert not is_excluded_path(Path("tests/unit/x.md"))
+    assert not is_excluded_path(Path("tests/x/fixtures/y.md"))
+
+
 def test_graph_object_exposed_for_renderer(tmp_path: Path) -> None:
     """DocGraphResult.graph carries the networkx graph (the SVG renderer needs
     the full edge list, which as_dict doesn't serialise)."""

--- a/skills/assess/tests/test_doc_staleness.py
+++ b/skills/assess/tests/test_doc_staleness.py
@@ -176,3 +176,18 @@ def test_doc_staleness_honors_user_excludes(tmp_path: Path) -> None:
     assert r["association"]["doc_count"] == 1
     assert r["association"]["code_file_count"] == 1
     assert all("regulatory-raw" not in d["path"] for d in r["docs"])
+
+
+def test_doc_staleness_excludes_test_fixtures(tmp_path: Path) -> None:
+    """Markdown and code under `**/tests/fixtures/**` are scanner inputs, not
+    repo content, so they must not count toward the staleness association
+    (issue #83)."""
+    _write(tmp_path, "README.md", "main doc")
+    _write(tmp_path, "src/app.py", "x = 1")
+    _write(tmp_path, "tests/fixtures/sample/CLAUDE.md", "fixture")
+    _write(tmp_path, "tests/fixtures/sample/loader.py", "y = 2")
+
+    r = analyze_doc_staleness(tmp_path)
+    assert r["association"]["doc_count"] == 1
+    assert r["association"]["code_file_count"] == 1
+    assert all("fixtures" not in d["path"] for d in r["docs"])

--- a/skills/assess/tests/test_liveness_scan.py
+++ b/skills/assess/tests/test_liveness_scan.py
@@ -150,6 +150,17 @@ def test_dead_code_filters_user_excluded_candidates_post_scan(
     assert all("regulatory-raw" not in p for p in paths)
 
 
+def test_dead_code_excludes_test_fixtures(tmp_path: Path, monkeypatch) -> None:
+    """Vulture is told to skip `**/tests/fixtures/**` at scan time, and the
+    post-scan filter drops any fixture candidate that slips through, so a
+    deliberately-dead fixture file never surfaces as repo dead code (#83)."""
+    from lib.liveness_scan import _under_excluded, _vulture_excludes
+
+    assert "*/tests/fixtures/*" in _vulture_excludes().split(",")
+    assert _under_excluded("a/tests/fixtures/sample.py") is True
+    assert _under_excluded("src/app.py") is False
+
+
 # ── observability rungs ────────────────────────────────────────────────────
 
 def test_observability_none(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`/assess` reported **88% orphan rate / 12% reachability / 31 islands** on this repo, but the orphan set was dominated by non-navigational markdown - chiefly test fixtures under `skills/assess/tests/fixtures/**` that exist only to exercise the bloat/skills detectors. Counting scanner *inputs* as repo *docs* inflated the orphan rate and depressed the Layer 0 navigability read, producing a scary-but-misleading framing on a repo that is actually fine.

This excludes `**/tests/fixtures/**` from the doc graph (and from doc-staleness and liveness scans) by default, mirroring the mechanism that already auto-excludes `.assess/`.

Closes #83

## Changes Made

- **`doc_graph.py`**: new `EXCLUDE_PATH_SEQUENCES = (("tests", "fixtures"),)` plus a shared `is_excluded_path(rel)` helper that combines the existing single-segment `EXCLUDE_DIRS` match with multi-segment sequence matching. `discover_doc_files` now uses it.
- **`doc_staleness.py`**, **`liveness_scan.py`**: replaced the duplicated `any(part in EXCLUDE_DIRS for part in rel.parts)` checks with `is_excluded_path` across doc/code discovery, the dead-code language probe, and the post-scan candidate filter. `_vulture_excludes` now also emits `*/tests/fixtures/*` so vulture skips fixtures at scan time.
- **`SKILL.md`**: documents the new auto-exclusion alongside the `.assess/` note.
- **`plugin.json`**: `1.16.0` -> `1.16.1`.

## Technical Details

The exclusion matches the **consecutive `tests/fixtures` sequence**, not the bare `fixtures` dir name, so an unrelated top-level `fixtures/` of real content still counts. This is the built-in default; user-supplied `config.toml` / `--exclude` excludes continue to layer on top via `is_user_excluded`.

## Testing

`uv run --with pytest pytest` under `skills/assess/` (352 passed) and `scripts/` (69 passed). New tests:
- doc graph: fixtures excluded and orphan-rate math reflects it; unrelated top-level `fixtures/` not excluded; `is_excluded_path` unit coverage.
- doc-staleness: fixture doc + code dropped from the association.
- liveness: `_vulture_excludes` emits the fixtures glob and `_under_excluded` filters fixture candidates.

## Scope Notes

- The issue also suggested *considering* treating `agents/` and `commands/` plugin-definition markdown as a separate non-navigational class. That is more debatable (they are real repo content) and was left out of this PR; test fixtures were the clear-cut, must-fix case.
- `test_pressure.py` retains the single-segment `EXCLUDE_DIRS` check (fixtures are conventionally test-side there); left unchanged as out of scope.

## Risk Assessment

Low. Pure scan-discovery filtering with no API/flag changes; deterministic core fully covered by tests.