### PR TITLE
test(assess): hermetic git fixtures so the suite passes under commit signing

### DIFF
--- a/skills/assess/tests/conftest.py
+++ b/skills/assess/tests/conftest.py
@@ -1,4 +1,17 @@
-"""Shared pytest fixtures."""
+"""Shared pytest fixtures.
+
+Hermetic git. The fixtures below build throwaway git repos and assert on
+commit *metadata* (authorship, dates, coupling), never on signatures. A git
+subprocess inherits the ambient global/system config, and some environments
+enable commit signing there (``commit.gpgsign=true`` with an SSH/GPG signing
+program, e.g. Claude Code's web sandbox). Signing then fails inside the
+disposable test repos and ``git commit`` exits 128 — breaking the whole
+git-backed suite in any signing environment while CI (which doesn't sign)
+stays green. We neutralise ambient git config for the whole test process at
+import time (before any fixture builds a repo) by pointing GIT_CONFIG_GLOBAL
+/ GIT_CONFIG_SYSTEM at the null device. Each repo still sets its own local
+identity, so commits resolve an author/committer with no global config.
+"""
 from __future__ import annotations
 
 import datetime as _dt
@@ -7,6 +20,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
+
+# Applied at import time so it is in effect before any module/session-scoped
+# fixture creates a repo. See the module docstring for the why.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

The git-backed assess tests build throwaway repos and assert on commit *metadata* (authorship, dates, coupling) — never signatures. They inherited the ambient global/system git config, so in any environment with commit signing enabled (`commit.gpgsign=true` + a signing program — e.g. Claude Code's web sandbox) every test `git commit` tried to sign, failed, and exited 128: **35 failures locally while CI stayed green** (CI doesn't sign).

Fix: in the existing `skills/assess/tests/conftest.py`, neutralise ambient git config at import time — point `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` at `os.devnull` (+ `GIT_CONFIG_NOSYSTEM`) before any fixture builds a repo. The existing fixtures and their per-repo local identities are unchanged, so commits still resolve an author/committer.

Fitting for a tool that grades AI-agent-readiness: its own suite now runs cleanly inside an agent's signing sandbox, not just in CI.

## Scope note

This started as "fix the test fixtures **and** finalise the keyhole-findings prose." On investigation the prose half needed **no change**: `SKILL.md`'s "Cross-layer derived findings (keyhole readiness)" section already reads the findings correctly via `jq '.derived_findings, .attention' "$REPO_ROOT/.assess/run-context.json"`. So this PR is the one real fix — the test fixtures only. No `SKILL.md` change, no version bump (test-only).

## Verification
- `skills/assess` pytest: **384 passed** (was 35 failing in a signing environment).
- Single-file change off `main` (`skills/assess/tests/conftest.py`); `plugin.json` and `SKILL.md` untouched.

https://claude.ai/code/session_01F83n3vQscTg9A6jFUkpkY8