### PR TITLE
feat(assess): report accuracy + per-function complexity + layer guidance (#58 #59 #60 #62)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -443,6 +443,22 @@ ls "$REPO_ROOT"/.swiftlint.yml 2>/dev/null
 - Exhaustive matching? (exhaustive, strict unions)
 - Import boundary rules? (depguard, no-restricted-imports)
 
+**Per-language complexity-tool pointers** (name the *current canonical* tool when recommending a complexity/length rule, so the action doesn't pattern-match a discontinued package off training data - issue #62):
+
+| Language | Complexity / size rule source |
+|---|---|
+| Go | `golangci-lint`: `cyclop`, `gocognit`, `funlen`, `lll` |
+| JS/TS | ESLint `complexity`, `max-lines`, `max-lines-per-function`; or Biome equivalents |
+| Python | Ruff `C901` (mccabe), `PLR0915`; or `radon` for ad-hoc reports |
+| Java/Kotlin | `checkstyle` / `pmd` (Java), `detekt` (Kotlin) complexity rules |
+| C# | Roslyn analyzers (`EnableNETAnalyzers`), `CA1502`/`CA1505` maintainability rules |
+| Ruby | RuboCop `Metrics/*` (CyclomaticComplexity, MethodLength, ClassLength) |
+| Rust | Clippy `cognitive_complexity`, `too_many_lines` |
+| **Dart** | `custom_lint` + a community ruleset such as `solid_lints` (cyclomatic complexity / source-lines-of-code / number-of-parameters). The older `dart_code_metrics` is effectively discontinued for Dart 3 - do **not** recommend it; prefer `custom_lint`-based rulesets or point at <https://pub.dev> for the current option. |
+| Swift | SwiftLint `cyclomatic_complexity`, `function_body_length`, `file_length` |
+
+This list is a starting pointer, not a guarantee of currency - apply the currency-check in "Write the report" before naming any specific package version.
+
 **Cross-reference treemap evidence.** Read the stats sidecar to see what the linter actually catches in the wild - but only if Step 2 produced it. The sidecar is missing whenever the treemap script failed (no `uv`, non-git path, no scoreable files, etc.).
 
 ```bash
@@ -450,8 +466,17 @@ STATS="$REPO_ROOT/.assess/complexity-stats.json"
 if [ -f "$STATS" ]; then
   jq '{
     loc_p95: .loc.p95, loc_max: .loc.max,
-    ccn_p95: .ccn.p95, ccn_max: .ccn.max,
-    worst_complex: .top_complex[:3] | map(.path),
+    # Per-function ccn (`fn_ccn`) is the unit a linter threshold gates - compare
+    # THIS against cyclop:15 etc., never the file-aggregate `.ccn` block.
+    fn_ccn_p95: .fn_ccn.p95, fn_ccn_max: .fn_ccn.max,
+    fn_count: .fn_ccn.function_count,
+    # File-aggregate ccn (sum per file): drives the treemap hue / hotspot rank.
+    # NOT a per-function violation - label it as an aggregate in the report.
+    file_aggregate_ccn_p95: .ccn.p95, file_aggregate_ccn_max: .ccn.max,
+    # Each worst-complex row carries both: `ccn` is the file aggregate,
+    # `max_fn_ccn` is that file's worst single function (null = scc-scored, no
+    # function breakdown), which is what the threshold actually flags.
+    worst_complex: .top_complex[:3] | map({path, ccn, max_fn_ccn}),
     worst_large: .top_large[:3] | map(.path)
   }' "$STATS"
 else
@@ -461,12 +486,21 @@ fi
 
 If the sidecar is missing, skip the combined-scoring matrix below and fall back to the original Layer 3 rule: Present if linter config includes AI-relevant rules (including complexity/length), Partial if linter exists without them, Missing if no linter at all. Record "treemap unavailable" in the Evidence column so the gap is auditable.
 
-Thresholds for "high" (based on industry conventions - adjust for context):
+**Per-function vs file-aggregate complexity - do not conflate them (issue #58).** The sidecar carries two complexity signals:
+
+- **`fn_ccn` / a row's `max_fn_ccn`** - *per-function* cyclomatic complexity. A linter rule (`cyclop: 15`, `gocognit`, `complexity`) gates this. Compare it against the thresholds below.
+- **`ccn` / a row's `ccn`** - the *file-level aggregate* (sum of every function's complexity). It drives the treemap hue and the hotspot rank, but it is **not** a per-function value and a per-function threshold does not apply to it. A file of a dozen simple functions can sum past 100 with no single function violating anything.
+
+When you name a complexity hotspot, lead with the per-function fact against the threshold and label the aggregate as an aggregate. E.g. _"`service_modules.go` - file-aggregate ccn 136 across 13 functions; worst single function ccn 13, under the cyclop:15 threshold (no per-function violation)."_ Never report the aggregate as if it were one function's complexity. When `max_fn_ccn` is `null` (scc-scored file, no function breakdown), say so - don't invent a per-function number.
+
+**Verify any structural mechanism against the source before narrating it.** Do not write "a large switch dispatching by module name" (or any other concrete structure) inferred from a metric - the number tells you nothing about whether the code is a switch, a dispatch table, or a recursive walk. If you describe a mechanism, you must have read the file and confirmed it; otherwise describe only what the metric shows ("high aggregate complexity concentrated in N functions") and leave the mechanism to whoever opens the file.
+
+Thresholds for "high" (per-function `fn_ccn` for the complexity rows; `loc` is per-file - based on industry conventions, adjust for context):
 
 | Signal | Watch | High |
 |---|---|---|
-| p95 cyclomatic complexity | ≥ 10 | ≥ 15 |
-| max cyclomatic complexity | ≥ 30 | ≥ 50 |
+| p95 per-function cyclomatic complexity (`fn_ccn.p95`) | ≥ 10 | ≥ 15 |
+| max per-function cyclomatic complexity (`fn_ccn.max`) | ≥ 30 | ≥ 50 |
 | p95 file size (LOC) | ≥ 500 | ≥ 800 |
 | max file size (LOC) | ≥ 1500 | ≥ 2000 |
 
@@ -480,7 +514,9 @@ Thresholds for "high" (based on industry conventions - adjust for context):
 | Linter exists, no complexity/length rules | High | **Missing** - concrete evidence of the gap |
 | No linter at all | Either | **Missing** |
 
-When scoring Partial or Missing on this combined check, name the top 3 worst offenders from `top_complex` / `top_large` in the report's Evidence/Gap columns. Those are the files the missing rule would have flagged.
+In the matrix, "complexity in the High range" means **per-function** `fn_ccn` clears the threshold (a real per-function violation the linter rule would block) - not the file-aggregate `ccn`. A high aggregate with every function under the threshold is a *large file*, scored on the LOC rows, not a complexity violation.
+
+When scoring Partial or Missing on this combined check, name the top 3 worst offenders from `top_complex` / `top_large` in the report's Evidence/Gap columns. Those are the files the missing rule would have flagged. For each `top_complex` offender, cite its `max_fn_ccn` (the per-function value the threshold gates), not just the aggregate `ccn` - and if `max_fn_ccn` is under the threshold, it is not actually a per-function offender even though its aggregate is high.
 
 ### Layer 4: Architecture Tests (Conventions as Contracts)
 
@@ -725,13 +761,26 @@ The "Top 3 Actions" table at the bottom names specific files. Start there.
 
 [![Complexity hotspot](./complexity-heatmap.svg)](./complexity-heatmap.svg)
 
+- **Measured at commit:** `<head_short>` (<committed_date>)<staleness-suffix>
 - **Files scored:** <N>
 - **Churn window chosen:** <last 12mo | last 24mo | last 5y | all-time>
-- **Complexity profile:** p95 ccn <N> (max <M>); p95 LOC <N> (max <M>)
-- **Top hotspots** (composite `sqrt(ccn) × sqrt(1 + commits)` - a sub-linear blend of complexity and recent churn, so a complex-AND-active file leads, a frozen-but-complex file ranks below it, and a churny-but-trivial file can't top the list on churn alone):
-  1. `<path>` — <loc> LOC, ccn <N>, <M> commits in window
+- **Complexity profile:** per-function ccn p95 <N> (max <M>); file-aggregate ccn p95 <N> (max <M>); p95 LOC <N> (max <M>)
+- **Top hotspots** (composite `sqrt(ccn) × sqrt(1 + commits)` - a sub-linear blend of complexity and recent churn, so a complex-AND-active file leads, a frozen-but-complex file ranks below it, and a churny-but-trivial file can't top the list on churn alone). `ccn` here is the **file aggregate**; the worst single function per file is in parentheses:
+  1. `<path>` — <loc> LOC, aggregate ccn <N> (worst function <max_fn_ccn>), <M> commits in window
   2. ...
   3. ...
+
+**Pin the snapshot to its commit (issue #59).** Read `measured_commit` from `run-context.json` and fill the "Measured at commit" line so every absolute LOC/CCN figure in this report reads as a snapshot of one commit, not a current truth:
+
+```bash
+jq '.measured_commit' "$REPO_ROOT/.assess/run-context.json"
+```
+
+- When `available: false`, omit the "Measured at commit" line (no git history to pin to).
+- Render `head_short` and `committed_date`. Add a `<staleness-suffix>` warning when the snapshot is stale, so a reader knows the numbers may have drifted:
+  - `dirty: true` → append " - **working tree had uncommitted changes; figures include un-committed edits**".
+  - `behind` is a positive integer → append " - **HEAD was <behind> commit(s) behind `<upstream>`; absolute figures are a snapshot and may read low against current code**".
+  - Clean and up to date (`dirty: false`, `behind` 0 or null) → no suffix.
 
 Size encodes lines of code, colour encodes cyclomatic complexity (dark red = high), saturation encodes recent git churn (vivid = active). Vivid red blocks are the migration risk. When the treemap carries a **hatched** overlay (only when opt-in mutation results exist), those blocks are covered-but-unpinned code - tests run them without constraining them - so they stop reading as safe green; the heatmap's own legend keys the diagonal (>30% survivor density) and cross-hatch (>50%, severe).
 
@@ -821,9 +870,13 @@ The `Issue` column is filled in by Step 6 if the user opts to create tracking is
 
 **Use repo-relative paths only.** Never write absolute paths from your environment (e.g. `/Users/.../repo/src/foo.go`) into the report. They leak the author's directory layout, break shell commands for other contributors, and look unprofessional in committed artifacts. Repo-relative paths (`src/foo.go`, `.golangci.yml`) work everywhere.
 
+**Currency-check any package you name (issue #62).** Before naming a specific package *version* in an action (`dart_code_metrics: ^5.7.6`, `some-linter@2.1.0`), prefer naming the **rule/concept plus a pointer to the language's package registry** (pub.dev, npm, crates.io, PyPI, RubyGems) over a hardcoded version - registries stay current; your training data doesn't. If you do name a specific package, verify it's still actively maintained for the repo's language/runtime version rather than trusting recall. This protects every language symmetrically: any canonical tool can be deprecated after the model's training cutoff (the `dart_code_metrics` case), so "name the rule + registry" is the safe default.
+
 Good actions look like:
 
-> _"Add `cyclop` rule (threshold 15) to `.golangci.yml`. Current p95 ccn is 23; immediate offenders: `internal/import/parser.go` (ccn 67), `internal/sync/reconciler.go` (ccn 54)."_
+> _"Add `cyclop` rule (threshold 15) to `.golangci.yml`. Current per-function p95 is 23; immediate offenders by worst function: `internal/import/parser.go` (function ccn 67), `internal/sync/reconciler.go` (function ccn 54)."_
+
+Cite the **per-function** value (`fn_ccn` / `max_fn_ccn`) against a per-function rule, not the file aggregate - a `cyclop:15` rule flags functions, so a file whose worst function is 12 is not an offender no matter how high its aggregate sums (issue #58).
 
 Generic actions to avoid:
 
@@ -836,6 +889,16 @@ Generic actions to avoid:
 - **Layer 0 Partial because a hub doc is stale:** name the specific stale hub from `stale_hubs` and its churning subject — _"refresh `docs/architecture.md` (251d stale; subject `src/api/` had 47 commits in window)"_ — not "improve the docs".
 - **Layer 0 Partial because the doc set is fragmented:** name the orphans / islands — _"link the 6 orphan docs into the MOC; `index.md` is named but not wired (out-degree 0)"_.
 - **Layer 6 Partial because coverage is enforced but truth-pressure is unverified:** the actions are _"strengthen assertions to pin observable behaviour at the named survivors"_ and _"add mutation testing to CI (e.g. `mutmut`, Stryker, PITest)"_ — **not** "raise the coverage threshold" (higher line-coverage numbers manufacture more lying signal without improving behavioural constraint).
+
+**Cross-check offenders against the recommendation's own scope (issue #59a).** When an action names a *scope* ("un-exclude `services/*/service/*.go`", "enforce the rule under `src/core/`"), every offender you list in that action's evidence must actually fall within that scope. Before writing the offender list, verify each path against the named pattern - a `service_modules.go` under `shared/pkg/saga/schema/` is **not** under `services/*/service/`, so it can't be cited as evidence for un-excluding `services/*/service/`. If the worst offenders sit outside the scope you're recommending, either widen the recommended scope to cover them or move them to a separate action with the right scope. The offender list and the recommended change must describe the same set of files.
+
+**Apply the same truth-pressure to `/assess`'s own structural findings (issue #59c).** `/assess` grades other docs for being honest; its own topology/count claims are held to the same bar. Before stating any count-based finding - "the README lists 15 services but there are 19", "N modules lack a base doc" - **count the actual entries**, don't estimate or trust a single signal. For a service/component-count claim, enumerate both sides (what the doc lists vs what exists on disk) and report the real delta and the specific missing names, not a round-number guess. A wrong count ("missing 2" when it's actually missing 4, including specific named services) erodes trust exactly as a stale doc does. If you can't enumerate precisely, say "approximately" and name what you couldn't verify rather than asserting a false-precise number.
+
+**Sub-threshold "approaching the cap" findings are not refactor tasks (issue #60).** Files in the *Watch* band but under the *High* threshold (e.g. 600-800 LOC against an 800 cap, or per-function ccn 10-14 against a 15 rule) are **not violations**. Do not default them into refactor tasks - pre-emptively decomposing files that currently work fine is churn-for-churn (review cost, merge conflicts, behaviour risk on working code). Instead:
+
+- Keep actual violations (over the High threshold) as the standard remediation tasks.
+- Surface "approaching the cap" files as an **optional, low-priority** item in *Additional Opportunities*, never the Top 3 - and frame it **annotate-first**: the recommendation is to add an acknowledgement marker (e.g. a `// large-file: tracked` comment or a lint allow-entry) so the file is consciously owned, leaving the decompose-or-not decision to the maintainer. Only escalate to a refactor task when the file is over the cap or the maintainer asks.
+- Label the band explicitly in the report so a reader sees "under the cap, watch" - never present a sub-threshold file as if it failed a gate.
 
 ### Why these three?
 <2-3 sentences explaining why these are highest leverage. Connect to specific gaps from the table above and to hotspot files where relevant. Be concrete about what each action prevents.>

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -41,7 +41,7 @@ from lib.anomaly_detector import detect_anomalies
 from lib.assess_config import load_excludes, load_structure_config
 from lib.doc_graph import build_doc_graph, is_repo_file
 from lib.doc_staleness import analyze_doc_staleness
-from lib.git_churn import tracked_files
+from lib.git_churn import git_commit_info, tracked_files
 from lib.keyhole_signals import integrate as integrate_keyhole_signals
 from lib.liveness_scan import scan_liveness
 from lib.structure_graph import analyze_structure
@@ -474,6 +474,10 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
 
     ctx = {
         "run_date": run_date,
+        # The commit the scan measured. Absolute LOC/CCN figures are a snapshot
+        # of this commit; the report pins the SHA and warns when HEAD is dirty
+        # or behind its upstream so the numbers aren't read as current (#59).
+        "measured_commit": git_commit_info(repo_root),
         "prior_stats_exists": prior_exists,
         "stats_summary": {
             "files_scored": current.get("files_scored", 0),

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -177,10 +177,26 @@ def lizard_scores(
     root: Path, include_artifacts: bool = False,
     extra_exclude_dirs: set[str] | None = None,
     extra_exclude_patterns: list[str] | None = None,
-) -> dict[Path, tuple[int, float]]:
+) -> dict[Path, tuple[int, float, list[float]]]:
+    """Return ``{abs_path: (loc, ccn_sum, fn_ccns)}`` for scoreable files.
+
+    Two distinct complexity signals come out of lizard, and conflating them is
+    exactly the failure mode issue #58 reported:
+
+    - ``ccn_sum`` - the **file-level aggregate** (sum of every function's
+      cyclomatic complexity). This is the treemap's hue and the composite
+      hotspot score's complexity axis. It is NOT comparable to a per-function
+      linter threshold like ``cyclop: 15``; a file of twelve simple functions
+      can sum past 100 without any single function violating anything.
+    - ``fn_ccns`` - the **per-function** values. ``max(fn_ccns)`` is the worst
+      single function and is what a per-function linter threshold actually
+      gates. ``write_stats`` carries both so the report can say "ccn 136
+      aggregate; worst function 13, under the 15 threshold" instead of
+      mislabelling the aggregate as a per-function violation.
+    """
     extra_dirs = extra_exclude_dirs or set()
     extra_pats = extra_exclude_patterns or []
-    scores: dict[Path, tuple[int, float]] = {}
+    scores: dict[Path, tuple[int, float, list[float]]] = {}
     for f in lizard.analyze(paths=[str(root)], exclude_pattern=[]):
         path = Path(f.filename).resolve()
         try:
@@ -193,8 +209,9 @@ def lizard_scores(
             continue
         if _is_user_excluded(rel, extra_dirs, extra_pats):
             continue
-        ccn = sum(fn.cyclomatic_complexity for fn in f.function_list) or 1
-        scores[path] = (f.nloc, float(ccn))
+        fn_ccns = [float(fn.cyclomatic_complexity) for fn in f.function_list]
+        ccn_sum = sum(fn_ccns) or 1.0
+        scores[path] = (f.nloc, float(ccn_sum), fn_ccns)
     return scores
 
 
@@ -263,13 +280,18 @@ def collect(root: Path, by: str = "complexity",
             extra_exclude_dirs: set[str] | None = None,
             extra_exclude_patterns: list[str] | None = None,
             ) -> tuple[list[tuple[Path, int, float, str]], str,
-                       dict[Path, int] | None, str | None]:
-    """Returns (files, effective_by, aux_data, aux_label).
+                       dict[Path, int] | None, str | None,
+                       dict[Path, list[float]]]:
+    """Returns (files, effective_by, aux_data, aux_label, fn_ccn_by_path).
 
     - files: [(path, loc, metric, source)] - metric depends on mode
     - effective_by: may differ from `by` if we fell back (e.g. no git)
     - aux_data: secondary per-file signal (hotspot mode only); None otherwise
     - aux_label: human label for aux signal in tooltips
+    - fn_ccn_by_path: per-function cyclomatic-complexity lists, lizard files
+      only (scc reports file-level complexity with no function breakdown, so
+      its paths are absent here). Threaded to `write_stats` so the report can
+      separate per-function violations from file-level aggregates (issue #58).
     """
     lz = lizard_scores(
         root, include_artifacts=include_artifacts,
@@ -282,8 +304,10 @@ def collect(root: Path, by: str = "complexity",
         extra_exclude_patterns=extra_exclude_patterns,
     )
     files: list[tuple[Path, int, float, str]] = []
-    for path, (loc, ccn) in lz.items():
+    fn_ccn_by_path: dict[Path, list[float]] = {}
+    for path, (loc, ccn, fn_ccns) in lz.items():
         files.append((path, loc, ccn, "lizard"))
+        fn_ccn_by_path[path] = fn_ccns
     for path, (loc, cx) in sc.items():
         if path not in lz:
             files.append((path, loc, cx, "scc"))
@@ -307,7 +331,7 @@ def collect(root: Path, by: str = "complexity",
             _git_not_found_warning(root)
             effective_by = "complexity"
 
-    return files, effective_by, aux_data, aux_label
+    return files, effective_by, aux_data, aux_label, fn_ccn_by_path
 
 
 DOMINANCE_WARN_THRESHOLD = 0.30  # one file >30% of total LOC = suspicious
@@ -470,7 +494,8 @@ def _read_plugin_version() -> str:
 def write_stats(files: list[tuple[Path, int, float, str]],
                 aux_data: dict[Path, int] | None,
                 aux_label: str | None,
-                root: Path, out_path: Path) -> None:
+                root: Path, out_path: Path,
+                fn_ccn_by_path: dict[Path, list[float]] | None = None) -> None:
     """Write a JSON stats sidecar summarising the treemap data.
 
     Consumed by the /assess skill: percentiles drive Layer 3 (linter) scoring,
@@ -479,11 +504,26 @@ def write_stats(files: list[tuple[Path, int, float, str]],
     geometric mean of complexity and recent churn. Both axes are damped, so a
     complex-AND-active file leads, a frozen-but-complex file ranks below it, and
     a trivially-simple-but-churny file can't top the list on churn alone.
+
+    The ``ccn`` block and every row's ``ccn`` field are **file-level aggregates**
+    (sum of per-function complexity). A per-function linter threshold (cyclop 15,
+    gocognit, etc.) is NOT comparable to those - so each row also carries
+    ``max_fn_ccn`` (the file's worst single function, or null for scc-scored
+    files with no function breakdown), and the top-level ``fn_ccn`` block reports
+    the per-function distribution. Layer 3 compares the linter threshold against
+    ``fn_ccn`` / ``max_fn_ccn``, never the aggregate (issue #58).
     """
+    fn_ccn_by_path = fn_ccn_by_path or {}
     locs = [f[1] for f in files]
     ccns = [f[2] for f in files]
     churns = ([float(aux_data.get(f[0], 0)) for f in files]
               if aux_data is not None else [])
+    # Per-function population, lizard files only. scc paths are absent from
+    # fn_ccn_by_path, so they simply don't contribute - the block self-labels
+    # its source so a reader knows it omits scc-scored files.
+    fn_population: list[float] = []
+    for vals in fn_ccn_by_path.values():
+        fn_population.extend(vals)
 
     def pct(values: list[float], q: float) -> float:
         return float(np.percentile(values, q)) if values else 0.0
@@ -494,13 +534,21 @@ def write_stats(files: list[tuple[Path, int, float, str]],
         except ValueError:
             return str(p)
 
+    def max_fn(path: Path) -> float | None:
+        vals = fn_ccn_by_path.get(path)
+        return float(max(vals)) if vals else None
+
     enriched = []
     for path, loc, ccn, src in files:
         churn = float(aux_data.get(path, 0)) if aux_data else 0.0
         enriched.append({
             "path": rel(path),
             "loc": int(loc),
+            # File-level aggregate (sum of per-function ccn). See `max_fn_ccn`
+            # for the per-function worst case the linter threshold gates.
             "ccn": float(ccn),
+            "ccn_basis": "file-aggregate",
+            "max_fn_ccn": max_fn(path),
             # Named `commits` to match what every consumer reads (stats_diff,
             # assess_core, the hotspot template). None when churn is unavailable
             # (no git), so a missing value is distinct from a real 0.
@@ -530,10 +578,25 @@ def write_stats(files: list[tuple[Path, int, float, str]],
             "max": float(max(locs)) if locs else 0.0,
             "total": sum(locs),
         },
+        # File-level aggregate complexity (sum per file). Drives the treemap hue
+        # and the hotspot composite - NOT comparable to a per-function linter
+        # threshold. Use `fn_ccn` for that comparison.
         "ccn": {
+            "basis": "file-aggregate",
             "p50": pct(ccns, 50),
             "p95": pct(ccns, 95),
             "max": float(max(ccns)) if ccns else 0.0,
+        },
+        # Per-function complexity distribution (the unit a linter threshold like
+        # cyclop:15 actually gates). lizard files only; scc files contribute no
+        # function breakdown. `function_count` is 0 when only scc scored the repo.
+        "fn_ccn": {
+            "basis": "per-function",
+            "source": "lizard-only",
+            "function_count": len(fn_population),
+            "p50": pct(fn_population, 50),
+            "p95": pct(fn_population, 95),
+            "max": float(max(fn_population)) if fn_population else 0.0,
         },
         "churn": ({
             "p50": pct(churns, 50),
@@ -662,7 +725,7 @@ def main() -> int:
         else:
             extra_dirs.add(pat)
 
-    files, effective_by, aux_data, aux_label = collect(
+    files, effective_by, aux_data, aux_label, fn_ccn_by_path = collect(
         root, by="hotspot", include_artifacts=args.include_artifacts,
         extra_exclude_dirs=extra_dirs,
         extra_exclude_patterns=extra_patterns,
@@ -683,7 +746,8 @@ def main() -> int:
            aux_data=aux_data, aux_label=aux_label,
            survivor_density=survivor_density)
     if args.stats:
-        write_stats(files, aux_data, aux_label, root, args.stats)
+        write_stats(files, aux_data, aux_label, root, args.stats,
+                    fn_ccn_by_path=fn_ccn_by_path)
     return 0
 
 

--- a/skills/assess/scripts/lib/git_churn.py
+++ b/skills/assess/scripts/lib/git_churn.py
@@ -67,6 +67,71 @@ def git_churn_scores(root: Path, since: str | None = None) -> dict[Path, int]:
     return counts
 
 
+def git_commit_info(root: Path) -> dict:
+    """Capture the commit the scan measured, so the report can pin its absolute
+    LOC/CCN figures to a snapshot and warn when that snapshot is stale.
+
+    Issue #59 observed figures drifting 15-25% low because a run measured an
+    older commit than the one a reader later compared against. Absolute numbers
+    are only trustworthy against a named commit; this surfaces that commit plus
+    two staleness signals.
+
+    Returns a dict:
+      - ``available``: False (with ``reason``) when ``root`` isn't a git repo or
+        git is unreachable; the report then omits the snapshot line.
+      - ``head_sha`` / ``head_short``: the commit HEAD pointed at during the scan.
+      - ``committed_date``: ISO-8601 author date of HEAD.
+      - ``subject``: HEAD's commit subject line.
+      - ``dirty``: True when tracked files have uncommitted changes, so the
+        measured numbers reflect the working tree, not any single commit.
+      - ``upstream``: the upstream tracking ref (e.g. ``origin/main``) or None.
+      - ``behind``: commits HEAD is behind ``upstream`` (0 = up to date,
+        None = no upstream configured), i.e. how stale the snapshot is vs remote.
+    """
+    def _git(*args: str) -> str | None:
+        try:
+            out = subprocess.run(
+                ["git", "-C", str(root), *args],
+                capture_output=True, text=True, check=True,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired):
+            return None
+        return out.stdout.strip()
+
+    head_sha = _git("rev-parse", "HEAD")
+    if not head_sha:
+        return {"available": False,
+                "reason": "not a git repo or no commits on HEAD"}
+
+    info: dict = {
+        "available": True,
+        "head_sha": head_sha,
+        "head_short": head_sha[:12],
+        "committed_date": _git("show", "-s", "--format=%cd", "--date=short",
+                               "HEAD"),
+        "subject": _git("show", "-s", "--format=%s", "HEAD"),
+        # `--porcelain` with untracked excluded: a non-empty result means the
+        # scan saw uncommitted edits to tracked files, so its numbers don't
+        # match the HEAD commit exactly.
+        "dirty": bool(_git("status", "--porcelain", "--untracked-files=no")),
+        "upstream": None,
+        "behind": None,
+    }
+
+    upstream = _git("rev-parse", "--abbrev-ref", "--symbolic-full-name",
+                    "@{upstream}")
+    if upstream:
+        info["upstream"] = upstream
+        behind = _git("rev-list", "--count", "HEAD..@{upstream}")
+        try:
+            info["behind"] = int(behind) if behind is not None else None
+        except ValueError:
+            info["behind"] = None
+    return info
+
+
 def file_last_commit_days(path: Path) -> int | None:
     """Days since `path` was last committed in git. None if not tracked.
 

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -122,6 +122,53 @@ def test_write_stats_commits_none_without_git(treemap, tmp_path):
     assert stats["top_hotspots"][0]["commits"] is None
 
 
+def test_write_stats_separates_aggregate_from_per_function_ccn(treemap, tmp_path):
+    """Issue #58: the file-level aggregate ccn (sum of per-function complexity)
+    must be labelled as an aggregate and never conflated with the per-function
+    value a linter threshold gates. A file summing to ccn 136 whose worst
+    single function is only 13 is NOT a per-function violation."""
+    root = tmp_path
+    f = root / "service_modules.go"   # the issue's actual offender shape
+    out = root / "stats.json"
+    # 13 functions whose complexities sum to 136 (the reported aggregate),
+    # worst single function = 13 (under a cyclop:15 threshold).
+    fn_ccns = [13.0, 13.0, 12.0, 12.0, 11.0, 11.0, 10.0, 10.0,
+               9.0, 9.0, 8.0, 8.0, 10.0]
+    assert sum(fn_ccns) == 136.0
+    treemap.write_stats(
+        [(f, 800, 136.0, "lizard")], {f: 3}, "commits (last 12mo)", root, out,
+        fn_ccn_by_path={f: fn_ccns},
+    )
+    stats = json.loads(out.read_text())
+
+    # The aggregate block self-labels and the per-function block is separate.
+    assert stats["ccn"]["basis"] == "file-aggregate"
+    assert stats["ccn"]["max"] == 136.0
+    assert stats["fn_ccn"]["basis"] == "per-function"
+    assert stats["fn_ccn"]["function_count"] == 13
+    assert stats["fn_ccn"]["max"] == 13.0   # worst function, not the sum
+
+    row = stats["top_complex"][0]
+    assert row["ccn"] == 136.0              # aggregate preserved for the hue
+    assert row["ccn_basis"] == "file-aggregate"
+    assert row["max_fn_ccn"] == 13.0        # the per-function truth for Layer 3
+
+
+def test_write_stats_scc_file_has_null_max_fn_ccn(treemap, tmp_path):
+    """scc reports file-level complexity with no function breakdown, so a
+    scc-scored file carries max_fn_ccn=null - the report must not invent a
+    per-function value it never measured."""
+    root = tmp_path
+    f = root / "report.sql"
+    out = root / "stats.json"
+    # No fn_ccn_by_path entry for this path -> scc-style, per-function unknown.
+    treemap.write_stats([(f, 400, 50.0, "scc")], None, None, root, out,
+                        fn_ccn_by_path={})
+    stats = json.loads(out.read_text())
+    assert stats["top_complex"][0]["max_fn_ccn"] is None
+    assert stats["fn_ccn"]["function_count"] == 0
+
+
 def test_assess_dir_is_self_excluded_by_default(treemap):
     """A prior run's run-context.json must not be scored on the next run -
     the script's own output directory is in EXCLUDE_DIRS. Otherwise re-runs
@@ -187,7 +234,7 @@ def test_cli_exclude_classifies_glob_vs_dir(treemap, monkeypatch, tmp_path):
         captured["extra_dirs"] = kwargs.get("extra_exclude_dirs")
         captured["extra_patterns"] = kwargs.get("extra_exclude_patterns")
         # Return an empty result so main bails out early but cleanly.
-        return [], "complexity", None, None
+        return [], "complexity", None, None, {}
 
     monkeypatch.setattr(treemap, "collect", fake_collect)
     monkeypatch.setattr(
@@ -219,7 +266,7 @@ def test_cli_exclude_merges_with_config_toml(treemap, monkeypatch, tmp_path):
     def fake_collect(*args, **kwargs):
         captured["extra_dirs"] = kwargs.get("extra_exclude_dirs")
         captured["extra_patterns"] = kwargs.get("extra_exclude_patterns")
-        return [], "complexity", None, None
+        return [], "complexity", None, None, {}
 
     monkeypatch.setattr(treemap, "collect", fake_collect)
     monkeypatch.setattr(

--- a/skills/assess/tests/test_git_commit_info.py
+++ b/skills/assess/tests/test_git_commit_info.py
@@ -1,0 +1,99 @@
+"""Tests for git_churn.git_commit_info - the measured-commit snapshot that lets
+the /assess report pin its absolute LOC/CCN figures to a SHA and warn when the
+snapshot is stale (issue #59)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parents[1] / "scripts" / "lib" / "git_churn.py"
+_spec = importlib.util.spec_from_file_location("git_churn", _LIB)
+git_churn = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(git_churn)
+
+
+def test_returns_unavailable_outside_git_repo(tmp_path):
+    """A plain directory (no .git) degrades to available:False with a reason,
+    so the report omits the snapshot line rather than inventing a SHA."""
+    info = git_churn.git_commit_info(tmp_path)
+    assert info["available"] is False
+    assert "reason" in info
+
+
+def test_pins_head_sha_and_clean_tree(git_repo):
+    repo, commit = git_repo
+    (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+    commit("initial commit")
+
+    info = git_churn.git_commit_info(repo)
+    assert info["available"] is True
+    assert len(info["head_sha"]) == 40
+    assert info["head_short"] == info["head_sha"][:12]
+    assert info["subject"] == "initial commit"
+    assert info["committed_date"]  # ISO short date, non-empty
+    # Clean working tree, and a fresh repo has no upstream configured.
+    assert info["dirty"] is False
+    assert info["upstream"] is None
+    assert info["behind"] is None
+
+
+def test_flags_dirty_working_tree(git_repo):
+    """Uncommitted edits to a tracked file mean the measured numbers reflect
+    the working tree, not HEAD - the report must warn on this."""
+    repo, commit = git_repo
+    (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+    commit("initial commit")
+    # Modify the tracked file without committing.
+    (repo / "a.py").write_text("x = 2\nprint(x)\n", encoding="utf-8")
+
+    info = git_churn.git_commit_info(repo)
+    assert info["dirty"] is True
+
+
+def test_untracked_file_does_not_mark_dirty(git_repo):
+    """Only tracked-file changes count as dirty - a stray untracked file (e.g.
+    a contributor's scratch note) must not flip the snapshot warning."""
+    repo, commit = git_repo
+    (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+    commit("initial commit")
+    (repo / "scratch.txt").write_text("notes\n", encoding="utf-8")
+
+    info = git_churn.git_commit_info(repo)
+    assert info["dirty"] is False
+
+
+def test_reports_behind_count_vs_upstream(git_repo, tmp_path):
+    """When HEAD trails its upstream, `behind` is the commit gap - that is the
+    staleness signal that explains absolute figures drifting low (#59)."""
+    import subprocess
+
+    repo, commit = git_repo
+    (repo / "a.py").write_text("v = 1\n", encoding="utf-8")
+    commit("c1")
+    (repo / "a.py").write_text("v = 2\n", encoding="utf-8")
+    commit("c2")
+
+    # Stand up a local "remote" two commits ahead, then point the branch's
+    # upstream at it while leaving HEAD one commit back.
+    def _g(*args, cwd=repo):
+        subprocess.run(["git", "-C", str(cwd), *args],
+                       check=True, capture_output=True, text=True)
+
+    remote = tmp_path / "remote.git"
+    _g("clone", "--bare", str(repo), str(remote), cwd=tmp_path)
+    branch = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True, capture_output=True, text=True).stdout.strip()
+    _g("remote", "add", "origin", str(remote))
+    _g("fetch", "-q", "origin")
+    _g("branch", f"--set-upstream-to=origin/{branch}", branch)
+
+    # Advance the remote by one commit so HEAD is exactly 1 behind.
+    (repo / "a.py").write_text("v = 3\n", encoding="utf-8")
+    commit("c3")
+    _g("push", "-q", "origin", branch)
+    _g("reset", "-q", "--hard", "HEAD~1")  # move HEAD back behind upstream
+
+    info = git_churn.git_commit_info(repo)
+    assert info["upstream"] == f"origin/{branch}"
+    assert info["behind"] == 1


### PR DESCRIPTION
## Summary

Improves `/assess` report accuracy and per-language guidance across four feedback issues. The core change separates **per-function** cyclomatic complexity from the **file-level aggregate** so the report stops narrating an aggregate sum as a per-function violation, and threads the **measured commit SHA** into the report so absolute figures read as a snapshot.

Closes #58
Closes #59
Closes #60
Closes #62

## Changes Made

### #58 - per-function vs file-aggregate complexity
- `complexity-treemap.py` now captures per-function CCN lists from lizard. The stats sidecar keeps the file-aggregate `ccn` (sum, drives the treemap hue/hotspot rank) but adds a per-function `fn_ccn` distribution block and a `max_fn_ccn` field on every `top_complex`/`top_hotspots`/`top_large` row. Both the aggregate block and rows self-label with `basis: file-aggregate`.
- scc-scored files (no function breakdown) carry `max_fn_ccn: null` - the report must not invent a per-function number.
- SKILL.md Layer 3 compares linter thresholds (`cyclop:15`, etc.) against `fn_ccn`/`max_fn_ccn`, never the aggregate, and requires verifying any structural mechanism ("a large switch dispatching by X") against source before narrating it.

### #59 - report truth-pressure
- New `git_commit_info()` in `git_churn.py` captures the measured HEAD SHA, commit date, dirty-tree flag, upstream ref, and commits-behind count. Wired into `run-context.json` as `measured_commit`.
- SKILL.md report header pins `head_short` + `committed_date` and warns when the tree was dirty or HEAD trailed its upstream (59b).
- Guidance added to cross-check offender lists against the recommendation's named scope (59a) and to enumerate actual entries before stating any topology/service-count finding (59c).

### #60 - approaching-the-cap
- Sub-threshold "Watch" band files (under the High cap) are reframed as optional, low-priority, **annotate-first** items - never defaulted into Top 3 refactor tasks.

### #62 - per-language currency
- Layer 3 gains a per-language complexity-tool pointer table including a current Dart entry (`custom_lint` + `solid_lints`, not the discontinued `dart_code_metrics`).
- A currency-check instruction prefers naming a rule + package registry over a hardcoded version, protecting every language symmetrically.

## Technical Details

The file-aggregate vs per-function distinction is the root of #58: line 196 of `complexity-treemap.py` summed every function's complexity into one `ccn` value, which Layer 3 then compared against per-function linter thresholds. A real run against this repo shows `lib/test_pressure.py` at file-aggregate ccn 216 but worst single function only 20 - previously reported as if 216 were one function.

## Testing

- New `tests/test_git_commit_info.py` (5 tests): unavailable-outside-repo, SHA pinning, dirty-tree detection, untracked-file isolation, behind-upstream count.
- New treemap tests: aggregate-vs-per-function separation (the issue's 136-sum / 13-worst shape) and scc null `max_fn_ccn`.
- Full suite: 354 passed (`skills/assess/`), 69 passed (`scripts/` standalone pipeline). Standalone `assess` ZIP builds clean.

## Risk Assessment

Low. The stats changes are additive (new keys on existing rows + a new block); existing consumers (stats_diff, assess_core, wiki templates) are unaffected. `measured_commit` is a new run-context key. SKILL.md changes are prose guidance. No marker changes needed (no plugin-only constructs introduced).

---

_Generated by [`/ai-native-toolkit:assess`](https://github.com/bjcoombs/ai-native-toolkit) feedback loop._
