### PR TITLE
feat: Deterministic findings core, keyhole readiness, prescribed actions, and trust axis (tasks 2-5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -705,22 +705,28 @@ rg -i 'retrospective|retro|feedback loop|learnings|post.?mortem' "$REPO_ROOT"/{C
 
 ### Cross-layer derived findings (keyhole readiness)
 
-The layers above each measure one axis. The deterministic core also crosses those axes against each other and emits six named findings - the "where to look" signals no single layer surfaces. Read them once, after the per-layer scans:
+The layers above each measure one axis. The deterministic core also crosses those axes against each other and emits eight named findings - the "where to look" signals no single layer surfaces. Read them once, after the per-layer scans:
 
 ```bash
-jq '.derived_findings, .attention' "$REPO_ROOT/.assess/run-context.json"
+jq '.derived_findings, .attention, .keyhole_summary, .prescribed_actions' "$REPO_ROOT/.assess/run-context.json"
 ```
 
-`derived_findings` is a fixed-order list of six `{name, paths, action}` objects - all six always present, `paths` may be empty. Omit a finding from the report when its `paths` is empty. Each pairs an axis-crossing with the action it implies:
+`derived_findings` is a fixed-order list of eight `{name, paths, action}` objects - all eight always present, `paths` may be empty. Omit a finding from the report when its `paths` is empty. Each pairs an axis-crossing with the action it implies:
 
 - **`hidden_coupling`** - modular statically but bleeds across boundaries historically (files that keep changing together). The static map says "isolated"; git says "coupled." Action: investigate the seam before trusting the boundary.
 - **`lying_map`** - high complexity under a stale doc: the map exists but no longer matches the territory. Action: fix or delete the doc - a wrong map is worse than none.
 - **`unexplained_complexity`** - high complexity with no doc and no recorded intent. Action: write the missing contract. Do **not** auto-generate it - a guessed contract is just another lying map.
+- **`untrusted_hotspot`** (E1 trust axis) - a complexity hotspot whose tests are hollow: an opt-in mutation pass let a high fraction of mutants survive, so the suite *runs* the code but doesn't *pin* it. Silent without mutation data (the default read-only run never fires it). Action: strengthen tests to pin observable behaviour, not internal state.
+- **`self_referential_tests`** (E2 trust axis) - the code and its co-located tests were introduced in the same commit, so the suite may verify the author's mental model rather than independently-specified behaviour. Action: request human review - the tests verify internal consistency, not truth.
 - **`orphaned_understanding`** - high complexity with no human anchor and no intent: nobody owns the knowledge. Action: assign a human anchor before further change.
 - **`candidate_dead_weight`** - high complexity with no runtime evidence it is live. The bias is to **keep** (static reachability can't see external callers - Layer 1's caveat applies). Action: verify liveness, then delete only if confirmed dead.
 - **`refactor_boundary`** (positive) - high containment: edits stay local. A safe zone, never an attention row. Action: safe to hand an agent in isolation; cite these paths in Strengths.
 
 `attention` ranks the few units landing in the most *negative* findings (`refactor_boundary` never counts) - the "look here first" list, each row carrying its `findings` and `score`. Lead the report's findings with the top of this list.
+
+**Copy `findings_markdown` verbatim.** `run-context.json` carries a pre-rendered `findings_markdown` string - the deterministic findings section (the eight findings with their paths and actions, then the attention list). Paste it into the report **verbatim, in the `## Cross-Layer Findings (Keyhole Readiness)` section below the Scorecard** - do not paraphrase, summarise, reorder, or drop findings. You write prose *around* it (the "why these matter here" framing), but the section itself is the deterministic core's product, not yours. This is what makes the findings impossible to omit regardless of which LLM drives the run.
+
+`keyhole_summary` rolls the same findings into a one-line readiness summary (`summary_text`), reported alongside the 0-8 score in Step 4 - see the **Keyhole Readiness** line in the report template. `prescribed_actions` lists the attention-derived Top-3 actions the report MUST include - see the **Mandatory attention rule** in Step 4's Top 3 Actions.
 
 ## Step 3.5: Read Cross-Run Context
 
@@ -821,6 +827,9 @@ Colour = staleness (vivid red = a frozen doc beside churning code = a lying map)
 ## AI Readiness
 
 **Score: X / 8** — <maturity-label>
+**Keyhole Readiness:** <paste `keyhole_summary.summary_text` from run-context.json verbatim>
+
+The two headline metrics measure **different things and are never combined.** The 0-8 score answers _"is the scaffolding in place to catch problems?"_ (a property of the contracts and enforcement layers). The Keyhole Readiness summary answers _"where is today's structural pain?"_ - a pure count of structural concerns and safe zones rolled up from the eight cross-layer findings. A repo can score 7/8 and still carry many structural concerns (great scaffolding over churning legacy), or 3/8 with zero concerns (small, calm codebase). Report both side by side; never average, rescale, or fold one into the other.
 
 The **What it asks** column is the question that layer answers for an agent working here — read it first; the framework name is secondary. The **Band** orders them by dependency: a read-side blind spot makes the write-side scores mean less (you can't trust enforcement of a picture you can't see), and the meta band only matters once the rest works.
 
@@ -878,15 +887,19 @@ These artefacts look true but aren't - the most dangerous failure mode for an ag
 - **L1 — dead-but-present:** take `dead_code.candidates[0]`; fill from `path`, `symbol`, `kind`. Keep the `dead_code.caveat` in mind - static reachability proves "nothing in this repo calls it," never "no external consumer calls it" - so frame it as a candidate, not a verdict.
 - **L6 — green-but-hollow:** take `test_pressure.survivor_clusters[0]` only when `test_pressure.survivor_density.overall > 0.3`; fill the file from the cluster's `file`. State the mutation score as `1 - survivor_density.overall` and pair it with the file's line coverage when you have it. This is the hollow-gate pattern Layer 6 scores Partial for.
 
+<paste the `findings_markdown` string from run-context.json verbatim here — it renders as a `## Cross-Layer Findings (Keyhole Readiness)` section with the eight findings, their paths, their deterministic actions, and the attention list. Do not paraphrase, summarise, reorder, or drop any finding. Add a sentence of framing before or after if it helps a reader, but the section itself is copied, not rewritten.>
+
 ## Top 3 Actions
 
 Prioritize by leverage: agent instructions and CI first, then linters and coverage, then architecture tests and retro loops. Each action should be completable in a single session and reference **specific files** from the hotspot snapshot wherever possible — generic advice is the failure mode this report exists to prevent.
 
+**Mandatory attention rule (hard, not a suggestion).** If `attention` in run-context.json is non-empty, its top entries MUST appear in this Top 3 Actions table. The `prescribed_actions` array lists them with their finding-derived action text, their `rank`, and their `path` (pre-rendered as table rows you can paste - see `prescribed_actions` and `render_prescribed_actions`). You MAY add context, combine an attention path with a related gap, or fill the deterministic `?` cells (layer, effort, command) with judgement - but you may NOT omit an attention-list path from the Top 3 unless that path has already been addressed in this repo. When `attention` is empty, prioritise by leverage as above. This rule exists because the attention list is the deterministic core's "look here first" ranking; letting the LLM silently drop it would reintroduce exactly the non-determinism Part 1 removes.
+
 | # | Action | Layer | Effort | Command / First Step | Hotspot files this addresses | Issue |
 |---|--------|-------|--------|---------------------|------------------------------|-------|
-| 1 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths from top_hotspots / top_complex / top_large, or "—" if not file-specific> | — |
-| 2 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> | — |
-| 3 | <one-line action> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> | — |
+| 1 | <one-line action - if `prescribed_actions` is non-empty, rank 1's action and path go here> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths from top_hotspots / top_complex / top_large, or "—" if not file-specific> | — |
+| 2 | <one-line action - rank 2 from `prescribed_actions` if present> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> | — |
+| 3 | <one-line action - rank 3 from `prescribed_actions` if present> | <layer number> | <small/medium/large> | `<exact command or file to edit>` | <paths or —> | — |
 
 The `Issue` column is filled in by Step 6 if the user opts to create tracking issues. Leave as `—` initially.
 

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -716,21 +716,6 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
             extra_exclude_dirs=extra_exclude_dirs,
         ).as_dict(),
     )
-    keyhole = integrate_keyhole_signals(
-        repo_root=repo_root,
-        complexity_stats=current,
-        doc_staleness=doc_staleness if isinstance(doc_staleness, dict) else {},
-        dead_code=ctx["dead_code"],
-        observability=ctx["observability"],
-        structure=structure,
-    )
-    ctx["structure"] = keyhole["structure"]
-    ctx["behaviour"] = keyhole["behaviour"]
-    ctx["documentation"] = keyhole["documentation"]
-    ctx["understanding"] = keyhole["understanding"]
-    ctx["runtime"] = keyhole["runtime"]
-    ctx["derived_findings"] = keyhole["derived_findings"]
-    ctx["attention"] = keyhole["attention"]
 
     # Layer 1 write-side truth pressure: does the suite pin behaviour down, or
     # merely visit it? Best-effort like every other read-side scan. opt_in=False
@@ -738,6 +723,8 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # /assess stays read-only and fast - the cheap hollow-test heuristics and
     # mutation-config detection still run. hot_files come from the current top
     # hotspots so an opt-in mutation run would target the files that matter most.
+    # Scanned before the keyhole integrate so the E1 trust axis can cross the
+    # mutation survivor density with the complexity hotspots.
     hot_files = [h.get("path") for h in current.get("top_hotspots", [])
                  if h.get("path")]
     test_pressure = _safe(
@@ -766,6 +753,30 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
             "duplicate_truth": [],
         },
     }
+
+    keyhole = integrate_keyhole_signals(
+        repo_root=repo_root,
+        complexity_stats=current,
+        doc_staleness=doc_staleness if isinstance(doc_staleness, dict) else {},
+        dead_code=ctx["dead_code"],
+        observability=ctx["observability"],
+        structure=structure,
+        test_pressure=ctx["test_pressure"],
+    )
+    ctx["structure"] = keyhole["structure"]
+    ctx["behaviour"] = keyhole["behaviour"]
+    ctx["documentation"] = keyhole["documentation"]
+    ctx["understanding"] = keyhole["understanding"]
+    ctx["runtime"] = keyhole["runtime"]
+    ctx["derived_findings"] = keyhole["derived_findings"]
+    ctx["attention"] = keyhole["attention"]
+    # Deterministic report-skeleton products (assess-dogfooded Part 1): the
+    # pre-rendered findings section the LLM copies verbatim, the keyhole
+    # readiness summary reported alongside (never merged into) the 0-8 score, and
+    # the mandatory attention-derived Top-3 actions.
+    ctx["findings_markdown"] = keyhole["findings_markdown"]
+    ctx["keyhole_summary"] = keyhole["keyhole_summary"]
+    ctx["prescribed_actions"] = keyhole["prescribed_actions"]
 
     ctx["plugin_version"] = _read_plugin_version()
     ctx["anomalies"] = [

--- a/skills/assess/scripts/lib/change_coupling.py
+++ b/skills/assess/scripts/lib/change_coupling.py
@@ -378,3 +378,43 @@ def authorship_analysis(repo_root: Path, path: Path | str) -> dict:  # noqa: C90
         "intent_source": intent_source,
         "contributors": contributor_list,
     }
+
+
+# --- E2: self-referential test authorship -------------------------------------
+
+def find_self_referential_tests(
+    repo_root: Path,
+    test_to_code_map: dict[str, str],
+    commit_sets: list[set[Path]] | None = None,
+) -> list[dict]:
+    """E2: tests added in the same commit as the code they cover.
+
+    A test introduced alongside its subject in one commit risks verifying
+    *internal consistency* (the author's mental model at the moment of writing)
+    rather than *truth* (independently specified behaviour). This is the
+    high-precision, same-commit signal: each ``{test_file, source_file}`` pair
+    from ``test_to_code_map`` is flagged when at least one commit touches both
+    files. It deliberately does NOT chase code+tests split across two commits -
+    start with the precise signal, measure the miss rate before widening.
+
+    ``commit_sets`` is reused from the orchestrator's single ``git log`` parse
+    when supplied; otherwise it is parsed here. Returns a list of
+    ``{test_file, source_file, reason}`` dicts, sorted by ``test_file`` for
+    determinism. Empty map or no git history yields ``[]``.
+    """
+    if not test_to_code_map:
+        return []
+    if commit_sets is None:
+        commit_sets = parse_commit_file_sets(Path(repo_root))
+    commit_path_sets = [{str(f) for f in files} for files in commit_sets]
+    self_ref: list[dict] = []
+    for test_file, source_file in sorted(test_to_code_map.items()):
+        for paths in commit_path_sets:
+            if test_file in paths and source_file in paths:
+                self_ref.append({
+                    "test_file": test_file,
+                    "source_file": source_file,
+                    "reason": "test added in same commit as code",
+                })
+                break
+    return self_ref

--- a/skills/assess/scripts/lib/keyhole_signals.py
+++ b/skills/assess/scripts/lib/keyhole_signals.py
@@ -22,6 +22,7 @@ structured data + the named findings; the LLM write-back fills judgement later.
 """
 from __future__ import annotations
 
+import re
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -29,6 +30,7 @@ from lib.change_coupling import (
     authorship_analysis,
     change_coupling_pairs,
     containment_ratio,
+    find_self_referential_tests,
     parse_commit_file_sets,
 )
 from lib.coupling_analysis import detect_hidden_coupling, find_refactor_boundaries
@@ -59,6 +61,8 @@ FINDING_ORDER = [
     "hidden_coupling",
     "lying_map",
     "unexplained_complexity",
+    "untrusted_hotspot",  # E1: complex churning code with hollow tests
+    "self_referential_tests",  # E2: tests authored with the code they cover
     "orphaned_understanding",
     "candidate_dead_weight",
     "refactor_boundary",
@@ -67,10 +71,28 @@ FINDING_ACTIONS = {
     "hidden_coupling": "investigate the seam",
     "lying_map": "fix or delete the doc",
     "unexplained_complexity": "write the missing contract (do NOT auto-generate)",
+    "untrusted_hotspot": "strengthen tests to pin observable behaviour (not internal state)",
+    "self_referential_tests": "request human review - tests verify internal consistency, not truth",
     "orphaned_understanding": "assign a human anchor before further change",
     "candidate_dead_weight": "verify liveness, then delete if dead",
     "refactor_boundary": "safe to hand an agent in isolation",
 }
+
+# Source-file suffix/stem markers that mean a file IS itself a test (so it never
+# needs - and never maps to - a separate sibling test). Mirrors the same idiom
+# list assess_core uses for its co-location check, kept self-contained here so
+# the lib layer never imports back up into the orchestrator.
+_TEST_SIBLING_BUILDERS = [
+    lambda stem, ext: f"{stem}_test{ext}",    # Go, Python (pytest co-located)
+    lambda stem, ext: f"{stem}.test{ext}",    # JS/TS (jest)
+    lambda stem, ext: f"{stem}.spec{ext}",    # JS/TS/Angular (jasmine/jest)
+    lambda stem, ext: f"{stem}_spec{ext}",    # Ruby (rspec), some JS
+    lambda stem, ext: f"test_{stem}{ext}",    # Python (unittest)
+    lambda stem, ext: f"{stem}Test{ext}",     # Java/Kotlin/C# (JUnit)
+    lambda stem, ext: f"{stem}Tests{ext}",    # C#/Swift (XCTest)
+]
+_ADJACENT_TEST_DIRS = ["__tests__", "tests", "test", "spec"]
+_IS_TEST_RE = re.compile(r"(^test_|_test$|\.test$|\.spec$|_spec$|Tests?$)")
 
 
 # --------------------------------------------------------------------------
@@ -377,6 +399,267 @@ def build_attention_list(
 
 
 # --------------------------------------------------------------------------
+# E1 - untrusted hotspots (complexity x hollow tests)
+# --------------------------------------------------------------------------
+
+# A hotspot is "untrusted" when at least this fraction of its mutants survive -
+# the suite runs the code but doesn't pin it. Asymmetric like dead-weight: this
+# fires only on positive mutation evidence, so a read-only /assess (no opt-in
+# mutation pass) reports no untrusted hotspots rather than guessing.
+DEFAULT_SURVIVOR_DENSITY_THRESHOLD = 0.3
+
+
+def find_untrusted_hotspots(
+    complexity_stats: dict,
+    test_pressure: dict,
+    threshold_survivor_density: float = DEFAULT_SURVIVOR_DENSITY_THRESHOLD,
+) -> list[str]:
+    """E1: complexity hotspots whose tests are hollow (mutants survive).
+
+    Crosses the complexity hotspot list with the per-file mutation survivor
+    density. A hotspot whose tests let a high fraction of mutants survive is a
+    trust failure: the suite *visits* the code but doesn't *pin* it. Returns the
+    sorted hotspot paths over the density threshold.
+
+    Degrades to ``[]`` whenever there is no per-file mutation data - the default
+    read-only /assess run never mutates, so E1 stays silent rather than
+    manufacturing a finding from the always-on cheap heuristics. It speaks only
+    when an opt-in mutation pass populated ``test_pressure.per_file``.
+    """
+    if not isinstance(test_pressure, dict):
+        return []
+    per_file = test_pressure.get("per_file") or []
+    if not per_file:
+        return []
+    hotspot_paths = {
+        h.get("path")
+        for h in complexity_stats.get("top_hotspots", [])
+        if h.get("path")
+    }
+    density_by_file: dict[str, float] = {}
+    for entry in per_file:
+        total = entry.get("total")
+        survived = entry.get("survived") or 0
+        if total:
+            density_by_file[entry.get("file")] = survived / total
+    return sorted(
+        p for p in hotspot_paths
+        if density_by_file.get(p, 0.0) >= threshold_survivor_density
+    )
+
+
+# --------------------------------------------------------------------------
+# E2 - self-referential test authorship (test+code co-located AND co-committed)
+# --------------------------------------------------------------------------
+
+def _find_sibling_test(repo_root: Path, rel_path: str) -> Path | None:
+    """Return the co-located test file for a source path, or ``None``.
+
+    Mirrors assess_core's ``_has_sibling_test`` co-location idioms but returns
+    the test *path* (not a bool) so the E2 map can pair a test with its source.
+    A file that is itself a test maps to ``None`` - it is not a source needing a
+    sibling. Returns ``None`` when the source isn't on disk or no sibling is
+    found.
+    """
+    src = repo_root / rel_path
+    if not src.is_file():
+        return None
+    stem, ext = src.stem, src.suffix
+    if _IS_TEST_RE.search(stem):
+        return None  # the file IS a test, not a source needing a sibling
+    directory = src.parent
+    candidate_names = [build(stem, ext) for build in _TEST_SIBLING_BUILDERS]
+    for name in candidate_names:
+        cand = directory / name
+        if cand.is_file():
+            return cand
+    for sub in _ADJACENT_TEST_DIRS:
+        test_dir = directory / sub
+        if not test_dir.is_dir():
+            continue
+        for name in candidate_names + [f"{stem}{ext}"]:
+            cand = test_dir / name
+            if cand.is_file():
+                return cand
+    return None
+
+
+def build_test_to_code_map(
+    repo_root: Path, source_paths: list[str],
+) -> dict[str, str]:
+    """Map ``test_file -> source_file`` via co-location conventions.
+
+    Best-effort and filesystem-only: each source path that has a co-located test
+    contributes one ``{repo-relative test path: source path}`` entry. Paths the
+    co-location idioms miss (far-away mirror test trees) simply don't appear,
+    which correctly degrades E2 to "no evidence" rather than a false negative.
+    """
+    repo_root = Path(repo_root)
+    mapping: dict[str, str] = {}
+    for src in source_paths:
+        test = _find_sibling_test(repo_root, src)
+        if test is None:
+            continue
+        try:
+            rel = test.relative_to(repo_root).as_posix()
+        except ValueError:
+            rel = test.as_posix()
+        mapping[rel] = src
+    return mapping
+
+
+# --------------------------------------------------------------------------
+# Deterministic markdown / summary renderers (the report-skeleton products)
+# --------------------------------------------------------------------------
+
+# Cap on paths-per-finding and attention rows in the rendered markdown so a
+# pathological repo can't bloat the report skeleton. The structured arrays in
+# run-context.json keep the full (already-capped) lists.
+MAX_FINDING_PATHS_RENDERED = 10
+MAX_ATTENTION_ROWS_RENDERED = 5
+
+
+def render_findings_markdown(
+    findings: list[dict], attention: list[dict],
+) -> str:
+    """Render the derived findings + attention list as a markdown section.
+
+    This is the deterministic report skeleton: the LLM writes prose *around* it
+    but cannot omit, rename, or reorder the findings. Findings with no paths are
+    skipped (nothing to point at); when none have paths the section says so
+    explicitly rather than rendering an empty heading. Always ends with a single
+    trailing newline so it concatenates cleanly into the report.
+    """
+    lines = ["## Cross-Layer Findings (Keyhole Readiness)", ""]
+    rendered_any = False
+    for f in findings:
+        paths = f.get("paths") or []
+        if not paths:
+            continue
+        rendered_any = True
+        lines.append(f"### {f['name']}")
+        lines.append("")
+        lines.append(f"Action: {f['action']}")
+        lines.append("")
+        lines.append("Paths:")
+        for p in paths[:MAX_FINDING_PATHS_RENDERED]:
+            lines.append(f"- {p}")
+        lines.append("")
+    if not rendered_any:
+        lines.append(
+            "_No cross-layer findings surfaced - no path crossed an axis boundary._"
+        )
+        lines.append("")
+    if attention:
+        lines.append("### Attention List (Priority Order)")
+        lines.append("")
+        for a in attention[:MAX_ATTENTION_ROWS_RENDERED]:
+            names = ", ".join(a.get("findings", []))
+            lines.append(f"- {a['path']} (score {a['score']}): {names}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _format_summary(concerns: list[dict], safe_zones: int) -> str:
+    """One-line human-readable keyhole-readiness summary.
+
+    Pure count with a positive/negative split (PRD: never imply commensurability
+    with the 0-8 score). Singular/plural handled for the headline count and the
+    safe-zone count; the per-finding labels keep the finding name verbatim
+    (``2 hidden coupling``), matching the PRD's worked example.
+    """
+    def plural(n: int, word: str) -> str:
+        return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+    zones = plural(safe_zones, "safe zone")
+    if not concerns:
+        return f"No structural concerns, {zones}."
+    total = sum(c["count"] for c in concerns)
+    detail = ", ".join(f"{c['count']} {c['name'].replace('_', ' ')}" for c in concerns)
+    headline = plural(total, "structural concern")
+    return f"{headline} ({detail}), {zones}."
+
+
+def build_keyhole_summary(findings: list[dict]) -> dict:
+    """Roll the derived findings into a count/severity readiness summary.
+
+    Reported *alongside* the 0-8 layered score, never merged into it: the score
+    asks "is the scaffolding in place to catch problems?", this asks "where is
+    today's structural pain?". Returns ``{concerns, safe_zones, total_concerns,
+    summary_text}`` where ``concerns`` is the per-finding ``{name, count}`` for
+    every negative finding with paths and ``safe_zones`` is the
+    ``refactor_boundary`` path count (the one positive finding).
+    """
+    concerns: list[dict] = []
+    safe_zones = 0
+    for f in findings:
+        if f["name"] == "refactor_boundary":
+            safe_zones = len(f["paths"])
+        elif f["paths"]:
+            concerns.append({"name": f["name"], "count": len(f["paths"])})
+    return {
+        "concerns": concerns,
+        "safe_zones": safe_zones,
+        "total_concerns": sum(c["count"] for c in concerns),
+        "summary_text": _format_summary(concerns, safe_zones),
+    }
+
+
+# How many attention units are promoted into the mandatory prescribed-actions
+# set. The report's Top 3 Actions must include these.
+MAX_PRESCRIBED_ACTIONS = 3
+
+
+def build_prescribed_actions(
+    attention: list[dict],
+    findings: list[dict],
+    max_actions: int = MAX_PRESCRIBED_ACTIONS,
+) -> list[dict]:
+    """Map the top attention units to their finding-derived prescribed actions.
+
+    The attention list already ranks units by negative-finding count; this picks
+    the action for each unit's *worst* finding (severity = ``FINDING_ORDER``
+    minus the positive ``refactor_boundary``, so the deterministic worst-first
+    order is the single source of truth). Returns ``{path, action, findings,
+    rank}`` for up to ``max_actions`` units - the Top-3 the report MUST include.
+    """
+    finding_actions = {f["name"]: f["action"] for f in findings}
+    severity = [n for n in FINDING_ORDER if n != "refactor_boundary"]
+    prescribed: list[dict] = []
+    for i, unit in enumerate(attention[:max_actions]):
+        for name in severity:
+            if name in unit["findings"]:
+                prescribed.append({
+                    "path": unit["path"],
+                    "action": finding_actions[name],
+                    "findings": unit["findings"],
+                    "rank": i + 1,
+                })
+                break
+    return prescribed
+
+
+def render_prescribed_actions(prescribed: list[dict]) -> str:
+    """Render the mandatory attention-derived actions as Top-3 table rows.
+
+    Pre-fills the rank, action, hotspot path, and issue columns of the report's
+    Top 3 Actions table; the LLM fills the ``?`` layer/effort/command cells with
+    judgement. Returns ``""`` when there is nothing to prescribe (empty
+    attention), so the LLM falls back to its own prioritisation.
+    """
+    if not prescribed:
+        return ""
+    lines = []
+    for p in prescribed:
+        # Columns: # | Action | Layer | Effort | Command / First Step | Hotspot
+        # files this addresses | Issue
+        lines.append(
+            f"| {p['rank']} | {p['action']} | ? | ? | ? | `{p['path']}` | — |"
+        )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
 # Orchestration entry point
 # --------------------------------------------------------------------------
 
@@ -421,13 +704,16 @@ def integrate(
     observability: dict,
     structure: dict,
     commit_sets: list[set[Path]] | None = None,
+    test_pressure: dict | None = None,
 ) -> dict:
     """Build the five run-context blocks + derived findings + attention list.
 
     Pure orchestration over the lib signals. ``commit_sets`` may be passed in
     (the orchestrator parses git log once and reuses it for churn etc.);
-    otherwise it is parsed here. Every block is built defensively - a failure in
-    one degrades that block to ``available: False`` and leaves the rest intact.
+    otherwise it is parsed here. ``test_pressure`` is the Layer-1 write-side scan
+    (the E1 trust axis crosses it with the complexity hotspots); when absent E1
+    degrades to silent. Every block is built defensively - a failure in one
+    degrades that block to ``available: False`` and leaves the rest intact.
     """
     repo_root = Path(repo_root)
     if commit_sets is None:
@@ -481,16 +767,37 @@ def integrate(
         complexity_stats, dead_code, understanding.get("intent_source_by_path", {})
     )
 
+    # E1 trust axis: complexity hotspots whose tests are hollow. Silent without
+    # opt-in mutation data, so it degrades cleanly on the default read-only run.
+    try:
+        untrusted = find_untrusted_hotspots(complexity_stats, test_pressure or {})
+    except Exception:  # noqa: BLE001 - degrade, never crash
+        untrusted = []
+
+    # E2 trust axis: tests co-located AND co-committed with the code they cover -
+    # the suite may verify internal consistency, not truth. Filesystem + git
+    # work, wrapped so a parse failure degrades to no finding.
+    try:
+        source_paths = _paths_from_stats(complexity_stats)
+        test_to_code = build_test_to_code_map(repo_root, source_paths)
+        self_ref = find_self_referential_tests(repo_root, test_to_code, commit_sets)
+        self_ref_paths = sorted({sr["source_file"] for sr in self_ref})
+    except Exception:  # noqa: BLE001 - degrade, never crash
+        self_ref_paths = []
+
     findings = assemble_findings({
         "hidden_coupling": [h["path"] for h in behaviour.get("hidden_coupling_findings", [])],
         "lying_map": [d["path"] for d in documentation.get("stale_doc_on_complexity", [])],
         "unexplained_complexity": [
             d["path"] for d in documentation.get("unexplained_complexity", [])
         ],
+        "untrusted_hotspot": untrusted,
+        "self_referential_tests": self_ref_paths,
         "orphaned_understanding": understanding.get("orphaned_understanding", []),
         "candidate_dead_weight": dead_weight,
         "refactor_boundary": [b["path"] for b in behaviour.get("refactor_boundaries", [])],
     })
+    attention = build_attention_list(findings)
 
     return {
         "structure": structure,
@@ -499,5 +806,8 @@ def integrate(
         "understanding": understanding,
         "runtime": runtime,
         "derived_findings": findings,
-        "attention": build_attention_list(findings),
+        "attention": attention,
+        "findings_markdown": render_findings_markdown(findings, attention),
+        "keyhole_summary": build_keyhole_summary(findings),
+        "prescribed_actions": build_prescribed_actions(attention, findings),
     }

--- a/skills/assess/tests/fixtures/golden/run-context-baseline.json
+++ b/skills/assess/tests/fixtures/golden/run-context-baseline.json
@@ -41,6 +41,44 @@
       "score": 1
     }
   ],
+  "findings_markdown": "## Cross-Layer Findings (Keyhole Readiness)\n\n### hidden_coupling\n\nAction: investigate the seam\n\nPaths:\n- scripts\n- scripts/tests\n- skills/assess/scripts\n- skills/assess/scripts/lib\n- skills/assess/tests\n\n### refactor_boundary\n\nAction: safe to hand an agent in isolation\n\nPaths:\n- commands\n\n### Attention List (Priority Order)\n\n- scripts (score 1): hidden_coupling\n- scripts/tests (score 1): hidden_coupling\n- skills/assess/scripts (score 1): hidden_coupling\n- skills/assess/scripts/lib (score 1): hidden_coupling\n- skills/assess/tests (score 1): hidden_coupling\n",
+  "keyhole_summary": {
+    "concerns": [
+      {
+        "name": "hidden_coupling",
+        "count": 5
+      }
+    ],
+    "safe_zones": 1,
+    "total_concerns": 5,
+    "summary_text": "5 structural concerns (5 hidden coupling), 1 safe zone."
+  },
+  "prescribed_actions": [
+    {
+      "path": "scripts",
+      "action": "investigate the seam",
+      "findings": [
+        "hidden_coupling"
+      ],
+      "rank": 1
+    },
+    {
+      "path": "scripts/tests",
+      "action": "investigate the seam",
+      "findings": [
+        "hidden_coupling"
+      ],
+      "rank": 2
+    },
+    {
+      "path": "skills/assess/scripts",
+      "action": "investigate the seam",
+      "findings": [
+        "hidden_coupling"
+      ],
+      "rank": 3
+    }
+  ],
   "behaviour": {
     "available": true,
     "change_coupling_pairs": [
@@ -784,7 +822,6 @@
   },
   "derived_findings": [
     {
-      "action": "investigate the seam",
       "name": "hidden_coupling",
       "paths": [
         "scripts",
@@ -792,34 +829,45 @@
         "skills/assess/scripts",
         "skills/assess/scripts/lib",
         "skills/assess/tests"
-      ]
+      ],
+      "action": "investigate the seam"
     },
     {
-      "action": "fix or delete the doc",
       "name": "lying_map",
-      "paths": []
+      "paths": [],
+      "action": "fix or delete the doc"
     },
     {
-      "action": "write the missing contract (do NOT auto-generate)",
       "name": "unexplained_complexity",
-      "paths": []
+      "paths": [],
+      "action": "write the missing contract (do NOT auto-generate)"
     },
     {
-      "action": "assign a human anchor before further change",
+      "name": "untrusted_hotspot",
+      "paths": [],
+      "action": "strengthen tests to pin observable behaviour (not internal state)"
+    },
+    {
+      "name": "self_referential_tests",
+      "paths": [],
+      "action": "request human review - tests verify internal consistency, not truth"
+    },
+    {
       "name": "orphaned_understanding",
-      "paths": []
+      "paths": [],
+      "action": "assign a human anchor before further change"
     },
     {
-      "action": "verify liveness, then delete if dead",
       "name": "candidate_dead_weight",
-      "paths": []
+      "paths": [],
+      "action": "verify liveness, then delete if dead"
     },
     {
-      "action": "safe to hand an agent in isolation",
       "name": "refactor_boundary",
       "paths": [
         "commands"
-      ]
+      ],
+      "action": "safe to hand an agent in isolation"
     }
   ],
   "diff": "<<normalized>>",

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -424,6 +424,46 @@ def test_build_run_context_includes_anomalies_field(tmp_path: Path) -> None:
     assert "ZERO_FILES_SCORED" in codes
 
 
+def test_run_context_has_deterministic_keyhole_products(tmp_path: Path) -> None:
+    """assess-dogfooded Part 1: run-context.json carries the deterministic
+    report-skeleton products - the pre-rendered findings markdown, the keyhole
+    readiness summary, and the prescribed Top-3 actions - plus the eight derived
+    findings (six original + E1/E2 trust axis)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 1, "loc": {}, "ccn": {},
+        "top_hotspots": [{"path": "src/a.py", "loc": 100, "ccn": 12, "commits": 3}],
+        "top_complex": [{"path": "src/a.py", "ccn": 12}],
+        "top_large": [{"path": "src/a.py", "loc": 100}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-22")
+
+    # Task 2: deterministic findings markdown is present and well-formed.
+    assert "findings_markdown" in ctx
+    assert ctx["findings_markdown"].startswith(
+        "## Cross-Layer Findings (Keyhole Readiness)"
+    )
+    # Task 3: keyhole readiness summary reported alongside the 0-8 score.
+    assert "keyhole_summary" in ctx
+    assert set(ctx["keyhole_summary"]) == {
+        "concerns", "safe_zones", "total_concerns", "summary_text"
+    }
+    # Task 4: prescribed actions array exists (possibly empty for a clean repo).
+    assert "prescribed_actions" in ctx
+    assert isinstance(ctx["prescribed_actions"], list)
+    # Task 5: derived findings now carry the eight named axes in fixed order.
+    names = [f["name"] for f in ctx["derived_findings"]]
+    assert names == [
+        "hidden_coupling", "lying_map", "unexplained_complexity",
+        "untrusted_hotspot", "self_referential_tests",
+        "orphaned_understanding", "candidate_dead_weight", "refactor_boundary",
+    ]
+
+
 def test_instructions_grade_is_None_when_no_files(tmp_path: Path) -> None:
     """When no instruction file exists, instructions_grade is None (not 'F').
 
@@ -519,6 +559,7 @@ def test_keyhole_blocks_present_and_backward_compatible(git_repo) -> None:
     findings = ctx["derived_findings"]
     assert findings, "derived_findings must not be empty"
     expected = {"hidden_coupling", "lying_map", "unexplained_complexity",
+                "untrusted_hotspot", "self_referential_tests",
                 "orphaned_understanding", "candidate_dead_weight", "refactor_boundary"}
     assert {f["name"] for f in findings} == expected
     for f in findings:

--- a/skills/assess/tests/test_change_coupling.py
+++ b/skills/assess/tests/test_change_coupling.py
@@ -13,6 +13,7 @@ from lib.change_coupling import (
     authorship_analysis,
     change_coupling_pairs,
     containment_ratio,
+    find_self_referential_tests,
     parse_commit_file_sets,
 )
 
@@ -286,3 +287,49 @@ def test_authorship_contributor_line_stats(tmp_path: Path) -> None:
     # First commit adds 2 lines; second adds 1 more. 3 added total, 0 removed.
     assert alice["lines_added"] == 3
     assert alice["lines_removed"] == 0
+
+
+# --- E2: find_self_referential_tests ------------------------------------------
+
+def test_self_referential_test_same_commit_flagged(tmp_path: Path) -> None:
+    """Test + code introduced in one commit -> self-referential."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"pkg/svc.go": "package pkg",
+                   "pkg/svc_test.go": "package pkg"}, "feat: svc + test together")
+    result = find_self_referential_tests(
+        repo, {"pkg/svc_test.go": "pkg/svc.go"}
+    )
+    assert result == [{
+        "test_file": "pkg/svc_test.go",
+        "source_file": "pkg/svc.go",
+        "reason": "test added in same commit as code",
+    }]
+
+
+def test_self_referential_test_separate_commits_not_flagged(tmp_path: Path) -> None:
+    """Code first, test in a later commit -> not the same-commit signal."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"pkg/svc.go": "package pkg"}, "feat: svc")
+    _commit(repo, {"pkg/svc_test.go": "package pkg"}, "test: svc")
+    result = find_self_referential_tests(
+        repo, {"pkg/svc_test.go": "pkg/svc.go"}
+    )
+    assert result == []
+
+
+def test_self_referential_test_empty_map_returns_empty(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"a.py": "1"}, "c1")
+    assert find_self_referential_tests(repo, {}) == []
+
+
+def test_self_referential_test_reuses_passed_commit_sets(tmp_path: Path) -> None:
+    """commit_sets passed in (the orchestrator's single git-log parse) is used
+    directly - no second git call needed."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, {"m.py": "1", "test_m.py": "1"}, "feat+test")
+    commit_sets = parse_commit_file_sets(repo)
+    result = find_self_referential_tests(
+        repo, {"test_m.py": "m.py"}, commit_sets=commit_sets
+    )
+    assert [r["source_file"] for r in result] == ["m.py"]

--- a/skills/assess/tests/test_golden_baseline.py
+++ b/skills/assess/tests/test_golden_baseline.py
@@ -44,18 +44,37 @@ def test_golden_run_context_volatile_fields_are_normalized() -> None:
 
 
 def test_golden_run_context_keeps_derived_findings_shape() -> None:
-    """All six keyhole findings present in fixed order - the contract the
-    report's findings section and Part 1's deterministic surfacing rely on."""
+    """All eight keyhole findings present in fixed order - the contract the
+    report's findings section and Part 1's deterministic surfacing rely on. The
+    E1/E2 trust-axis findings (untrusted_hotspot, self_referential_tests) join
+    the original six between unexplained_complexity and orphaned_understanding."""
     ctx = golden.load_golden_run_context()
     names = [f["name"] for f in ctx["derived_findings"]]
     assert names == [
         "hidden_coupling",
         "lying_map",
         "unexplained_complexity",
+        "untrusted_hotspot",
+        "self_referential_tests",
         "orphaned_understanding",
         "candidate_dead_weight",
         "refactor_boundary",
     ]
+
+
+def test_golden_run_context_has_deterministic_keyhole_products() -> None:
+    """Part 1 adds three deterministic report-skeleton products to the bus: the
+    pre-rendered findings markdown, the keyhole readiness summary (reported
+    alongside the 0-8 score), and the mandatory attention-derived Top-3
+    actions."""
+    ctx = golden.load_golden_run_context()
+    assert ctx["findings_markdown"].startswith(
+        "## Cross-Layer Findings (Keyhole Readiness)"
+    )
+    assert set(ctx["keyhole_summary"]) == {
+        "concerns", "safe_zones", "total_concerns", "summary_text"
+    }
+    assert isinstance(ctx["prescribed_actions"], list)
 
 
 def test_normalize_run_context_is_idempotent() -> None:

--- a/skills/assess/tests/test_keyhole_signals.py
+++ b/skills/assess/tests/test_keyhole_signals.py
@@ -280,3 +280,217 @@ def test_attention_list_ranks_by_cross_axis_count() -> None:
     assert all(a["path"] != "safe" for a in attention)
     paths = [a["path"] for a in attention]
     assert "single" in paths
+
+
+# --- Task 2: render_findings_markdown ----------------------------------------
+
+def _sample_findings() -> list[dict]:
+    """Two findings with paths + the positive boundary, the rest empty."""
+    return ks.assemble_findings({
+        "hidden_coupling": ["dir/a"],
+        "lying_map": ["docs/x.md", "docs/y.md"],
+        "refactor_boundary": ["island"],
+    })
+
+
+def test_render_findings_markdown_includes_paths_and_actions() -> None:
+    findings = _sample_findings()
+    attention = ks.build_attention_list(findings)
+    md = ks.render_findings_markdown(findings, attention)
+    assert md.startswith("## Cross-Layer Findings (Keyhole Readiness)")
+    # Only findings with paths render a heading.
+    assert "### hidden_coupling" in md
+    assert "### lying_map" in md
+    assert "### refactor_boundary" in md
+    # The deterministic action text appears verbatim.
+    assert f"Action: {ks.FINDING_ACTIONS['hidden_coupling']}" in md
+    # Every path is listed.
+    assert "- docs/x.md" in md
+    assert "- docs/y.md" in md
+    # Empty findings produce no heading.
+    assert "### unexplained_complexity" not in md
+    assert md.endswith("\n")
+
+
+def test_render_findings_markdown_empty_is_minimal_but_valid() -> None:
+    findings = ks.assemble_findings({})  # all six/eight empty
+    md = ks.render_findings_markdown(findings, [])
+    assert md.startswith("## Cross-Layer Findings (Keyhole Readiness)")
+    assert "No cross-layer findings surfaced" in md
+    # No finding headings when nothing has paths.
+    assert "###" not in md
+
+
+def test_render_findings_markdown_caps_paths_at_ten() -> None:
+    findings = ks.assemble_findings({
+        "lying_map": [f"docs/{i}.md" for i in range(20)],
+    })
+    md = ks.render_findings_markdown(findings, [])
+    listed = [ln for ln in md.splitlines() if ln.startswith("- docs/")]
+    assert len(listed) == ks.MAX_FINDING_PATHS_RENDERED
+
+
+def test_render_findings_markdown_attention_section_caps_at_five() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": [f"u{i}" for i in range(8)],
+        "lying_map": [f"u{i}" for i in range(8)],  # each unit scores 2
+    })
+    attention = ks.build_attention_list(findings)
+    md = ks.render_findings_markdown(findings, attention)
+    assert "### Attention List (Priority Order)" in md
+    # Attention rows carry the "(score N)" marker; finding path bullets do not.
+    rows = [ln for ln in md.splitlines() if ln.startswith("- u") and "(score" in ln]
+    assert len(rows) == ks.MAX_ATTENTION_ROWS_RENDERED
+
+
+# --- Task 3: build_keyhole_summary -------------------------------------------
+
+def test_build_keyhole_summary_counts_concerns_and_safe_zones() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": ["a", "b"],
+        "lying_map": ["c"],
+        "refactor_boundary": ["s1", "s2", "s3"],
+    })
+    summary = ks.build_keyhole_summary(findings)
+    assert summary["safe_zones"] == 3
+    assert summary["total_concerns"] == 3
+    by_name = {c["name"]: c["count"] for c in summary["concerns"]}
+    assert by_name == {"hidden_coupling": 2, "lying_map": 1}
+    # The summary text is a pure count, parallel to the 0-8 score - never a score.
+    assert summary["summary_text"] == (
+        "3 structural concerns (2 hidden coupling, 1 lying map), 3 safe zones."
+    )
+
+
+def test_build_keyhole_summary_empty_findings_neutral_message() -> None:
+    summary = ks.build_keyhole_summary(ks.assemble_findings({}))
+    assert summary["concerns"] == []
+    assert summary["total_concerns"] == 0
+    assert summary["safe_zones"] == 0
+    assert summary["summary_text"] == "No structural concerns, 0 safe zones."
+
+
+def test_build_keyhole_summary_singular_plural() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": ["a"],
+        "refactor_boundary": ["s1"],
+    })
+    summary = ks.build_keyhole_summary(findings)
+    assert summary["summary_text"] == (
+        "1 structural concern (1 hidden coupling), 1 safe zone."
+    )
+
+
+def test_build_keyhole_summary_no_concerns_with_safe_zones() -> None:
+    findings = ks.assemble_findings({"refactor_boundary": ["s1", "s2"]})
+    summary = ks.build_keyhole_summary(findings)
+    assert summary["summary_text"] == "No structural concerns, 2 safe zones."
+
+
+# --- Task 4: build_prescribed_actions / render_prescribed_actions ------------
+
+def test_build_prescribed_actions_picks_worst_finding_per_unit() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": ["worst"],
+        "lying_map": ["worst", "mid"],
+        "unexplained_complexity": ["worst", "mid"],
+    })
+    attention = ks.build_attention_list(findings)
+    prescribed = ks.build_prescribed_actions(attention, findings)
+    # 'worst' lands in 3 findings (score 3) -> ranks first.
+    assert prescribed[0]["path"] == "worst"
+    assert prescribed[0]["rank"] == 1
+    # 'worst' spans hidden_coupling + lying_map + unexplained; hidden_coupling
+    # is highest severity (earliest in FINDING_ORDER).
+    assert prescribed[0]["action"] == ks.FINDING_ACTIONS["hidden_coupling"]
+    # 'mid' lands in lying_map + unexplained_complexity; lying_map is worse.
+    mid = next(p for p in prescribed if p["path"] == "mid")
+    assert mid["action"] == ks.FINDING_ACTIONS["lying_map"]
+
+
+def test_build_prescribed_actions_caps_at_three() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": [f"u{i}" for i in range(5)],
+        "lying_map": [f"u{i}" for i in range(5)],
+    })
+    attention = ks.build_attention_list(findings)
+    prescribed = ks.build_prescribed_actions(attention, findings)
+    assert len(prescribed) == 3
+    assert [p["rank"] for p in prescribed] == [1, 2, 3]
+
+
+def test_build_prescribed_actions_empty_attention() -> None:
+    assert ks.build_prescribed_actions([], ks.assemble_findings({})) == []
+
+
+def test_render_prescribed_actions_rows_and_empty() -> None:
+    findings = ks.assemble_findings({
+        "hidden_coupling": ["worst"],
+        "lying_map": ["worst"],
+    })
+    attention = ks.build_attention_list(findings)
+    prescribed = ks.build_prescribed_actions(attention, findings)
+    rows = ks.render_prescribed_actions(prescribed)
+    # Seven-column table row matching the SKILL.md Top 3 Actions template.
+    assert rows.startswith("| 1 |")
+    assert rows.count("|") == 8  # 7 columns => 8 pipes
+    assert "`worst`" in rows
+    assert ks.render_prescribed_actions([]) == ""
+
+
+# --- Task 5 E1: find_untrusted_hotspots --------------------------------------
+
+def test_find_untrusted_hotspots_flags_high_survivor_density() -> None:
+    complexity_stats = {"top_hotspots": [
+        {"path": "src/hot.py"}, {"path": "src/cold.py"},
+    ]}
+    test_pressure = {"per_file": [
+        {"file": "src/hot.py", "survived": 4, "total": 10},   # 0.4 >= 0.3
+        {"file": "src/cold.py", "survived": 1, "total": 10},  # 0.1 < 0.3
+    ]}
+    assert ks.find_untrusted_hotspots(complexity_stats, test_pressure) == ["src/hot.py"]
+
+
+def test_find_untrusted_hotspots_silent_without_mutation_data() -> None:
+    complexity_stats = {"top_hotspots": [{"path": "src/hot.py"}]}
+    # No per_file -> no mutation evidence -> nothing flagged (read-only default).
+    assert ks.find_untrusted_hotspots(complexity_stats, {"per_file": []}) == []
+    assert ks.find_untrusted_hotspots(complexity_stats, {}) == []
+    assert ks.find_untrusted_hotspots(complexity_stats, None) == []
+
+
+def test_find_untrusted_hotspots_only_flags_actual_hotspots() -> None:
+    complexity_stats = {"top_hotspots": [{"path": "src/hot.py"}]}
+    test_pressure = {"per_file": [
+        {"file": "src/not_a_hotspot.py", "survived": 9, "total": 10},
+    ]}
+    assert ks.find_untrusted_hotspots(complexity_stats, test_pressure) == []
+
+
+# --- Task 5 E2: test-to-code mapping -----------------------------------------
+
+def test_build_test_to_code_map_finds_colocated_tests(tmp_path: Path) -> None:
+    repo = tmp_path
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "svc.go").write_text("package pkg")
+    (repo / "pkg" / "svc_test.go").write_text("package pkg")
+    (repo / "pkg" / "lonely.go").write_text("package pkg")  # no sibling test
+    mapping = ks.build_test_to_code_map(repo, ["pkg/svc.go", "pkg/lonely.go"])
+    assert mapping == {"pkg/svc_test.go": "pkg/svc.go"}
+
+
+def test_build_test_to_code_map_python_and_adjacent_dir(tmp_path: Path) -> None:
+    repo = tmp_path
+    (repo / "src").mkdir()
+    (repo / "src" / "mod.py").write_text("x = 1")
+    (repo / "src" / "tests").mkdir()
+    (repo / "src" / "tests" / "test_mod.py").write_text("x = 1")
+    mapping = ks.build_test_to_code_map(repo, ["src/mod.py"])
+    assert mapping == {"src/tests/test_mod.py": "src/mod.py"}
+
+
+def test_find_sibling_test_skips_test_files_themselves(tmp_path: Path) -> None:
+    repo = tmp_path
+    (repo / "foo_test.go").write_text("package x")
+    assert ks._find_sibling_test(repo, "foo_test.go") is None
+    assert ks.build_test_to_code_map(repo, ["foo_test.go"]) == {}


### PR DESCRIPTION
## Summary

Part 1 of the `assess-dogfooded` work (tasks 2-5), combined into one PR because all four add functions to `keyhole_signals.py`, wire through `integrate()` / `build_run_context()` into `run-context.json`, and edit the same `SKILL.md` report template. Everything rides the run-context data bus: deterministic computation in `keyhole_signals.py` -> assembled in `integrate()` -> serialized to `run-context.json`.

## Changes Made

**Task 2 - Deterministic Findings Surfacing.** `render_findings_markdown(findings, attention)` pre-renders the cross-layer findings (each finding's paths + deterministic action, then the attention list) as a `## Cross-Layer Findings (Keyhole Readiness)` markdown section. Surfaced as `findings_markdown`; `SKILL.md` instructs the LLM to paste it **verbatim** below the Scorecard. The findings now appear in the report skeleton independent of LLM cooperation.

**Task 3 - Keyhole Readiness Summary.** `build_keyhole_summary(findings)` rolls the findings into a count/severity summary (`{concerns, safe_zones, total_concerns, summary_text}`), e.g. _"5 structural concerns (5 hidden coupling), 1 safe zone."_ Reported **alongside** the 0-8 score, never merged into it - `SKILL.md` adds a **Keyhole Readiness** line under the Score and explains the two metrics measure different things and are never combined (PRD: avoid implied commensurability).

**Task 4 - Mandatory Top-3 Actions.** `build_prescribed_actions(attention, findings)` maps the top attention units to their worst-finding-derived action (severity = `FINDING_ORDER` minus the positive `refactor_boundary`, single source of truth). `render_prescribed_actions()` pre-renders them as Top-3 table rows. `SKILL.md` Step 4 makes attention -> Top-3 a **hard rule**, not prose.

**Task 5 - Signal E Trust Axis.** Two new findings join `FINDING_ORDER`/`FINDING_ACTIONS` between `unexplained_complexity` and `orphaned_understanding`:
- **E1 `untrusted_hotspot`** (`find_untrusted_hotspots`): complexity hotspots whose mutation survivor density clears a threshold - the suite runs the code but doesn't pin it. Asymmetric like dead-weight: silent without opt-in mutation data, so the default read-only run never manufactures it.
- **E2 `self_referential_tests`** (`find_self_referential_tests` in `change_coupling.py`): code and its co-located tests introduced in the same commit - the suite may verify internal consistency, not truth. High-precision same-commit signal; `build_test_to_code_map`/`_find_sibling_test` build the test->code map from co-location conventions.

## Technical Details

- `test_pressure` is now scanned **before** the keyhole `integrate()` call in `build_run_context()` and passed in, so E1 can cross mutation survivor density with the complexity hotspots. All other ordering preserved.
- E1/E2 are wrapped defensively in `integrate()` (degrade to `[]`, never crash), matching the existing `_safe_block` discipline.
- `derived_findings` is now an **eight**-entry fixed-order list; `keyhole_summary` and `prescribed_actions` treat `refactor_boundary` as the sole positive/safe-zone finding.

## Golden baseline

`run-context.json` is the **primary** Part-3 parity target, so it was regenerated deliberately:
- `derived_findings` now carries all eight findings in fixed order (existing six paths preserved byte-for-byte; the two new findings are **empty for this repo** - verified empirically: no co-located test siblings (`build_test_to_code_map` returns 0) and no mutation data (`test_pressure.per_file` empty)).
- Added the three deterministic products (`findings_markdown`, `keyhole_summary`, `prescribed_actions`).
- Reused `normalize_run_context` from `golden.py`; the regenerated fixture is normalize-idempotent.
- `test_golden_baseline.py` updated to the eight-finding shape + a new test asserting the three products. The shape change is intentional, not a weakened parity test.

The `assess-report-baseline.md` is an LLM-authored **structural reference** (not a byte-stable parity target, per the Phase-0 analysis doc), so it is left as-is; the deterministic run-context bus is the invariant that pins parity. The report template's new Keyhole Readiness line + Cross-Layer Findings section will populate on the next live run.

## Testing

All four required checks pass locally (`GIT_CONFIG_GLOBAL=/dev/null` to clear the ~7 phantom git-commit failures):
- `skills/assess` pytest: **415 passed** (added 28 unit tests across `test_keyhole_signals.py`, `test_change_coupling.py`, `test_assess_core.py`, `test_golden_baseline.py`)
- `scripts/` pytest: **69 passed** (standalone-build integration confirms no forbidden strings leak into the ZIP from the SKILL.md additions)
- `plugin contract` pytest: **61 passed** (internal markdown links resolve)
- ruff (assess + scripts) + mypy (deterministic core): clean

## Risk Assessment

Low. New functions are pure transforms with defensive wrapping; existing finding data is untouched; the two new findings are empty for this repo so behaviour is additive. The version bump to **1.21.0** (MINOR - new features on an existing skill) is the only hot-file change.

## Follow-up (not opened as issues)

- E1 fires only with an opt-in mutation pass; with the default read-only run it is structurally silent. If a per-file survivor-density ratio is ever exposed by the mutation tier, E1's threshold could use it directly.
- E2 uses the high-precision same-commit signal and does not yet chase code+tests split across two commits, nor match on per-commit authorship (same-commit is the v1; measure miss rate before widening).
