### PR TITLE
ci: add ruff complexity gate and mypy type checking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,29 @@ jobs:
 
       - name: Run pytest
         run: uv run --with pytest pytest -v tests/
+
+  lint:
+    name: ruff + mypy gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+
+      # Layer 3 complexity ratchet + pyflakes/pycodestyle gate (issue #77).
+      # Config (threshold, exclusions, per-function noqa) lives in each
+      # pyproject.toml so the gate is identical locally and in CI.
+      - name: Ruff lint + complexity gate (skills/assess)
+        run: uv run --with ruff ruff check .
+        working-directory: skills/assess
+
+      - name: Ruff lint + complexity gate (scripts)
+        run: uv run --with ruff ruff check .
+        working-directory: scripts
+
+      # Layer 2 type gate (issue #79). Scoped to the deterministic core (lib/);
+      # config in skills/assess/pyproject.toml selects the files and checks.
+      - name: Mypy type gate (skills/assess deterministic core)
+        run: uv run --with mypy mypy
+        working-directory: skills/assess

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -13,3 +13,16 @@ dev = [
 testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-v --tb=short"
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Mirror the skills/assess gate (issue #77): Ruff's default E4/E7/E9 + F rules
+# plus the mccabe complexity ratchet. build_standalone_skill_zip (ccn 17)
+# carries an explicit ``# noqa: C901``; the gate fails the moment any other
+# function regresses past the threshold.
+select = ["E4", "E7", "E9", "F", "C901"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15

--- a/scripts/transform_skill.py
+++ b/scripts/transform_skill.py
@@ -104,7 +104,7 @@ def strip_frontmatter(text: str) -> str:
     return text[m.end():].lstrip("\n")
 
 
-def build_standalone_skill_zip(
+def build_standalone_skill_zip(  # noqa: C901  # marker-transform + zip assembly; ccn 17, ratchet target
     skill_source_dir: Path,
     out_zip: Path,
     standalone_name: str,

--- a/skills/assess/pyproject.toml
+++ b/skills/assess/pyproject.toml
@@ -22,3 +22,57 @@ addopts = "-v --tb=short"
 # import from their own `src/` package which isn't on the path, so collecting
 # them errors. Exclude the whole fixtures tree from collection.
 norecursedirs = ["tests/fixtures"]
+
+[tool.ruff]
+target-version = "py311"
+# Test fixtures are deliberately messy sample repos consumed as *data*, not
+# code we own. The doc-graph and test-pressure scans already exclude them; the
+# linter must too, or it grades the fixtures instead of the core.
+#
+# doc-graph-svg.py is an auxiliary Matplotlib renderer (not part of the
+# deterministic assess core that issue #77 targets) and carries pre-existing
+# defects the new linter surfaces - an undefined ``_classify`` in the
+# ``colour="status"`` branch (F821) and an unused ``pr_max`` (F841). Excluded
+# here and flagged for a separate fix rather than papered over with inline noqa.
+extend-exclude = ["tests/fixtures", "scripts/doc-graph-svg.py"]
+
+[tool.ruff.lint]
+# Ruff's default rule set (E4/E7/E9 pycodestyle + F pyflakes) plus the mccabe
+# cyclomatic-complexity gate (C901). This is the Layer 3 "no linter" fix from
+# issue #77: a load-bearing complexity ratchet, not a style overhaul.
+select = ["E4", "E7", "E9", "F", "C901"]
+
+[tool.ruff.lint.per-file-ignores]
+# Package __init__.py files deliberately re-export names (some private, e.g.
+# test_pressure's shutil/subprocess/_parse_* surfaced for test monkeypatching);
+# F401 "imported but unused" is the wrong signal there.
+"**/__init__.py" = ["F401"]
+
+[tool.ruff.lint.mccabe]
+# Per-function cyclomatic complexity. 15 fences current reality: every linted
+# function already sits at or below it except the genuine offenders (ccn 17-19),
+# which carry an explicit ``# noqa: C901`` with a note - build_doc_graph and
+# authorship_analysis here, and build_standalone_skill_zip in scripts/. The gate
+# fails the moment any other function regresses past 15; ratchet down as the
+# offenders are decomposed.
+max-complexity = 15
+
+[tool.mypy]
+# Issue #79: type hints existed but were unenforced. This gate makes them a
+# contract. Scoped to the deterministic core (lib/) where the annotations are
+# densest and most load-bearing; the top-level orchestrator scripts
+# (assess_core.py, assess_finalize.py, complexity-treemap.py) and the build
+# pipeline are the next ratchet step.
+files = ["scripts/lib"]
+# lib/ is a package; treat scripts/ as the import base so lib.<mod> resolves and
+# the back-compat shims (scripts/stats_diff.py, lib/assess_core.py) don't collide
+# as duplicate top-level modules.
+mypy_path = "scripts"
+explicit_package_bases = true
+namespace_packages = true
+# networkx and grimp ship no type stubs; their absence is not a code defect.
+# The lib modules carry defensive ``# type: ignore[assignment]`` on their
+# degrade-gracefully ``nx = None`` fallbacks so they also type-check when stubs
+# ARE installed; ``warn_unused_ignores`` is left off so those stay put.
+ignore_missing_imports = true
+warn_redundant_casts = true

--- a/skills/assess/pyproject.toml
+++ b/skills/assess/pyproject.toml
@@ -28,13 +28,7 @@ target-version = "py311"
 # Test fixtures are deliberately messy sample repos consumed as *data*, not
 # code we own. The doc-graph and test-pressure scans already exclude them; the
 # linter must too, or it grades the fixtures instead of the core.
-#
-# doc-graph-svg.py is an auxiliary Matplotlib renderer (not part of the
-# deterministic assess core that issue #77 targets) and carries pre-existing
-# defects the new linter surfaces - an undefined ``_classify`` in the
-# ``colour="status"`` branch (F821) and an unused ``pr_max`` (F841). Excluded
-# here and flagged for a separate fix rather than papered over with inline noqa.
-extend-exclude = ["tests/fixtures", "scripts/doc-graph-svg.py"]
+extend-exclude = ["tests/fixtures"]
 
 [tool.ruff.lint]
 # Ruff's default rule set (E4/E7/E9 pycodestyle + F pyflakes) plus the mccabe
@@ -49,12 +43,12 @@ select = ["E4", "E7", "E9", "F", "C901"]
 "**/__init__.py" = ["F401"]
 
 [tool.ruff.lint.mccabe]
-# Per-function cyclomatic complexity. 15 fences current reality: every linted
-# function already sits at or below it except the genuine offenders (ccn 17-19),
-# which carry an explicit ``# noqa: C901`` with a note - build_doc_graph and
-# authorship_analysis here, and build_standalone_skill_zip in scripts/. The gate
-# fails the moment any other function regresses past 15; ratchet down as the
-# offenders are decomposed.
+# Per-function cyclomatic complexity. 15 fences current reality: every function
+# already sits at or below it except four genuine offenders (ccn 17-19), which
+# carry an explicit ``# noqa: C901`` with a note - build_doc_graph and
+# authorship_analysis here, render in doc-graph-svg.py, and
+# build_standalone_skill_zip in scripts/. The gate fails the moment any other
+# function regresses past 15; ratchet down as the four are decomposed.
 max-complexity = 15
 
 [tool.mypy]

--- a/skills/assess/scripts/doc-graph-svg.py
+++ b/skills/assess/scripts/doc-graph-svg.py
@@ -190,14 +190,13 @@ def _render_ghosts(broken_links: list[dict], pos: dict, radius,
     return "\n".join(out)
 
 
-def render(result, out_path: Path, repo_root: Path, *, layout: str = "radial",
+def render(result, out_path: Path, repo_root: Path, *, layout: str = "radial",  # noqa: C901  # SVG layout + colour-mode branching; ccn 18, ratchet target
            size_mode: str = "lines", colour: str = "staleness",
            staleness: dict | None = None, show_labels: bool = False) -> None:
     graph = result.graph
     nodes = list(graph.nodes())
     n = len(nodes)
     pr = result.pagerank or {x: 1.0 / max(n, 1) for x in nodes}
-    pr_max = max(pr.values()) if pr else 1.0
     in_deg = dict(graph.in_degree())
     out_deg = dict(graph.out_degree())
 
@@ -227,7 +226,7 @@ def render(result, out_path: Path, repo_root: Path, *, layout: str = "radial",
 
     def fill(node: str) -> str:
         if colour == "status":
-            return _STATUS_COLOR[_classify(node, entries, unreachable, orphans)]
+            return _STATUS_COLOR[classify_node(node, entries, unreachable, orphans)]
         base = cmap(min(days[node] / day_cap, 1.0) if day_cap else 0.0)
         sat = (churn[node] / churn_cap) if churn_cap else 0.0
         return rgba_to_hex(blend_to_grey(base, sat))

--- a/skills/assess/scripts/lib/change_coupling.py
+++ b/skills/assess/scripts/lib/change_coupling.py
@@ -148,7 +148,9 @@ def change_coupling_pairs(
         for (a, b), count in counts.items()
         if count >= min_support
     ]
-    pairs.sort(key=lambda d: (-d["co_change_count"], d["file_a"], d["file_b"]))
+    # dict values are heterogeneous (str | int | float), so mypy types the
+    # lookup as ``object``; the negation is valid at runtime (count is int).
+    pairs.sort(key=lambda d: (-d["co_change_count"], d["file_a"], d["file_b"]))  # type: ignore[operator]
     return pairs
 
 
@@ -241,7 +243,7 @@ def _coauthors_have_agent(coauthor_field: str) -> bool:
     return False
 
 
-def authorship_analysis(repo_root: Path, path: Path | str) -> dict:
+def authorship_analysis(repo_root: Path, path: Path | str) -> dict:  # noqa: C901  # multi-signal B4 heuristic; ccn 19, ratchet target
     """B4: human-anchor / intent-source signals and a conservative class for ``path``.
 
     Returns ``{human_anchor, authorship_class, intent_source, contributors}``:

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -213,7 +213,7 @@ class DocGraphResult:
         }
 
 
-def is_repo_file(path: Path, repo_root: Path, tracked: set[Path] | None) -> bool:
+def is_repo_file(path: Path, repo_root: Path, tracked: set[Path] | frozenset[Path] | None) -> bool:
     """True if `path` is genuinely part of the repo.
 
     Excludes two classes of non-repo file the scan must ignore:
@@ -468,7 +468,7 @@ def classify_node(node: str, entries: set, unreachable: set, orphans: set) -> st
     return "island"
 
 
-def build_doc_graph(
+def build_doc_graph(  # noqa: C901  # graph assembly + link resolution; ccn 19, ratchet target
     repo_root: Path, doc_files: list[Path] | None = None,
     extra_exclude_dirs: set[str] | None = None,
     extra_exclude_patterns: list[str] | None = None,

--- a/skills/assess/scripts/lib/doc_staleness.py
+++ b/skills/assess/scripts/lib/doc_staleness.py
@@ -33,7 +33,6 @@ from lib.doc_graph import (
 )
 from lib.git_churn import (
     file_last_commit_days,
-    git_churn_scores,
     pick_churn_window,
     tracked_files,
 )

--- a/skills/assess/scripts/lib/keyhole_signals.py
+++ b/skills/assess/scripts/lib/keyhole_signals.py
@@ -370,7 +370,9 @@ def build_attention_list(
         {"path": path, "findings": sorted(set(names)), "score": len(set(names))}
         for path, names in reasons.items()
     ]
-    units.sort(key=lambda u: (-u["score"], u["path"]))
+    # dict values are heterogeneous (str | list | int), so mypy types the
+    # lookup as ``object``; the negation is valid at runtime (score is int).
+    units.sort(key=lambda u: (-u["score"], u["path"]))  # type: ignore[operator]
     return units[:max_units]
 
 

--- a/skills/assess/scripts/lib/structure_graph.py
+++ b/skills/assess/scripts/lib/structure_graph.py
@@ -460,8 +460,8 @@ def analyze_structure(
 
     modules = sorted(import_graph.modules)
     package_set = set(package_names) | {
-        m for m in modules if _module_file(m, roots) and
-        _module_file(m, roots).name == "__init__.py"
+        m for m in modules
+        if (mf := _module_file(m, roots)) is not None and mf.name == "__init__.py"
     }
 
     # Measure each module's size and public surface once.

--- a/skills/assess/tests/test_anomaly_detector.py
+++ b/skills/assess/tests/test_anomaly_detector.py
@@ -1,7 +1,7 @@
 """Tests for anomaly detection on /assess run output."""
 from __future__ import annotations
 
-from lib.anomaly_detector import Anomaly, detect_anomalies
+from lib.anomaly_detector import detect_anomalies
 
 
 def _ctx(**overrides) -> dict:

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 import assess_core
 from assess_core import build_run_context

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 import lib.doc_graph as doc_graph
 from lib.doc_graph import build_doc_graph, group_broken_links

--- a/skills/assess/tests/test_instruction_bloat.py
+++ b/skills/assess/tests/test_instruction_bloat.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from lib.agent_instructions_grader import (
     SIZE_THRESHOLD_LINES,
-    SIZE_THRESHOLD_WORDS,
     compute_bloat_penalty,
     compute_size_metrics,
     detect_skills_delegation,

--- a/skills/assess/tests/test_stats_diff.py
+++ b/skills/assess/tests/test_stats_diff.py
@@ -1,13 +1,11 @@
 """Tests for stats sidecar diff."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 
 from lib.stats_diff import (
-    HotspotTransition,
     diff_stats,
     hotspot_commits,
     load_stats,

--- a/skills/assess/tests/test_wiki_writer.py
+++ b/skills/assess/tests/test_wiki_writer.py
@@ -1,10 +1,8 @@
 """Tests for wiki writer module."""
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
-import pytest
 
 from lib.wiki_writer import (
     HotspotEntry,


### PR DESCRIPTION
## Summary

Closes #77
Closes #79

Adds the repo's first linter (Layer 3) and type checker (Layer 2), wired into CI, so per-function complexity and type-correctness ratchet instead of drifting - the repo applying its own write-side-enforcement thesis to itself. On its very first run the complexity/lint gate caught a latent `NameError` in a shipped script, which this PR also fixes (below).

## Changes

- **Ruff complexity + lint gate** (`skills/assess/pyproject.toml`, `scripts/pyproject.toml`): `[tool.ruff.lint]` selects the default E4/E7/E9 + F rules plus the mccabe `C901` cyclomatic-complexity gate at `max-complexity = 15`.
- **Mypy type gate** (`skills/assess/pyproject.toml`): `[tool.mypy]` scoped to the deterministic core (`scripts/lib`), `ignore_missing_imports` for the stub-less deps (networkx, grimp), `explicit_package_bases` + `mypy_path = "scripts"` so `lib.<mod>` resolves and the back-compat shims do not collide as duplicate modules.
- **CI** (`.github/workflows/tests.yml`): new `lint` job runs `ruff check` over `skills/assess` and `scripts`, then `mypy`.
- Fixed the type errors mypy surfaced in the core and the NameError ruff surfaced (below). Version bumped 1.17.0 -> 1.18.0.

## Threshold / config rationale

**Ruff `max-complexity = 15`** - per-function mccabe (not the file-aggregate ccn the treemap reports). At 15 every function already sits under the bar except four genuine offenders (ccn 17-19), each carrying an explicit `# noqa: C901` with a one-line reason: `build_doc_graph` and `authorship_analysis` (lib), `render` (doc-graph-svg.py), and `build_standalone_skill_zip` (scripts). The threshold fences current reality and fails the moment any other function regresses; the four noqas are the documented ratchet targets. Chose a sane threshold + four explicit exemptions over a meaningless high number. Package `__init__.py` files are exempt from `F401` (deliberate re-exports, incl. test-pressure's monkeypatch surface); test fixtures stay excluded.

**Mypy scoped to `lib/`** - the deterministic core, where annotations are densest and most load-bearing. The top-level orchestrators (`assess_core.py`, `assess_finalize.py`, `complexity-treemap.py`) and the build pipeline are the next ratchet step. `warn_unused_ignores` is deliberately left off so the modules' defensive `# type: ignore[assignment]` on their `nx = None` degrade-gracefully fallbacks stay put (needed when stubs are installed). Fixed the real errors rather than blanket-ignoring:

- `is_repo_file` signature widened to accept `frozenset[Path]` (callers pass a frozenset).
- `structure_graph` `__init__.py` detection narrowed with a walrus None-guard (`_module_file` returns `Path | None`).
- two heterogeneous-dict sort keys (`change_coupling`, `keyhole_signals`) carry a targeted `# type: ignore[operator]` - the dict values are `str | int | float` so mypy types the lookup `object`, but the negation is valid at runtime (the key is always an int).

## Latent bug fixed in this PR

ruff's first run surfaced a genuine pre-existing `NameError` in the auxiliary renderer `skills/assess/scripts/doc-graph-svg.py`: the `--colour status` branch called an undefined `_classify` (F821) - a stale name from a rename whose call site was missed. The correct function, `classify_node`, is already imported and used with the identical signature elsewhere in the same file. Renamed `_classify` -> `classify_node` (verified `_STATUS_COLOR`'s keys - entry/reachable/island/orphan - exactly match `classify_node`'s return values) and removed an unused `pr_max` (F841). The file stays fully under the ruff gate. A latent runtime crash caught and fixed on the gate's first run is the strongest possible justification for #77.

## Testing

- `ruff check` clean on `skills/assess` and `scripts`.
- `mypy`: Success, no issues found in 22 source files.
- `python -m py_compile` clean on the edited `doc-graph-svg.py`.
- pytest green: 358 (skills/assess) + 69 (scripts) + 56 (plugin contract).

## Risk

Low. Config + CI plus localised fixes; no behaviour change in the deterministic core (the sort keys and walrus are semantically identical and `is_repo_file` only widens an accepted type). The `doc-graph-svg.py` rename makes the previously-broken `--colour status` mode actually work; the removed `pr_max` was dead. The new `lint` job is additive.
