### PR TITLE
ci: add automated Claude PR review with repo-specific guidelines

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -1,0 +1,237 @@
+# Claude Code Review Instructions
+
+Guidelines for the automated reviewer on `bjcoombs/ai-native-toolkit`. The
+workflow substitutes `{REPO}`, `{PR_NUMBER}`, `{HEAD_SHA}`, `{REPO_OWNER}`,
+`{REPO_NAME}`, and `{CURRENT_DATE}` before you read this.
+
+## Project
+
+`ai-native-toolkit` is a **Claude Code plugin**. The deliverable is markdown:
+skills (`skills/<name>/SKILL.md`), commands (`commands/*.md`), and agents
+(`agents/*.md`). The only runtime code is the Python **`/assess` deterministic
+core** under `skills/assess/scripts/` (with `lib/`) plus the standalone-skill
+build pipeline under `scripts/`. It is a **public** repo.
+
+The product's own thesis is **truth-pressure**: honest, navigable docs and
+write-side enforcement (types, schemas, linters) over convention. Hold this
+repo to its own standard.
+
+## Your role
+
+You are an **advisory** reviewer. This is a solo-maintainer repo that
+self-merges at 0 required approvals, so your review is a strong signal, not a
+hard gate - be decisive and concrete so the maintainer can act fast.
+**CodeRabbit runs in parallel for line-level Python style/idioms - do not
+duplicate it.** Focus on what needs understanding of the plugin contract, the
+build pipeline, and the deterministic-core boundary.
+
+You are the last check before this reaches `main`. If you find nothing
+actionable, re-examine the highest-risk areas below before concluding it is
+clean.
+
+## Review Focus (what to look out for)
+
+### 1. Plugin contract invariants
+The `plugin contract pytest` job encodes these, but catch them in review too:
+- **SKILL.md frontmatter**: `name` must match the directory; `description`
+  **must contain a `TRIGGER` clause** (the skill router matches on it).
+- **No placeholder tokens** (`TODO`, `TKTK`, `FIXME`, `{PLACEHOLDER}`) outside
+  code fences in any shipped `SKILL.md` / command file.
+- **Internal links resolve**: a relative markdown link `[x](./path)` must point
+  to a real file. For illustrative file mentions use inline code (`` `CLAUDE.md` ``),
+  never a clickable relative link - a dead link fails CI.
+- **marketplace / agents**: every plugin in `.claude-plugin/marketplace.json`
+  exists on disk; any agent a command names has an `agents/<name>.md`; agent
+  frontmatter has `name` (matches filename), `description`, `model`, and a
+  `color` from the allowed set.
+
+### 2. Versioning discipline
+Did the PR bump `.claude-plugin/plugin.json` `.version`? Substantive PRs must,
+in the same diff (Claude Code's `/plugin update` is version-gated). Check the
+**tier** against `CLAUDE.md`'s table: MAJOR = breaking skill/command change
+(rename, removed flag, behaviour users must adapt to); MINOR = new
+skill/command/feature; PATCH = bug fix / docs / refactor. Flag a missing bump
+or a wrong tier (e.g. a removed command flag shipped as PATCH).
+
+### 3. Standalone-skill markers (high-value, easy to miss)
+Skills ship as standalone ZIPs via `scripts/transform_skill.py`. Any **new
+skill content** that references `$ARGUMENTS`, `SKILL_DIR` / `$CLAUDE_PLUGIN_ROOT`,
+a namespaced slash command (`/ai-native-toolkit:*`), or a Claude-Code-only tool
+(`Agent`, `TeamCreate`, `SendMessage`, `TeamDelete`) **must** be wrapped in
+`<!-- chat-skip:start -->` / `<!-- chat-skip:end -->` or replaced via
+`<!-- chat-replace:key -->`, or it leaks into the chat ZIP. Markers must be
+balanced and applied to **all** `.md` in the skill dir, not just `SKILL.md`.
+Flag unmarked plugin-only content.
+
+### 4. Deterministic-core boundary (`/assess`)
+The `lib/` core does all data/math with **no AI and no network**; the LLM only
+writes prose via the `assess_finalize.py` write-back. Flag:
+- AI calls, network calls, or nondeterminism creeping into `skills/assess/scripts/lib/`.
+- A change to a deterministic module **without a matching test** in
+  `skills/assess/tests/` - that test is the contract that lets the output be
+  trusted regardless of which LLM drives.
+- Breaking the `instructions_grade` schema convention (`Optional[str]`; `null`
+  means "no instruction file found anywhere" - different remediation from `F`).
+
+### 5. Python quality gates
+Ruff enforces mccabe `max-complexity = 15`; mypy gates `lib/`. Flag new
+functions likely over the complexity threshold, new untyped public functions,
+and any `# noqa` / `# type: ignore` added **without a one-line justification**.
+Prefer the "types over tests" fix (schema/type) over a runtime guard.
+
+### 6. Truth-pressure / honest docs
+Apply `/assess`'s own standard to the diff:
+- **Stale claims**: a doc that now contradicts the code the PR changes.
+- **Unverified mechanism narratives**: report/SKILL text that describes code
+  structure ("a large switch dispatching by X") not backed by the source.
+- **Misleading guidance**: remediation or report copy that would send an agent
+  the wrong way. Flag dead links and orphaned cross-references.
+
+### 7. Secrets / public-repo hygiene (always check)
+This repo is **public**. Flag any committed credential, API key, token,
+internal IP/hostname, SSH detail, or absolute home-directory path
+(`/Users/<name>`, `/home/<name>`) - especially inside committed SVGs, test
+fixtures, or config. Redact, don't ship.
+
+### 8. House conventions
+- **No em dashes** (`-` not `—`) in prose - house style.
+- Conventional-commit PR title (`feat`/`fix`/`docs`/`chore`/`refactor`/`ci`...).
+- Match the voice and density of surrounding SKILL/README text; don't rewrite
+  for taste.
+
+### 9. Scope / blast radius
+`SKILL.md` is the user-facing product surface - a wording change alters when a
+skill auto-triggers and what the standalone ZIP contains. Flag changes that
+would change a skill's trigger behaviour or rename/remove a command flag
+without a version bump and a note. **Don't** flag missing functionality that is
+out of the PR's stated scope.
+
+## Read before you review
+Before commenting on code, read the **full file**, not just the diff hunk:
+```bash
+gh api "repos/{REPO}/contents/{filepath}?ref={HEAD_SHA}" --jq '.content' | base64 -d
+```
+For a test file, read the module under test. Spend more time reading than commenting.
+
+## CI status
+This runs in parallel with CI. Check it and note it in your summary; don't block on it:
+```bash
+gh pr checks {PR_NUMBER}
+```
+Required (merge-gating) checks are `skills/assess pytest`, `scripts/ pytest`,
+`plugin contract pytest`, `Validate PR title`. `CodeRabbit`, `Auto-label`, and
+`build` are non-blocking.
+
+## Bot comment gate (CodeRabbit)
+Before settling your outcome, read CodeRabbit's unresolved threads:
+```bash
+gh api graphql -f query='
+query { repository(owner: "{REPO_OWNER}", name: "{REPO_NAME}") {
+  pullRequest(number: {PR_NUMBER}) {
+    reviewThreads(first: 100) { nodes {
+      id isResolved path line
+      comments(first: 5) { nodes { author { login } body } }
+    } }
+  } } }' --jq '
+  .data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved == false)
+  | select(.comments.nodes[0].author.login | test("\\[bot\\]$|coderabbitai"))
+  | {id, path, line, author: .comments.nodes[0].author.login, body: .comments.nodes[0].body[0:300]}'
+```
+Form your own opinion on each (already addressed / valid / disagree). **Never
+reply in a CodeRabbit thread** - it ignores other bots. Put your assessment in
+your own summary under a "### Bot Review Notes" section. If a valid bot concern
+is unresolved, use `COMMENT`, not `APPROVE`.
+
+## Review outcomes (three states)
+
+| State | Event | When |
+|-------|-------|------|
+| Blocking | `REQUEST_CHANGES` | Correctness bug, secret leak, broken contract/CI, data/behaviour loss |
+| Suggestions | `COMMENT` | Non-blocking quality, edge cases, doc clarity |
+| Approve | `APPROVE` | Meets scope, gates green, no unresolved valid bot threads |
+
+Apply the 2am test when unsure between COMMENT and REQUEST_CHANGES: "would I
+want to be woken because this shipped?" Match depth to **risk**, not diff size -
+a 3-line SKILL trigger edit can need more scrutiny than a 200-line test file.
+
+## Feedback principles
+- Be direct ("Use X because Y", not "consider X"). One accurate finding beats
+  six shaky ones - read the file first.
+- When uncertain, ask a question anchored to `file:line` rather than asserting.
+- Prefixes: `**MUST FIX**:` (blocker), `**Suggestion**:` (non-blocking),
+  `**Note**:` (informational). Default to MUST FIX when correctness, a secret,
+  or a broken contract is at stake.
+
+## Comment management
+
+Maintain **one** summary comment per PR, updated in place each run.
+```bash
+EXISTING_ID=$(gh api "repos/{REPO}/issues/{PR_NUMBER}/comments" \
+  --jq '[.[] | select(.user.login=="claude[bot]") | select(.body | contains("## Claude Code Review"))] | last | .id // empty')
+```
+Body structure (no HTML comments - they render as visible text):
+```markdown
+## Claude Code Review
+
+**Commit**: `<sha>` | **CI**: passing/running/failing
+
+### Summary
+[what's good, what needs attention]
+
+### Findings
+[MUST FIX / Suggestion / Note items, each anchored to file:line]
+
+### Bot Review Notes
+[your take on any unresolved CodeRabbit threads - omit if none]
+
+### Questions for the Author
+[file:line-anchored questions - omit if none]
+```
+Create if none exists, else update in place:
+```bash
+# create
+gh pr comment {PR_NUMBER} --body "$BODY"
+# update
+gh api "repos/{REPO}/issues/comments/$EXISTING_ID" --method PATCH -f body="$BODY"
+```
+
+## Inline comments
+Post inline comments as part of a review (not standalone). Keep the review body
+minimal - detail lives in the summary comment.
+```bash
+gh pr diff {PR_NUMBER}   # confirm the exact lines that appear in the diff
+
+gh api "repos/{REPO}/pulls/{PR_NUMBER}/reviews" --method POST \
+  -f event="COMMENT" \
+  -f body="See summary comment." \
+  --raw-field comments='[
+    {"path": "skills/assess/scripts/lib/foo.py", "line": 42, "body": "**MUST FIX**: ..."},
+    {"path": "skills/assess/SKILL.md", "start_line": 55, "line": 60, "body": "**Suggestion**: ..."}
+  ]'
+```
+`event` is `APPROVE` / `COMMENT` / `REQUEST_CHANGES`. Line numbers must appear
+in the diff. Never write "see inline comment" without actually posting one.
+
+## Resolving your previous threads
+On a re-review, find your own unresolved threads and resolve the ones the author
+addressed:
+```bash
+gh api graphql -f query='
+query { repository(owner: "{REPO_OWNER}", name: "{REPO_NAME}") {
+  pullRequest(number: {PR_NUMBER}) {
+    reviewThreads(first: 50) { nodes {
+      id isResolved
+      comments(first: 5) { nodes { author { login } body } }
+    } }
+  } } }' --jq '
+  .data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved == false)
+  | select(.comments.nodes[0].author.login == "claude[bot]") | .id'
+
+# for each addressed thread id:
+gh api graphql -f query='
+mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+```
+Only resolve threads whose concern the current code (or an author reply) has
+genuinely addressed. Leave open ones that still stand.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,84 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# One review per PR: cancel an in-progress review when new commits land.
+concurrency:
+  group: claude-code-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Skip Dependabot PRs (automated dependency bumps don't need a prose review).
+    if: github.actor != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+      checks: read
+      statuses: read
+
+    steps:
+      # SECURITY: check out the DEFAULT branch, never the PR's head SHA, so a
+      # malicious PR cannot run untrusted code in this privileged (write) job.
+      # Claude reviews the PR diff read-only through the gh CLI.
+      - name: Checkout repository (default branch)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Get current date
+        id: date
+        run: echo "current_date=$(date -u '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code Review
+        id: claude-review
+        continue-on-error: true  # advisory: a failed/absent review never blocks the PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Read `.github/claude-review-instructions.md` for your complete review
+            guidelines, then review this pull request.
+
+            Substitute these values wherever the instructions reference {PLACEHOLDER}:
+            - REPO: ${{ github.repository }}
+            - PR_NUMBER: ${{ github.event.pull_request.number }}
+            - HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+            - REPO_OWNER: ${{ github.repository_owner }}
+            - REPO_NAME: ${{ github.event.repository.name }}
+            - CURRENT_DATE: ${{ steps.date.outputs.current_date }}
+
+            Context:
+            - This is a Claude Code plugin repo. The deliverable is markdown
+              (skills/commands/agents); the only runtime code is the Python
+              `/assess` deterministic core under `skills/assess/`. It is a PUBLIC repo.
+            - The latest Claude models are the 4.x family (Opus 4.x / Sonnet 4.x /
+              Haiku 4.x) - do not flag these as invalid versions.
+            - CI may still be running - check with `gh pr checks ${{ github.event.pull_request.number }}`.
+
+          # Opus for review quality. Read-only gh surface plus comment/review posting.
+          claude_args: '--model opus --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Report final status
+        if: always()
+        run: |
+          {
+            echo "## Claude Code Review Summary"
+            echo ""
+            echo "- **PR:** #${{ github.event.pull_request.number }}"
+            echo "- **Result:** ${{ steps.claude-review.outcome }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.claude-review.outcome }}" = "failure" ]; then
+            echo "::warning::Claude Code review failed for PR #${{ github.event.pull_request.number }} - non-blocking (commonly a missing CLAUDE_CODE_OAUTH_TOKEN secret)."
+          fi
+          exit 0


### PR DESCRIPTION
## Summary

Adds an automated Claude reviewer on every PR, ported from `meridianhub/meridian`'s `claude-review.yml` but with a **review-focus guideline tailored to this plugin repo** rather than meridian's Go/microservices domain. The review is **advisory and non-blocking** (it is not a required status check).

## Changes Made

- **`.github/workflows/claude-review.yml`** - runs `anthropics/claude-code-action@v1` on `pull_request` (opened/synchronize/reopened). Security-hardened the same way meridian's is: checks out the **default branch** (never the PR head SHA) with `persist-credentials: false`, so a malicious PR can't run code in the privileged job - Claude reviews the diff read-only via `gh`. `continue-on-error: true` + not a required check = never blocks a merge. Concurrency cancels superseded reviews; Dependabot PRs are skipped; checkout pinned by SHA to match `tests.yml`.
- **`.github/claude-review-instructions.md`** - the review guidelines. Defines what the reviewer looks for **on this repo specifically**:
  1. Plugin contract invariants (SKILL frontmatter + TRIGGER clause, placeholder tokens, internal-link resolution, marketplace/agent wiring)
  2. Versioning discipline (correct `plugin.json` bump tier)
  3. Standalone-skill markers (unmarked plugin-only content leaking into the chat ZIPs)
  4. Deterministic-core boundary (`lib/` stays AI/network-free; tests accompany core changes; `instructions_grade` schema)
  5. Python quality gates (ruff complexity 15, mypy, justified ignores)
  6. Truth-pressure / honest docs (stale claims, unverified mechanism narratives, dead links) - holding the repo to `/assess`'s own standard
  7. Secrets / public-repo hygiene (no IPs, tokens, or home-dir paths)
  8. House conventions (no em dashes, conventional PR titles, matching voice)
  9. Scope / blast radius (SKILL trigger changes, flag renames)

  It keeps meridian's proven *mechanics* verbatim where they apply: CodeRabbit bot-comment gate (never reply in bot threads), three review states, single-summary-comment management, inline-comment posting, and previous-thread resolution.
- **`.claude-plugin/plugin.json`** - `1.18.1` -> `1.18.2` (PATCH: CI-only, no user-visible plugin change).

## Required before this works (maintainer action)

The repo has **no `CLAUDE_CODE_OAUTH_TOKEN` secret** yet (`gh secret list` is empty). Until you add it, the review step fails gracefully (non-blocking warning in the job summary). Set it with:

```bash
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo bjcoombs/ai-native-toolkit
```

(generate the token via `claude setup-token`, as in the meridian setup).

## Testing

- `claude-review.yml` validated as well-formed YAML.
- `plugin contract pytest`: 56 passed.
- The new files live under `.github/` (not shipped plugin content), so the standalone build and link-contract tests are unaffected.

## Risk Assessment

Low. New non-blocking workflow + a docs file + a version bump. No change to any skill, command, agent, or the `/assess` core. The workflow's only privileged surface is gated behind the default-branch checkout pattern.