### PR TITLE
feat: add /ghsync skill for org-wide repo clone and sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
-  "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.18.2",
+  "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
+  "version": "1.19.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Spawns a Fibonacci-sized team (default 3) that cycles through De Bono's six hats
 | `/assess` | Layered AI-readiness assessment (0-8 contract model) plus a Codecov-style complexity hotspot SVG and a doc-navigability graph SVG (both colour-blind-safe). Ships [`complexity-treemap.py`](skills/assess/scripts/complexity-treemap.py) and [`doc-graph-svg.py`](skills/assess/scripts/doc-graph-svg.py) so the agent runs them with no external setup. Filters build artifacts and generated code by default (opt-out with `--include-artifacts`); warns when one file dominates LOC. Offers to install optional `scc` for repos heavy in markdown/JSON/YAML. Generated PRs include a self-install footer so reviewers can adopt the plugin. |
 | `/huddle` | Multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing (solo -> debate -> huddle -> panel -> board). Three execution modes: solo flat-parallel, phased sub-agent (default fallback), and team mode (needs Agent Teams capability flag). |
 | `/deslop` | Detect and remove the telltale signs of AI writing - puffery, the rule of three, "not X but Y", filler diction, chatbot leakage, fabricated citations. Two modes: a silent quality gate while writing prose, or an explicit de-slop/audit pass. Ships a [`references/full-checklist.md`](skills/deslop/references/full-checklist.md) A-F catalog derived from Wikipedia's "Signs of AI writing" (29 May 2026) - the skill flags itself for re-derivation if it goes stale, since the tells drift with model generations. |
+| `/ghsync` | Bulk clone and keep in sync every GitHub repo you can access across an org - built for onboarding into a new enterprise. Discovers repos through the teams you belong to, deduplicates, then clones new ones and fast-forward syncs existing checkouts and their worktrees into a `<repo>/<repo>-main` + `<repo>/worktree` layout. Org defaults to the directory you run from. Never clobbers local work (uncommitted or off-default-branch repos are fetched, not pulled) and reports every exception in a summary. Ships [`ghsync.sh`](skills/ghsync/scripts/ghsync.sh); needs `gh` + `jq`, supports GitHub Enterprise via `GH_HOST`. |
 
 ### Commands (slash-only, no bundled assets)
 
@@ -295,6 +296,10 @@ ai-native-toolkit/
 │   │   ├── SKILL.md                   # Remove the signs of AI writing (12 high-frequency tells)
 │   │   └── references/
 │   │       └── full-checklist.md      # Exhaustive A-F catalog (Wikipedia-derived)
+│   ├── ghsync/
+│   │   ├── SKILL.md                   # Bulk clone + sync every org repo you can access
+│   │   └── scripts/
+│   │       └── ghsync.sh              # Org-wide clone + fast-forward sync into worktree layout
 │   ├── marathon/
 │   │   └── SKILL.md                   # Parallel agent marathon orchestration
 │   └── pr-review-merge/

--- a/skills/ghsync/SKILL.md
+++ b/skills/ghsync/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ghsync
+description: "Bulk clone and keep in sync every GitHub repo you can access across an org. Discovers all repos reachable through the teams you belong to, deduplicates them, then clones new ones and fast-forward syncs existing ones (and their worktrees) into a consistent <repo>/<repo>-main + <repo>/worktree layout. The org defaults to the directory you run from, so dropping into ~/dev/github.com/<org> mirrors that org. TRIGGER when the user types /ghsync, wants to clone or sync all org repos, asks to mirror everything they have access to, is onboarding into a new enterprise/org, or wants to refresh their local checkouts to latest."
+---
+
+# ghsync: mirror and sync every repo you can access
+
+Onboarding into a new enterprise means finding and cloning dozens of repos by
+hand, then drifting out of date. This skill does both halves: it **discovers**
+everything you can reach and **keeps it in sync**.
+
+- **First run** — clones every accessible repo into a worktree-friendly layout.
+- **Every run after** — fast-forward updates repos already on their default
+  branch, updates their worktrees, and clones anything new. It never clobbers
+  local work: repos with uncommitted changes or on a non-default branch are
+  fetched but not pulled, and reported in the summary.
+
+It is **org-agnostic** — point it at any GitHub org or GitHub Enterprise host.
+
+## How to run it
+
+The script lives next to this file. Resolve its directory the same way the
+other skills do (works whether installed as a plugin or hand-placed under
+`~/.claude/skills/`):
+
+```bash
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/ghsync}"
+SKILL_DIR="${SKILL_DIR:-$(dirname "$(realpath ~/.claude/skills/ghsync/SKILL.md)")}"
+
+# Org is derived from the directory you run in. To mirror the "meridianhub"
+# org, run from a directory named meridianhub:
+cd ~/dev/github.com/meridianhub
+bash "$SKILL_DIR/scripts/ghsync.sh"
+```
+
+The org defaults to the **basename of the directory you launch from**. So
+running inside `~/dev/github.com/meridianhub` syncs the `meridianhub` org into
+that directory. Override the org name or target directory explicitly when they
+differ:
+
+```bash
+bash "$SKILL_DIR/scripts/ghsync.sh" --org meridianhub --root ~/dev/github.com/meridianhub
+```
+
+## What to do when invoked
+
+1. **Confirm the target.** Run with `--list-teams` or `--list-repos` first so
+   the user sees which org and how many repos before any cloning. This doubles
+   as a check that the derived org name is correct.
+2. **Dry run on first use against a new org** (`--dry-run`) to preview clones
+   and updates without touching disk.
+3. **Run the real sync.** Stream the output; the run ends with a summary
+   (up-to-date / updated / failed / uncommitted / branch issues / worktrees).
+4. **Surface the exceptions.** Call out anything under *Failed*, *Uncommitted
+   changes*, or *Not on default branch* — these are the repos the user may need
+   to deal with manually.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--org NAME` | Org to sync (default: basename of `--root` / cwd) |
+| `--root DIR` | Directory to clone into (default: current directory) |
+| `--list-teams` | List your teams in the org (with repo counts) and exit |
+| `--list-repos` | List the deduplicated accessible repos and exit |
+| `--dry-run` | Show what would be cloned/updated without making changes |
+| `--limit N` | Process only the first N repos (useful for a quick test) |
+| `--quiet` | Suppress per-repository chatter; keep the final summary |
+
+## Layout produced
+
+```
+<root>/<repo>/
+  ├── <repo>-main/   # default-branch checkout, kept clean and up to date
+  └── worktree/      # ready for `git worktree add ...`
+```
+
+This matches the worktree convention the rest of the toolkit assumes:
+`<repo>-main` stays on the default branch and clean, and feature work happens in
+sibling worktrees.
+
+## Sync safety rules
+
+- Repos with **uncommitted changes** are fetched but not pulled (reported under
+  *Uncommitted changes*).
+- Repos **not on their default branch** are fetched but not pulled (reported
+  under *Not on default branch*).
+- Updates are **fast-forward only** (`git pull --ff-only`) — no merge commits,
+  no rebases, never a force.
+- Worktrees on the default branch with no local changes are fast-forwarded too.
+- A repo that exists locally without the `<repo>-main` structure is flagged
+  (*Wrong structure*) rather than touched.
+
+## Requirements & configuration
+
+- **`gh` and `jq`** on `PATH`, and `gh auth status` must be authenticated. The
+  script checks both up front.
+- **GitHub Enterprise:** `gh` uses its configured host. Target a GHE instance by
+  setting `GH_HOST=github.example.com` or running
+  `gh auth login --hostname github.example.com` first.
+- **Access model:** repos are discovered through the **teams you belong to** in
+  the org (`gh api user/teams`), then deduplicated. Repos you can only reach via
+  direct collaborator grants outside any team are not included.
+- **Blacklist:** export `GHSYNC_BLACKLIST="repo-a repo-b"` to skip oversized or
+  problematic repos.
+- **`timeout`:** optional but recommended (`brew install coreutils`) — caps each
+  repo at 5 minutes so one hung clone can't stall the run.
+- **Archived repos** are skipped from cloning and cached to
+  `<root>/.gh_archived_repos` for reference.

--- a/skills/ghsync/scripts/ghsync.sh
+++ b/skills/ghsync/scripts/ghsync.sh
@@ -1,0 +1,598 @@
+#!/bin/bash
+set -euo pipefail
+
+# ===================================================================
+# ghsync.sh - Bulk clone + sync every repo you can access in an org
+#
+# Discovers all GitHub repositories accessible to you across every team
+# you belong to in an org, deduplicates them, and clones or fast-forward
+# updates each into a worktree-friendly layout. Built for onboarding into
+# a new enterprise: drop into the org directory, run it, and you have a
+# local mirror of everything you can touch.
+#
+# Org detection:
+#   The org defaults to the basename of the directory you run from, so
+#   running inside ~/dev/github.com/meridianhub syncs the "meridianhub"
+#   org into that directory. Override with --org / --root.
+#
+# Layout produced (per repo, under the org root):
+#   <root>/<repo>/
+#     ├── <repo>-main/   # default-branch checkout
+#     └── worktree/      # empty dir, ready for git worktrees
+#
+# GitHub Enterprise: gh uses its configured host. To target a GHE host,
+# set GH_HOST (e.g. GH_HOST=github.example.com) or run `gh auth login
+# --hostname github.example.com` first.
+#
+# Usage: ./ghsync.sh [--org NAME] [--root DIR] [--quiet] [--limit N]
+#                    [--dry-run] [--list-teams] [--list-repos]
+#   --org NAME     Org to sync (default: basename of --root / cwd)
+#   --root DIR     Directory to clone into (default: current directory)
+#   --quiet        Suppress per-repository messages during sync
+#   --limit N      Process only N repositories (useful for testing)
+#   --dry-run      Show what would be done without making changes
+#   --list-teams   List your teams in the org and exit
+#   --list-repos   List the deduplicated accessible repos and exit
+# ===================================================================
+
+# Process command line args
+ORG=""
+ROOT=""
+QUIET_MODE=false
+REPO_LIMIT=0
+DRY_RUN=false
+LIST_TEAMS=false
+LIST_REPOS=false
+
+# Repositories to never sync (oversized, checkout issues, etc.).
+# Override per-machine by exporting GHSYNC_BLACKLIST as a space-separated
+# list before running.
+read -r -a REPO_BLACKLIST <<< "${GHSYNC_BLACKLIST:-}"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --org)
+      ORG=$2
+      shift 2
+      ;;
+    --org=*)
+      ORG=${1#*=}
+      shift
+      ;;
+    --root)
+      ROOT=$2
+      shift 2
+      ;;
+    --root=*)
+      ROOT=${1#*=}
+      shift
+      ;;
+    --quiet)
+      QUIET_MODE=true
+      shift
+      ;;
+    --limit)
+      REPO_LIMIT=$2
+      shift 2
+      ;;
+    --limit=*)
+      REPO_LIMIT=${1#*=}
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --list-teams)
+      LIST_TEAMS=true
+      shift
+      ;;
+    --list-repos)
+      LIST_REPOS=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '4,40p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--org NAME] [--root DIR] [--quiet] [--limit N] [--dry-run] [--list-teams] [--list-repos]"
+      exit 1
+      ;;
+  esac
+done
+
+# Derive root and org. Root is where repos land (default: cwd). Org defaults
+# to the basename of root, so dropping into ~/dev/github.com/<org> just works.
+ROOT="${ROOT:-$PWD}"
+if [[ ! -d "$ROOT" ]]; then
+    echo "Error: root directory does not exist: $ROOT"
+    exit 1
+fi
+ROOT="$(cd "$ROOT" && pwd)"
+ORG="${ORG:-$(basename "$ROOT")}"
+
+GITHUB_DEV_PATH="$ROOT"
+
+# Check dependencies
+for cmd in gh jq; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo "$cmd command not found. Install it using: brew install $cmd"
+        exit 1
+    fi
+done
+
+# Verify gh is authenticated before we make a flurry of API calls
+if ! gh auth status &> /dev/null; then
+    echo "Error: gh is not authenticated. Run: gh auth login"
+    [[ -n "${GH_HOST:-}" ]] && echo "  (targeting host: $GH_HOST)"
+    exit 1
+fi
+
+# Check for timeout command
+if ! command -v timeout &> /dev/null; then
+    if command -v gtimeout &> /dev/null; then
+        timeout() { gtimeout "$@"; }
+        export -f timeout
+    else
+        echo "Note: timeout command not found. Install coreutils for timeout protection: brew install coreutils"
+        timeout() { shift; "$@"; }
+        export -f timeout
+    fi
+fi
+
+echo "Org:  $ORG"
+echo "Root: $GITHUB_DEV_PATH"
+
+# Fetch user's teams in the org
+echo "Fetching your teams in $ORG..."
+user_teams=($(gh api user/teams --paginate --jq ".[] | select(.organization.login == \"$ORG\") | .slug"))
+
+if [ ${#user_teams[@]} -eq 0 ]; then
+    echo "Error: You don't appear to be a member of any teams in $ORG"
+    echo "  - Check the org name (it defaults to the directory you ran from: $(basename "$ROOT"))"
+    echo "  - Override with --org NAME if the directory name differs from the org"
+    exit 1
+fi
+
+echo "Found ${#user_teams[@]} team(s): ${user_teams[*]}"
+
+if [ "$LIST_TEAMS" = true ]; then
+    echo ""
+    echo "Teams you belong to in $ORG:"
+    for team in "${user_teams[@]}"; do
+        repo_count=$(gh api "orgs/$ORG/teams/$team/repos" --paginate --jq 'length' 2>/dev/null || echo "?")
+        echo "  - $team ($repo_count repos)"
+    done
+    exit 0
+fi
+
+# Fetch repos from all teams and deduplicate
+echo "Fetching repositories from all teams..."
+all_repos_file=$(mktemp)
+archived_repos_file=$(mktemp)
+
+for team in "${user_teams[@]}"; do
+    echo "  - Fetching from $team..."
+    # Fetch all repos and split into active vs archived
+    gh api "orgs/$ORG/teams/$team/repos" --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null >> "$all_repos_file" || true
+    gh api "orgs/$ORG/teams/$team/repos" --paginate --jq '.[] | select(.archived == true) | .name' 2>/dev/null >> "$archived_repos_file" || true
+done
+
+# Deduplicate and sort
+github_repos=($(sort -u "$all_repos_file"))
+rm -f "$all_repos_file"
+
+# Save archived repos to persistent cache (handy for downstream tooling)
+archived_repos_cache="${GITHUB_DEV_PATH}/.gh_archived_repos"
+sort -u "$archived_repos_file" > "$archived_repos_cache"
+archived_count=$(wc -l < "$archived_repos_cache" | tr -d ' ')
+rm -f "$archived_repos_file"
+echo "Found $archived_count archived repositories (cached to .gh_archived_repos)"
+
+# Filter out blacklisted repos
+filtered_repos=()
+for repo in "${github_repos[@]}"; do
+    is_blacklisted=false
+    for blacklisted in "${REPO_BLACKLIST[@]}"; do
+        if [ "$repo" = "$blacklisted" ]; then
+            is_blacklisted=true
+            break
+        fi
+    done
+    if [ "$is_blacklisted" = false ]; then
+        filtered_repos+=("$repo")
+    fi
+done
+github_repos=("${filtered_repos[@]}")
+
+if [ ${#REPO_BLACKLIST[@]} -gt 0 ]; then
+    echo "Excluded ${#REPO_BLACKLIST[@]} blacklisted repo(s): ${REPO_BLACKLIST[*]}"
+fi
+
+total_repos=${#github_repos[@]}
+
+if [ "$total_repos" -eq 0 ]; then
+    echo "No repositories found across your teams"
+    exit 0
+fi
+
+echo "Found $total_repos unique repositories across ${#user_teams[@]} team(s)"
+
+if [ "$LIST_REPOS" = true ]; then
+    echo ""
+    echo "Repositories accessible to you:"
+    for repo in "${github_repos[@]}"; do
+        echo "  - $repo"
+    done
+    exit 0
+fi
+
+# Create temp directory for status files
+temp_dir="${GITHUB_DEV_PATH}/.gh_sync_tmp"
+rm -rf "$temp_dir"
+mkdir -p "$temp_dir/status"
+status_dir="$temp_dir/status"
+
+export QUIET_MODE DRY_RUN GITHUB_DEV_PATH ORG
+
+# Progress indicator
+show_progress() {
+    if [ "$QUIET_MODE" = false ]; then
+        printf "."
+    fi
+}
+
+clear_line() {
+    printf "\r%*s\r" 80 ""
+}
+
+# Update worktrees for a repository
+update_worktrees() {
+    local repo=$1
+    local default_branch=$2
+    local main_path="${GITHUB_DEV_PATH}/$repo/${repo}-main"
+    local worktree_dir="${GITHUB_DEV_PATH}/$repo/worktree"
+
+    if [ ! -d "$worktree_dir" ]; then
+        return 0
+    fi
+
+    if [ -d "$main_path" ] && [ -d "$main_path/.git" ]; then
+        (
+        cd "$main_path" || return 1
+        local worktrees=()
+        while read -r line; do
+            worktrees+=("$line")
+        done < <(git worktree list | grep -v "$(pwd)" | awk '{print $1}')
+
+        if [ ${#worktrees[@]} -eq 0 ]; then
+            return 0
+        fi
+
+        for worktree in "${worktrees[@]}"; do
+            if [ -d "$worktree" ]; then
+                (
+                cd "$worktree" || exit 1
+
+                if ! git fetch origin &>/dev/null; then
+                    clear_line
+                    echo "*** Failed to fetch updates for worktree: $worktree"
+                    return 1
+                fi
+
+                local current_branch
+                current_branch=$(git branch --show-current)
+                local can_pull=true
+
+                if git status --porcelain -uno | grep -v '\.DS_Store' | grep -q '^[MADRCU]'; then
+                    can_pull=false
+                fi
+
+                if [ "$current_branch" != "$default_branch" ]; then
+                    can_pull=false
+                fi
+
+                if [ "$can_pull" = true ]; then
+                    local_commit=$(git rev-parse HEAD)
+                    remote_commit=$(git rev-parse "origin/$current_branch" 2>/dev/null || echo "")
+
+                    if [ -n "$remote_commit" ] && [ "$local_commit" != "$remote_commit" ]; then
+                        if [ "$DRY_RUN" = true ]; then
+                            clear_line
+                            echo "*** [DRY-RUN] Would update worktree: $repo:$worktree"
+                        elif git pull --ff-only origin "$current_branch" &>/dev/null; then
+                            clear_line
+                            echo "*** Updated worktree: $repo:$worktree"
+                            echo "$repo:$worktree" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/worktree_updated"
+                        else
+                            clear_line
+                            echo "*** Failed to update worktree: $repo:$worktree"
+                        fi
+                    fi
+                fi
+                )
+            fi
+        done
+        )
+    fi
+}
+
+# Ensure repository has the correct worktree structure
+ensure_worktree_structure() {
+    local repo=$1
+    local repo_path="${GITHUB_DEV_PATH}/$repo"
+
+    if [ -d "$repo_path/${repo}-main" ] && [ -d "$repo_path/${repo}-main/.git" ]; then
+        return 0
+    fi
+
+    if [ -d "$repo_path" ] && [ -d "$repo_path/.git" ]; then
+        clear_line
+        echo "*** Repository $repo exists but doesn't have the worktree structure"
+        echo "*** To fix: move it aside and run this script again"
+        echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/wrong_structure"
+        return 1
+    fi
+
+    return 1
+}
+
+update_repo() {
+    local repo=$1
+    local repo_path="${GITHUB_DEV_PATH}/$repo"
+    local main_path="${repo_path}/${repo}-main"
+    local subshell_status=0
+
+    show_progress
+
+    if [ -d "$repo_path" ]; then
+        if [ -d "$main_path" ] && [ -d "$main_path/.git" ]; then
+            (
+            cd "$main_path" &>/dev/null || {
+                clear_line
+                echo "*** Failed to cd to $main_path"
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                exit 1
+            }
+
+            local has_uncommitted=false
+            local non_default_branch=false
+            local can_update=true
+
+            if ! git rev-parse --git-dir > /dev/null 2>&1; then
+                clear_line
+                echo "*** $repo is not a valid git repository"
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                exit 1
+            fi
+
+            # Ensure long path support is enabled (no-op if already set;
+            # required on Windows for repos with deep directory trees)
+            git config core.longpaths true 2>/dev/null || true
+
+            if git status --porcelain -uno | grep -q '^[MADRCU]'; then
+                if [ "$QUIET_MODE" = false ]; then
+                    clear_line
+                    echo "*** $repo has uncommitted changes (will fetch but not pull)"
+                fi
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/uncommitted"
+                has_uncommitted=true
+                can_update=false
+            fi
+
+            current_branch=$(git branch --show-current)
+            default_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5)
+
+            if [ -z "$default_branch" ]; then
+                default_branch=$(gh repo view "$ORG/$repo" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+            fi
+
+            if [ -z "$default_branch" ]; then
+                default_branch="main"
+            fi
+
+            if [ "$current_branch" != "$default_branch" ]; then
+                if [ "$QUIET_MODE" = false ]; then
+                    clear_line
+                    echo "*** $repo is not on default branch ($current_branch != $default_branch)"
+                fi
+                echo "$repo ($current_branch)" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/skipped"
+                non_default_branch=true
+                can_update=false
+            fi
+
+            if ! git fetch origin &>/dev/null; then
+                if [ "$QUIET_MODE" = false ]; then
+                    clear_line
+                    echo "*** Failed to fetch updates for $repo"
+                fi
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                exit 1
+            fi
+
+            if [ "$can_update" = true ]; then
+                if ! git branch -r | grep -q "origin/$default_branch"; then
+                    clear_line
+                    echo "*** Remote branch $default_branch does not exist for $repo"
+                    echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                    exit 1
+                fi
+
+                local_commit=$(git rev-parse HEAD)
+                remote_commit=$(git rev-parse "origin/$default_branch")
+
+                if [ "$local_commit" != "$remote_commit" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        clear_line
+                        echo "*** [DRY-RUN] Would update $repo"
+                        echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/updated"
+                    elif git pull --ff-only origin "$default_branch" &>/dev/null; then
+                        if [ "$QUIET_MODE" = false ]; then
+                            clear_line
+                            echo "*** Updated $repo"
+                        fi
+                        echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/updated"
+                    else
+                        if [ "$QUIET_MODE" = false ]; then
+                            clear_line
+                            echo "*** Failed to update $repo"
+                        fi
+                        echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                        exit 1
+                    fi
+                else
+                    echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/current"
+                fi
+
+                update_worktrees "$repo" "$default_branch"
+            fi
+            exit 0
+            )
+            subshell_status=$?
+
+            if [ $subshell_status -ne 0 ]; then
+                clear_line
+                echo "*** Subshell operations failed for $repo"
+            fi
+
+        elif [ -d "$repo_path/.git" ]; then
+            clear_line
+            echo "*** Repository $repo has unexpected structure"
+            ensure_worktree_structure "$repo"
+        else
+            clear_line
+            echo "*** $repo exists but is not a valid git repository"
+            echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+        fi
+    else
+        # Clone new repo
+        clear_line
+        echo "*** Cloning $repo"
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "*** [DRY-RUN] Would clone $repo into proper structure"
+            echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/updated"
+        else
+            mkdir -p "$repo_path/${repo}-main"
+            mkdir -p "$repo_path/worktree"
+
+            if gh repo clone "$ORG/$repo" "$repo_path/${repo}-main" 2>&1; then
+                # Enable long path support — required on Windows for repos with
+                # deep directory trees (200+ char filenames)
+                git -C "$repo_path/${repo}-main" config core.longpaths true
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/updated"
+                clear_line
+                echo "*** Cloned $repo"
+            else
+                clear_line
+                echo "*** Failed to clone $repo"
+                echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+                rm -rf "$repo_path" 2>/dev/null || true
+            fi
+        fi
+    fi
+}
+
+# Clean up status files
+rm -f "${GITHUB_DEV_PATH}/.gh_sync_tmp/status"/{updated,failed,skipped,uncommitted,current,worktree_updated,wrong_structure} 2>/dev/null || true
+
+# Apply limit if specified
+if [ "$REPO_LIMIT" -gt 0 ] && [ "$REPO_LIMIT" -lt "$total_repos" ]; then
+    github_repos=("${github_repos[@]:0:$REPO_LIMIT}")
+    echo "Limited to $REPO_LIMIT repositories for processing"
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo "[DRY-RUN MODE - no changes will be made]"
+fi
+
+# Handle interruptions
+trap 'echo -e "\n\nInterrupted. Showing partial results..."; wait; break_early=true' INT TERM
+
+break_early=false
+i=0
+batch_size=5
+
+if [ "$QUIET_MODE" = false ]; then
+    printf "Processing repositories "
+fi
+
+for repo in "${github_repos[@]}"; do
+    if [ "$break_early" = true ]; then
+        break
+    fi
+
+    {
+        export GITHUB_DEV_PATH="$GITHUB_DEV_PATH"
+        export ORG="$ORG"
+        export DRY_RUN="$DRY_RUN"
+        timeout 300 bash -c "
+            $(declare -f update_repo update_worktrees ensure_worktree_structure clear_line show_progress)
+            update_repo '$repo'
+        " || {
+            clear_line
+            echo "*** Timeout processing $repo"
+            echo "$repo" >> "${GITHUB_DEV_PATH}/.gh_sync_tmp/status/failed"
+            show_progress
+        }
+    } &
+
+    if (( ++i % batch_size == 0 )); then
+        wait
+    fi
+done
+
+wait
+
+if [ "$QUIET_MODE" = false ]; then
+    printf " done!\n"
+fi
+
+# Print summary
+echo -e "\n====== GitHub Sync Summary ($ORG - ${#user_teams[@]} teams) ======"
+echo "Teams: ${user_teams[*]}"
+
+updated_count=$([ -f "$status_dir/updated" ] && wc -l < "$status_dir/updated" | tr -d ' ' || echo 0)
+current_count=$([ -f "$status_dir/current" ] && wc -l < "$status_dir/current" | tr -d ' ' || echo 0)
+failed_count=$([ -f "$status_dir/failed" ] && wc -l < "$status_dir/failed" | tr -d ' ' || echo 0)
+skipped_count=$([ -f "$status_dir/skipped" ] && wc -l < "$status_dir/skipped" | tr -d ' ' || echo 0)
+uncommitted_count=$([ -f "$status_dir/uncommitted" ] && wc -l < "$status_dir/uncommitted" | tr -d ' ' || echo 0)
+worktree_count=$([ -f "$status_dir/worktree_updated" ] && wc -l < "$status_dir/worktree_updated" | tr -d ' ' || echo 0)
+wrong_structure_count=$([ -f "$status_dir/wrong_structure" ] && wc -l < "$status_dir/wrong_structure" | tr -d ' ' || echo 0)
+
+echo "Up-to-date: $current_count | Updated: $updated_count | Failed: $failed_count | Uncommitted: $uncommitted_count | Branch issues: $skipped_count | Worktrees: $worktree_count | Wrong structure: $wrong_structure_count"
+
+if [ -f "$status_dir/failed" ]; then
+    echo -e "\nFailed ($failed_count):"
+    sort "$status_dir/failed"
+fi
+
+if [ -f "$status_dir/skipped" ]; then
+    echo -e "\nNot on default branch ($skipped_count):"
+    sort "$status_dir/skipped"
+fi
+
+if [ -f "$status_dir/uncommitted" ]; then
+    echo -e "\nUncommitted changes ($uncommitted_count):"
+    sort "$status_dir/uncommitted"
+fi
+
+if [ -f "$status_dir/wrong_structure" ]; then
+    echo -e "\nWrong structure ($wrong_structure_count):"
+    sort "$status_dir/wrong_structure"
+fi
+
+if [ -f "$status_dir/updated" ] && [ "$updated_count" -gt 0 ]; then
+    echo -e "\nUpdated ($updated_count):"
+    sort "$status_dir/updated"
+fi
+
+if [ -f "$status_dir/worktree_updated" ] && [ "$worktree_count" -gt 0 ]; then
+    echo -e "\nWorktrees updated ($worktree_count):"
+    sort "$status_dir/worktree_updated"
+fi
+
+# Cleanup
+rm -rf "$temp_dir"


### PR DESCRIPTION
## Summary

Adds `/ghsync`, a skill that bulk-clones and keeps in sync every GitHub repo you can access across an org. Built for onboarding into a new enterprise: drop into the org directory, run it, and you have a local mirror of everything reachable through your team memberships — and every later run keeps those checkouts current.

The logic originates from a personal `ghSync.sh` that was hardcoded to a single org. This generalises it into a reusable, org-agnostic toolkit skill.

## Changes Made

- `skills/ghsync/SKILL.md` — skill contract (name, description with TRIGGER clause), usage, flags, layout, sync-safety rules, requirements.
- `skills/ghsync/scripts/ghsync.sh` — the clone + fast-forward sync engine.
- `README.md` — skill table row and directory-tree entry.
- `.claude-plugin/plugin.json` — version bump 1.18.2 → 1.19.0 (MINOR: new skill) and description update.

## Technical Details

- **Org auto-derivation**: org defaults to the basename of the launch directory, so running inside `~/dev/github.com/<org>` mirrors that org. Override with `--org NAME` / `--root DIR`.
- **Clone + sync, not just clone**: new repos are cloned; existing checkouts on their default branch are fast-forwarded (`git pull --ff-only`), as are their clean worktrees.
- **Never clobbers local work**: repos with uncommitted changes or on a non-default branch are fetched but not pulled, and surfaced in the summary alongside failures and wrong-structure repos.
- **Layout**: `<root>/<repo>/<repo>-main` (default branch, clean) + `<root>/<repo>/worktree`, matching the toolkit's worktree convention.
- **Portability**: GitHub Enterprise via `GH_HOST`; `gh auth` checked up front; optional `timeout` caps each repo at 5 min; `GHSYNC_BLACKLIST` to skip repos. Removed the Sky-specific `repo-tagger.sh` tail.

## Testing

- `plugin contract pytest` — 61 passed (includes the new skill's frontmatter/TRIGGER/link checks).
- `bash -n` syntax check passes.
- Smoke-tested `--help`, unknown-flag handling, and org auto-derivation (running from a `meridianhub/` dir derives org `meridianhub` and prints the friendly no-teams error).

## Risk Assessment

Low. New isolated skill; no change to existing skills or commands. The script performs read APIs plus fast-forward-only pulls and fresh clones — no force operations, no merges, no destructive git.

## Deployment Notes

Available via `/plugin update` once merged and a release is cut at v1.19.0. Not added to the standalone-skill build (it is a local-machine tool, not a Claude Desktop chat skill).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/ghsync` skill for bulk cloning and syncing GitHub repositories across your organization with safeguards against uncommitted changes and non-default branches.

* **Documentation**
  * Updated documentation to include `/ghsync` command details, configuration options, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->