### PR TITLE
chore: add Marathon Configuration to CLAUDE.md and harden lint-job checkout

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,12 @@ jobs:
     name: ruff + mypy gates
     runs-on: ubuntu-latest
     steps:
+      # Read-only job: don't persist the checkout token for later steps
+      # (defense-in-depth; the workflow already restricts permissions to
+      # contents: read).
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ In-repo contract for agents editing `ai-native-toolkit`. Repo-specific rules onl
 
 Source for the `ai-native-toolkit` Claude Code plugin. Two portable skills (`/assess`, `/huddle`), portable framework commands (`/6hats`, `/understand`), and personal workflow commands that are opt-in (`/tm`, `/fix-pr`, `/fix-develop`).
 
-The deliverable is markdown: agents, commands, skills. The only executable code is `skills/assess/scripts/complexity-treemap.py`. There is no application runtime, no test suite, no build step.
+The deliverable is markdown: agents, commands, skills. It also ships a Python deterministic core under `skills/assess/scripts/` (plus `lib/`) and a standalone-skill build pipeline under `scripts/`. There is no application runtime, but there are pytest suites (`skills/assess/`, `scripts/`), a ruff + mypy lint gate, and a standalone-ZIP build step - all enforced in CI.
 
 ## Versioning
 
@@ -58,10 +58,59 @@ Commands without frontmatter still work but provide no `/help` description.
 ## CI
 
 - `.github/workflows/pr-lint.yml` validates PR titles match conventional-commit format and auto-applies the matching label (`feat` / `fix` / `docs` / `chore` / `refactor`). Other conventional types (`ci`, `build`, `test`, `perf`, `style`, `revert`) pass validation but aren't auto-labelled.
-- `.github/workflows/tests.yml` runs `uv run --with pytest pytest -v` against `skills/assess/` on every PR and push to `main`. A red test is a real regression - the deterministic core is reproducible, so flakes shouldn't happen.
+- `.github/workflows/tests.yml` runs three pytest jobs (`skills/assess pytest`, `scripts/ pytest`, `plugin contract pytest`) plus a `ruff + mypy gates` lint job (Layer 3 complexity ratchet + Layer 2 type gate) on every PR and push to `main`. A red test is a real regression - the deterministic core is reproducible, so flakes shouldn't happen. The `plugin contract pytest` job runs `test_internal_links_resolve` over every shipped `SKILL.md`/command file, so relative markdown links must point to real files - use inline code (`` `CLAUDE.md` ``), not a clickable `[..](./CLAUDE.md)` link, for illustrative file mentions.
+- **`main` has branch protection** (`enforce_admins: true`, 0 required approvals): a PR cannot merge unless `skills/assess pytest`, `scripts/ pytest`, `plugin contract pytest`, and `Validate PR title` are green. `CodeRabbit`, `Auto-label from PR title`, and the push-only `build` (standalone publish) job are intentionally **not** required. Emergency override: `gh api -X DELETE repos/bjcoombs/ai-native-toolkit/branches/main/protection`, then re-apply.
 - `.github/release.yml` configures categorised release notes when running `gh release create --generate-notes`. See the file for the label-to-category mapping.
 
 **CI triggers only on `main`** (`pull_request`/`push` to `main`). A PR targeting `main` gets `tests.yml` + `pr-lint.yml` on every synchronize; pushes to other branches with no open PR don't run them.
+
+## Marathon Configuration
+
+Project-specific settings the `/tm` and `/issues` commands (and the shared `marathon` skill) read to drive marathon mode. When this section is absent the commands fall back to defaults (base `main`, **1** approval) - which is wrong for this solo repo and would stall every PR, so keep it here.
+
+### Branch and Merge
+
+- **Base branch**: `main`
+- **PR target branch**: `main`
+- **Required approvals**: 0 - solo-maintainer repo, no second reviewer or approving bot. The lead merges each PR itself at green CI + resolved threads.
+- **Markdown-only PR approvals**: 0
+
+### Bot Reviewers
+
+**CodeRabbit** (`coderabbitai[bot]`):
+- Comments only, frequently rate-limited; its check often reports neutral/`null`. It is **not** a required status check and never blocks merge.
+- Fix code and push - CodeRabbit re-reviews and resolves its own threads. **Never reply in CodeRabbit threads** (it ignores replies from other bots).
+
+No human reviewers and no `claude[bot]` on this repo.
+
+### CI Patterns
+
+- **Required (merge-gating) checks**: `skills/assess pytest`, `scripts/ pytest`, `plugin contract pytest`, `Validate PR title` (enforced by branch protection - see the CI section).
+- **Non-blocking checks**: `CodeRabbit` (rate-limited bot), `Auto-label from PR title` (convenience automation), `build` (push-only standalone publish - does not run on PRs).
+- **Local-run gotcha**: the `skills/assess` pytest suite shows ~7 phantom git-commit failures from global git config when run locally - run with `GIT_CONFIG_GLOBAL=/dev/null` to clear them. They are not CI failures.
+- **Hot file on every PR**: `.claude-plugin/plugin.json` `.version` - each PR must bump it. Identical bumps 3-way-merge cleanly; divergent bumps conflict, so merge sequentially (highest version wins). Tell each teammate the next version explicitly when running several PRs at once.
+
+### GitHub Issues (for `/issues`)
+
+- **Agent-ready label**: `agent-ready`
+- **Needs-triage label**: `needs-triage`
+- **In-progress label**: `in-progress`
+- **Issue exclude labels**: `question`, `wontfix`, `duplicate`, `invalid` (skipped during triage)
+
+### Retrospective
+
+- **Retro log**: `~/.claude/projects/<project-slug>/memory/marathon-retros.md` - append each marathon's retrospective here after completion. (Path is per-machine; don't commit a resolved absolute path - it leaks a home directory, the exact issue `/assess` now warns about.)
+
+### Release after a marathon
+
+As the **final** step, once all of a marathon's PRs are merged and the retrospective is done, cut a GitHub release at the new plugin version so users get the update via `/plugin update` and the standalone-skills publish + categorised release notes fire:
+
+```bash
+VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+gh release create "v$VERSION" --generate-notes --title "v$VERSION"
+```
+
+`.github/release.yml` maps the PR labels (`feat`/`fix`/`docs`/`chore`/`refactor`) to release-note categories, and `build-standalone-skills.yml` republishes the standalone ZIPs on the version bump. One release per marathon, not one per PR.
 
 ## Testing a branch before merging
 


### PR DESCRIPTION
## Summary

The `/issues` (and `/tm`) marathon commands live in this repo but its `CLAUDE.md` had no `## Marathon Configuration` section, so marathon mode fell back to defaults (base `main`, **1** approval) - wrong for a solo-maintainer repo with no second reviewer, which would stall every PR. This adds the section, refreshes stale docs that the recent assess-feedback batch made inaccurate, and folds in the CI hardening suggested during that batch's review.

## Changes Made

**`CLAUDE.md`**
- New `## Marathon Configuration` section: base/target `main`, **0 required approvals** (solo repo), CodeRabbit treated as a non-blocking bot, the four required (merge-gating) checks vs the non-blocking ones, the `plugin.json` version hot-file caveat, the `/issues` label scheme, an optional retro-log pointer (placeholder path, not a resolved home dir), and - as the final marathon step - a **"Release after a marathon"** subsection (`gh release create "v$VERSION" --generate-notes`) so the version bump reaches users via `/plugin update` and triggers the standalone-skills publish + categorised notes.
- `## CI` section updated to reflect the three pytest jobs + the new `ruff + mypy gates` lint job, the `test_internal_links_resolve` link contract, and the newly-added **branch protection** on `main` (`enforce_admins: true`, 0 approvals, the four required checks, with the emergency-override command).
- `## Scope` line corrected: the old "only executable code is `complexity-treemap.py`; no test suite, no build step" is no longer true (there are pytest suites, a ruff/mypy gate, and a standalone-ZIP build pipeline).

**`.github/workflows/tests.yml`**
- `persist-credentials: false` on the read-only `ruff + mypy gates` job's checkout (defense-in-depth; the workflow already pins `permissions: contents: read`). This addresses the CodeRabbit hardening note from PR #92.

**`.claude-plugin/plugin.json`**
- Version `1.18.0` → `1.18.1` (PATCH: docs + CI config, no user-visible behaviour change).

## Testing

- `plugin contract pytest`: 56 passed (`GIT_CONFIG_GLOBAL=/dev/null`).
- `tests.yml` re-validated as well-formed YAML after the checkout edit.

## Risk Assessment

Low. Docs + one read-only-job checkout hardening + a version bump; no Python/runtime changes. The lint job's behaviour is unchanged (it only reads).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.18.1

* **Security**
  * Strengthened CI security with read-only credential handling to protect workflow execution

* **Documentation**
  * Enhanced repository documentation with expanded project overview, detailed CI/workflow procedures, branch protection guidelines, and new Marathon configuration section detailing release workflows and team retrospectives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->