### PR TITLE
fix: resolve three /assess self-check defects (#96, #97, #98)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -687,7 +687,7 @@ def main() -> int:
         "--test-pressure", type=Path, metavar="RUN_CONTEXT_JSON",
         help=("Path to a run-context.json. When its `test_pressure` block "
               "carries per-file mutation results, files with high survivor "
-              "density are hatched (>30% diagonal, >50% cross-hatch) so "
+              "density are hatched (>30%% diagonal, >50%% cross-hatch) so "
               "covered-but-unpinned code stops rendering as safe green. "
               "Absent or empty test_pressure data -> no overlay (silent)."),
     )

--- a/skills/assess/scripts/lib/doc_complexity_join.py
+++ b/skills/assess/scripts/lib/doc_complexity_join.py
@@ -233,7 +233,14 @@ def analyze_doc_complexity_join(
         # high bar means doc_value is already near zero, so the doc's state is
         # noise either way.
         if complexity_summarised >= threshold:
-            if freshness < 0:
+            # A low-confidence staleness signal (subject_method ==
+            # "repo-baseline") measures the doc against repo-wide churn, not the
+            # specific code it describes, so a doc edited today can still read as
+            # "stale" purely because the repo is busy elsewhere. That is too
+            # coarse to call a lying map - the same confidence guard the Layer 0
+            # stale-hub reporting applies. Leave such a doc unclassified.
+            low_confidence = doc.get("confidence") == "low"
+            if freshness < 0 and not low_confidence:
                 finding = "lying_map"
             elif freshness > 0:
                 finding = "good_contract"

--- a/skills/assess/scripts/lib/liveness_scan.py
+++ b/skills/assess/scripts/lib/liveness_scan.py
@@ -497,7 +497,23 @@ def scan_observability(repo_root: Path,
     instrumented = _detect_instrumented(repo_root, files)
     discoverable, runbooks = _detect_discoverable(repo_root, files)
     reachable = _detect_reachable(repo_root, files, runbooks)
-    rung = 3 if reachable else 2 if discoverable else 1 if instrumented else 0
+    # Instrumentation is *necessary* for the doc-based ladder (see the rung model
+    # above: rung 0 == "no runtime instrumentation; liveness unknowable"). A repo
+    # that only *documents* observability - an SRE how-to, or this toolkit's own
+    # SKILL.md describing what a runbook looks like - trips the discoverable /
+    # runbook-prose detectors without emitting any telemetry, which previously
+    # inflated such a repo straight to rung 3. So prose evidence only elevates
+    # the rung when the repo is actually instrumented. Genuinely *invokable*
+    # tooling (an .mcp.json telemetry server, a logs/metrics repo skill) is real
+    # agent-reachability on its own and still scores rung 3 without a manifest.
+    tool_reachable = [s for s in reachable
+                      if s.startswith(("MCP server", "repo skill"))]
+    if tool_reachable:
+        rung = 3
+    elif instrumented:
+        rung = 3 if reachable else 2 if discoverable else 1
+    else:
+        rung = 0
     return ObservabilityResult(
         instrumented=instrumented, discoverable=discoverable,
         reachable=reachable, rung=rung,

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -251,6 +251,19 @@ def test_cli_exclude_classifies_glob_vs_dir(treemap, monkeypatch, tmp_path):
     assert sorted(captured["extra_patterns"]) == ["*.csv", "data-*.json"]
 
 
+def test_argparse_help_builds_on_current_python(treemap, monkeypatch, capsys):
+    """Regression for the Python 3.14 crash: argparse now eagerly validates help
+    strings and rejects a bare ``%`` (it must be escaped ``%%``). Building the
+    parser via ``--help`` must raise SystemExit (help printed), never ValueError
+    ('badly formed help string'). Runs under whatever Python the suite is on, so
+    a 3.14 CI job catches a reintroduced bare ``%`` in any help text."""
+    monkeypatch.setattr(sys, "argv", ["complexity-treemap.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        treemap.main()
+    assert exc.value.code == 0
+    assert "--test-pressure" in capsys.readouterr().out
+
+
 def test_cli_exclude_merges_with_config_toml(treemap, monkeypatch, tmp_path):
     """`.assess/config.toml` and `--exclude` both layer onto the defaults;
     neither replaces the other. Config-supplied dirs join CLI dirs, and

--- a/skills/assess/tests/test_doc_complexity_join.py
+++ b/skills/assess/tests/test_doc_complexity_join.py
@@ -90,6 +90,25 @@ def test_complex_plus_stale_is_lying_map_negative_value() -> None:
     assert "do not auto-generate" in rec
 
 
+def test_low_confidence_stale_doc_is_not_a_lying_map() -> None:
+    """A stale-by-ratio doc whose staleness is low-confidence (subject_method ==
+    'repo-baseline') must NOT be classified a lying_map: the ratio is measured
+    against repo-wide churn, not the code the doc describes, so a doc edited
+    today reads as 'stale' purely because the repo is busy. Mirrors the Layer 0
+    stale-hub confidence guard. Same ratio as the lying_map case above, only the
+    confidence differs."""
+    staleness = _staleness(
+        [_doc("pkg/engine/README.md", ratio=6.0, confidence="low")])
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/engine/README.md"]
+    # freshness still computes negative from the coarse ratio...
+    assert doc["freshness"] == -1.0
+    # ...but the low-confidence signal is too coarse to call a lie.
+    assert doc["finding"] is None
+    assert result["findings"]["lying_maps"] == []
+
+
 def test_complex_plus_no_doc_is_unexplained_complexity() -> None:
     """CCN-30 code with no doc covering it -> unexplained_complexity, value 0."""
     # Only a doc far away that covers nothing complex.

--- a/skills/assess/tests/test_liveness_scan.py
+++ b/skills/assess/tests/test_liveness_scan.py
@@ -238,11 +238,44 @@ def test_single_body_token_does_not_reach_discoverable(tmp_path: Path) -> None:
 
 
 def test_two_body_tokens_reach_discoverable(tmp_path: Path) -> None:
+    # Instrumentation present so the discoverable doc can elevate the rung -
+    # this test isolates the 2-distinct-token threshold for *discoverable*
+    # detection, not the rung floor (see test_docs_only_without_instrumentation).
+    _write(tmp_path, "requirements.txt", "structlog\n")
     _write(tmp_path, "ops.md",
            "We watch SLOs in Grafana and page via alerting when budgets burn.")
     r = scan_observability(tmp_path)
     assert r.rung == 2
     assert r.discoverable
+
+
+def test_docs_only_without_instrumentation_is_rung_0(tmp_path: Path) -> None:
+    """A repo that only *documents* observability - no telemetry emitted - must
+    not inflate past rung 0. Regression for the self-referential false positive
+    where this toolkit's own SKILL.md (prose describing runbooks/runnable
+    queries) scored rung 3 with `instrumented: false`."""
+    _write(tmp_path, "runbooks/oncall.md",
+           "We watch SLOs in Grafana and Datadog.\n"
+           "Query logs:\n```bash\nkubectl logs deploy/api\n```\n")
+    r = scan_observability(tmp_path).as_dict()
+    assert r["instrumented"]["present"] is False
+    # the doc still registers as discoverable/reachable evidence...
+    assert r["discoverable"]["present"] is True
+    assert r["reachable"]["present"] is True
+    # ...but with nothing instrumented there is no telemetry to reach: rung 0.
+    assert r["rung"] == 0
+
+
+def test_mcp_tooling_reaches_rung_3_without_instrumentation(tmp_path: Path) -> None:
+    """An invokable telemetry tool (.mcp.json log/metric server) is real
+    agent-reachability on its own - it stands at rung 3 even with no in-repo
+    instrumentation manifest (the telemetry lives in deployed infra)."""
+    _write(tmp_path, ".mcp.json",
+           '{"mcpServers":{"loki-logs":{"command":"loki-mcp"}}}')
+    r = scan_observability(tmp_path).as_dict()
+    assert r["instrumented"]["present"] is False
+    assert r["rung"] == 3
+    assert any("MCP server" in s for s in r["reachable"]["signals"])
 
 
 # ── read-only: build-mutating dead-code tools are gated ────────────────────


### PR DESCRIPTION
## Summary

A meta-`/assess` run against this repo (the tool scanning itself) surfaced three defects in the deterministic core. Each is fixed here with a regression test. Bumps the plugin to **1.19.1** (PATCH — bug fixes).

Closes #96, closes #97, closes #98.

## Changes Made

### #96 — `complexity-treemap.py` crashed on Python 3.14
Python 3.14's `argparse` now eagerly validates help strings and rejects an unescaped `%`. The `--test-pressure` help contained `>30%`/`>50%`. Because `requires-python = ">=3.12"`, `uv` selects 3.14 (now the Homebrew default) and the treemap — the headline artefact — failed at startup.

- **Fix:** escape `%` → `%%` in the help text (renders as a literal `%`, backward-compatible across 3.12/3.13/3.14).
- **Why CI missed it:** the suite imports modules but CI's interpreter wasn't 3.14, so the argparse-construction path wasn't exercised on the failing version.
- **Test:** `test_argparse_help_builds_on_current_python` builds the parser via `--help` and asserts `SystemExit`, not `ValueError`. Run under a 3.14 job it catches any reintroduced bare `%`.

### #97 — Layer 1 liveness scored rung 3 with zero instrumentation
The discoverable / runbook-prose detectors matched documentation that merely *describes* observability tooling — including this repo's own `SKILL.md` (which documents what a runbook looks like, with example `kubectl`/`logcli` fences). That inflated a no-telemetry repo straight to rung 3 (`instrumented: false`).

- **Fix:** make instrumentation *necessary* for the doc-based ladder, per the rung model's own "instrumented is necessary" / "Missing = rung 0 = no instrumentation" contract. Prose only elevates the rung when the repo is actually instrumented. Genuinely invokable tooling (`.mcp.json` telemetry server, a logs/metrics repo skill) still scores rung 3 on its own (deployed-infra case).
- **Behaviour change:** a repo whose *only* observability signal is prose docs now scores rung 0 (was rung 2/3). `test_two_body_tokens_reach_discoverable` gained an instrumentation fixture so it still isolates the 2-token discoverable detector; new tests pin the corrected model.

### #98 — `lying_map` flagged fresh, low-confidence docs
`derived_findings.lying_map` fired on docs whose staleness is low-confidence (`subject_method == "repo-baseline"`), where the ratio is repo-wide churn, not the doc's subject — so a doc edited *today* read as a stale "lying map".

- **Fix:** apply the same `confidence != "low"` guard the Layer 0 stale-hub reporting already uses. Low-confidence stale docs are left unclassified.
- **Test:** `test_low_confidence_stale_doc_is_not_a_lying_map`.

## Testing

- `skills/assess` pytest: **384 passed** (3 new tests) on Python 3.13 **and** 3.14.
- `ruff` complexity gate + `mypy` type gate: clean.

## Risk Assessment

Low. Three targeted fixes in the deterministic core, each covered by a regression test. The one behaviour change (#97) makes a no-instrumentation repo score lower (more honest) — flagged above for review.

---
_Findings surfaced by [`/ai-native-toolkit:assess`](https://github.com/bjcoombs/ai-native-toolkit) run against its own repo._