### PR TITLE
feat: Add deterministic templated report renderer for /assess

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_report.py
+++ b/skills/assess/scripts/assess_report.py
@@ -1,0 +1,263 @@
+"""Deterministic report renderer for /assess.
+
+Reads ``.assess/run-context.json`` and renders a Markdown report from a stdlib
+``string.Template``. This is the *frozen harness*: it runs with zero model
+tokens and produces the same report for the same context, on every PR forever.
+
+It renders:
+- a metrics dashboard (complexity profile, churn window, total LOC),
+- the top-hotspots table,
+- the keyhole-readiness summary + the six cross-layer findings, and
+- the regression deltas (graduated / new / regressed / persistent).
+
+It deliberately does NOT reproduce (these require LLM judgement and are written
+elsewhere by the orchestrator, see SKILL.md):
+- the 0-8 layered readiness score,
+- the per-layer present/partial/missing prose, or
+- the Top 3 Actions priority narrative.
+
+The findings section, the keyhole summary, and the prescribed actions are
+already serialised into ``run-context.json`` by the deterministic core
+(``assess_core.build_run_context`` -> ``keyhole_signals``). This renderer
+*consumes* those products verbatim; it does not re-derive them.
+
+Run:
+    uv run assess_report.py <repo_root>            # writes .assess/deterministic-report.md
+    uv run assess_report.py <repo_root> --stdout   # prints the report to stdout
+"""
+# /// script
+# requires-python = ">=3.11"
+# ///
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from string import Template
+from typing import Any
+
+# Caps on rows rendered so a pathological repo can't bloat the frozen report.
+# The structured arrays in run-context.json keep the full lists.
+MAX_HOTSPOT_ROWS = 10
+MAX_DIFF_ROWS = 10
+
+# Diff categories rendered in order, with the gloss shown beside each count.
+DIFF_CATEGORIES = [
+    ("graduated", "Graduated", "left the hotspot list"),
+    ("new", "New", "entered the hotspot list"),
+    ("regressed", "Regressed", "complexity or churn increased"),
+    ("persistent", "Persistent", "still in the hotspot list"),
+]
+
+REPORT_TEMPLATE = Template("""# Deterministic Assessment Snapshot: $repo_name
+
+_Generated $run_date by `/assess` v$plugin_version.${commit_note}_
+
+## Metrics Dashboard
+
+- **Files scored:** $files_scored
+- **Total LOC:** $loc_total
+- **Complexity profile:** p95 LOC $loc_p95 (max $loc_max), p95 CCN $ccn_p95 (max $ccn_max)
+- **Churn window:** $churn_window
+
+### Top Hotspots
+
+$hotspots_table
+
+## Keyhole Readiness
+
+$keyhole_summary
+
+$findings_section
+
+## Changes Since Last Run
+
+$diff_section
+
+---
+
+_Deterministic portion of the assessment: metrics, hotspots, and cross-layer findings. The 0-8 layer scores, the per-layer prose, and the Top 3 Actions priority narrative require LLM judgement and are written separately._
+""")
+
+
+def _fmt(value: Any) -> str:
+    """Format a metric for display: ints as ints, whole floats without a
+    trailing ``.0``, fractional floats to one decimal, ``None`` as ``?``."""
+    if value is None:
+        return "?"
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else f"{value:.1f}"
+    return str(value)
+
+
+def render_hotspots_table(ctx: dict) -> str:
+    """Render the top hotspots as a Markdown table (capped at MAX_HOTSPOT_ROWS)."""
+    hotspots = ctx.get("stats_summary", {}).get("top_hotspots", [])
+    if not hotspots:
+        return "_No hotspots identified._"
+    lines = ["| Path | LOC | CCN | Commits |", "|------|-----|-----|---------|"]
+    for h in hotspots[:MAX_HOTSPOT_ROWS]:
+        lines.append(
+            f"| `{h.get('path', '?')}` | {_fmt(h.get('loc'))} | "
+            f"{_fmt(h.get('ccn'))} | {_fmt(h.get('commits'))} |"
+        )
+    return "\n".join(lines)
+
+
+def render_keyhole_summary(ctx: dict) -> str:
+    """Return the pre-built keyhole-readiness summary line (consumed verbatim)."""
+    summary = ctx.get("keyhole_summary") or {}
+    text = summary.get("summary_text")
+    return text if text else "_Keyhole readiness summary unavailable._"
+
+
+def render_findings_section(ctx: dict) -> str:
+    """Return the pre-rendered cross-layer findings section, verbatim.
+
+    The deterministic core already renders the six findings + attention list
+    into ``findings_markdown``; this renderer copies it so the section appears
+    whether or not an LLM is in the loop.
+    """
+    markdown = ctx.get("findings_markdown")
+    if not markdown or not markdown.strip():
+        return "_No cross-layer findings recorded._"
+    return markdown.strip()
+
+
+def _format_transition(category: str, entry: dict) -> str:
+    """Render one hotspot transition as a bullet, with deltas for regressions."""
+    path = entry.get("path", "?")
+    if category != "regressed":
+        return f"  - `{path}`"
+    bits = []
+    ccn_delta = entry.get("ccn_delta", 0)
+    loc_delta = entry.get("loc_delta", 0)
+    if ccn_delta:
+        bits.append(f"CCN {ccn_delta:+d}")
+    if loc_delta:
+        bits.append(f"LOC {loc_delta:+d}")
+    suffix = f" ({', '.join(bits)})" if bits else ""
+    return f"  - `{path}`{suffix}"
+
+
+def render_diff_section(ctx: dict) -> str:
+    """Render the regression deltas, honouring the first-run and reliability flags.
+
+    No prior snapshot -> say so. An unreliable diff (plugin-version mismatch in
+    the file filter) is suppressed with its note rather than shown, mirroring the
+    SKILL.md rule that phantom transitions must not read as real improvement.
+    """
+    if not ctx.get("prior_stats_exists"):
+        return "_No prior run to compare against - this is the first recorded snapshot._"
+    if not ctx.get("diff_reliable", True):
+        note = ctx.get("diff_version_note") or "prior and current snapshots are not comparable"
+        return f"_Diff suppressed: {note}._"
+
+    summary = ctx.get("diff", {})
+    detail = ctx.get("diff_detail", {})
+    lines: list[str] = []
+    for key, label, gloss in DIFF_CATEGORIES:
+        entries = detail.get(key, [])
+        count = summary.get(key, len(entries))
+        lines.append(f"- **{label}** ({gloss}): {count}")
+        for entry in entries[:MAX_DIFF_ROWS]:
+            lines.append(_format_transition(key, entry))
+        overflow = len(entries) - MAX_DIFF_ROWS
+        if overflow > 0:
+            lines.append(f"  - ...and {overflow} more")
+    return "\n".join(lines)
+
+
+def _render_commit_note(ctx: dict) -> str:
+    """Render the measured-commit provenance suffix for the generated-by line.
+
+    Pins the SHA the absolute LOC/CCN numbers were measured at and warns when
+    HEAD is dirty or behind upstream, so the figures aren't read as current
+    when they describe an uncommitted or stale tree. Returns a leading-space
+    string (it follows ``v<version>.``) or ``""`` when provenance is unknown.
+    """
+    commit = ctx.get("measured_commit") or {}
+    if not commit.get("available"):
+        return ""
+    short = commit.get("head_short") or str(commit.get("head_sha", ""))[:7]
+    note = f" Measured at `{short}`"
+    subject = commit.get("subject")
+    if subject:
+        note += f' ("{subject}")'
+    warnings = []
+    if commit.get("dirty"):
+        warnings.append("working tree dirty")
+    behind = commit.get("behind")
+    if isinstance(behind, int) and behind > 0:
+        warnings.append(f"{behind} commit(s) behind upstream")
+    if warnings:
+        note += f" - {', '.join(warnings)}"
+    return note + "."
+
+
+def _render_churn_window(ctx: dict) -> str:
+    """Surface the churn-window label the treemap/doc-staleness pass settled on."""
+    doc_staleness = ctx.get("doc_staleness") or {}
+    window = doc_staleness.get("churn_window")
+    return window if window else "unavailable"
+
+
+def render_report(ctx: dict, repo_name: str) -> str:
+    """Render the full deterministic Markdown report from a run-context dict.
+
+    Pure: takes the loaded context and the repo name, returns the report string.
+    ``Template.substitute`` is strict - a missing key raises, which surfaces a
+    template/data drift at the seam rather than silently emitting ``$placeholder``.
+    """
+    stats = ctx.get("stats_summary", {})
+    loc = stats.get("loc", {})
+    ccn = stats.get("ccn", {})
+    report = REPORT_TEMPLATE.substitute(
+        repo_name=repo_name,
+        run_date=ctx.get("run_date", "unknown"),
+        plugin_version=ctx.get("plugin_version", "unknown"),
+        commit_note=_render_commit_note(ctx),
+        files_scored=stats.get("files_scored", 0),
+        loc_total=_fmt(loc.get("total")),
+        loc_p95=_fmt(loc.get("p95")),
+        loc_max=_fmt(loc.get("max")),
+        ccn_p95=_fmt(ccn.get("p95")),
+        ccn_max=_fmt(ccn.get("max")),
+        churn_window=_render_churn_window(ctx),
+        hotspots_table=render_hotspots_table(ctx),
+        keyhole_summary=render_keyhole_summary(ctx),
+        findings_section=render_findings_section(ctx),
+        diff_section=render_diff_section(ctx),
+    )
+    return report.rstrip() + "\n"
+
+
+def load_context(repo_root: Path) -> dict:
+    """Load ``.assess/run-context.json`` from a repo root."""
+    ctx_path = repo_root / ".assess" / "run-context.json"
+    return json.loads(ctx_path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    to_stdout = "--stdout" in args
+    positional = [a for a in args if not a.startswith("-")]
+    if not positional:
+        print("Usage: assess_report.py <repo_root> [--stdout]", file=sys.stderr)
+        return 2
+    repo_root = Path(positional[0]).resolve()
+    ctx = load_context(repo_root)
+    report = render_report(ctx, repo_root.name)
+    if to_stdout:
+        sys.stdout.write(report)
+    else:
+        out_path = repo_root / ".assess" / "deterministic-report.md"
+        out_path.write_text(report, encoding="utf-8")
+        print(str(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/assess/tests/test_assess_report.py
+++ b/skills/assess/tests/test_assess_report.py
@@ -1,0 +1,356 @@
+"""Tests for the deterministic report renderer (assess_report.py).
+
+The renderer is the frozen harness: same context in, same Markdown out, no LLM.
+These tests pin its template substitution, the section renderers (hotspots,
+keyhole summary, findings, diff), the conditional fallbacks, and the honest
+boundary - it must NOT reproduce the LLM-only 0-8 score or Top 3 Actions.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assess_report import (
+    _fmt,
+    _render_commit_note,
+    load_context,
+    main,
+    render_diff_section,
+    render_findings_section,
+    render_hotspots_table,
+    render_keyhole_summary,
+    render_report,
+)
+
+
+def _full_ctx() -> dict:
+    """A realistic, non-normalised run-context with every section populated."""
+    return {
+        "run_date": "2026-06-01",
+        "plugin_version": "1.22.0",
+        "measured_commit": {
+            "available": True,
+            "head_short": "abc1234",
+            "head_sha": "abc1234def5678",
+            "subject": "feat: add the thing",
+            "dirty": False,
+            "behind": 0,
+        },
+        "prior_stats_exists": True,
+        "diff_reliable": True,
+        "diff_version_note": None,
+        "stats_summary": {
+            "files_scored": 58,
+            "loc": {"max": 761.0, "p50": 132.5, "p95": 483.65, "total": 10428},
+            "ccn": {"max": 169.0, "p50": 31.0, "p95": 107.35, "basis": "file-aggregate"},
+            "top_hotspots": [
+                {"path": "scripts/assess_core.py", "loc": 493, "ccn": 106.0, "commits": 14},
+                {"path": "lib/doc_graph.py", "loc": 514, "ccn": 169.0, "commits": 7},
+            ],
+        },
+        "diff": {"graduated": 1, "regressed": 1, "new": 1, "persistent": 1},
+        "diff_detail": {
+            "graduated": [{"path": "old/file.py", "ccn_delta": 0, "loc_delta": 0}],
+            "new": [{"path": "new/file.py", "ccn_delta": 0, "loc_delta": 0}],
+            "regressed": [{"path": "hot/file.py", "ccn_delta": 12, "loc_delta": 60}],
+            "persistent": [{"path": "stable/file.py", "ccn_delta": 0, "loc_delta": 0}],
+        },
+        "doc_staleness": {"churn_window": "commits (last 12mo)", "available": True},
+        "keyhole_summary": {
+            "concerns": [{"name": "hidden_coupling", "count": 5}],
+            "safe_zones": 1,
+            "total_concerns": 5,
+            "summary_text": "5 structural concerns (5 hidden coupling), 1 safe zone.",
+        },
+        "findings_markdown": (
+            "## Cross-Layer Findings (Keyhole Readiness)\n\n"
+            "### hidden_coupling\n\n"
+            "Action: investigate the seam\n\n"
+            "Paths:\n- scripts\n- scripts/tests\n"
+        ),
+        "prescribed_actions": [
+            {"path": "scripts", "action": "investigate the seam",
+             "findings": ["hidden_coupling"], "rank": 1},
+        ],
+    }
+
+
+def _minimal_ctx() -> dict:
+    """The thinnest valid context: first run, no hotspots, no findings."""
+    return {
+        "run_date": "2026-06-01",
+        "plugin_version": "1.22.0",
+        "prior_stats_exists": False,
+        "stats_summary": {"files_scored": 0, "loc": {}, "ccn": {}, "top_hotspots": []},
+    }
+
+
+# --------------------------------------------------------------------------
+# _fmt
+# --------------------------------------------------------------------------
+
+def test_fmt_none_is_question_mark() -> None:
+    assert _fmt(None) == "?"
+
+
+def test_fmt_whole_float_drops_decimal() -> None:
+    assert _fmt(493.0) == "493"
+
+
+def test_fmt_fractional_float_one_decimal() -> None:
+    out = _fmt(107.35)
+    assert out.startswith("107.")
+    assert len(out.split(".")[1]) == 1
+
+
+def test_fmt_int_passthrough() -> None:
+    assert _fmt(14) == "14"
+
+
+# --------------------------------------------------------------------------
+# Full render
+# --------------------------------------------------------------------------
+
+def test_full_render_has_all_sections() -> None:
+    report = render_report(_full_ctx(), "ai-native-toolkit")
+    assert "# Deterministic Assessment Snapshot: ai-native-toolkit" in report
+    assert "## Metrics Dashboard" in report
+    assert "### Top Hotspots" in report
+    assert "## Keyhole Readiness" in report
+    assert "## Changes Since Last Run" in report
+    # No unsubstituted placeholders leaked.
+    assert "$" not in report
+
+
+def test_full_render_metrics_values() -> None:
+    report = render_report(_full_ctx(), "demo")
+    assert "**Files scored:** 58" in report
+    assert "**Total LOC:** 10428" in report
+    assert "p95 LOC 483" in report
+    assert "max 761" in report
+    assert "p95 CCN 107" in report
+    assert "max 169" in report
+    assert "**Churn window:** commits (last 12mo)" in report
+
+
+def test_full_render_substitute_is_strict() -> None:
+    # render_report must not raise on a fully populated context.
+    render_report(_full_ctx(), "demo")
+
+
+def test_minimal_render_uses_fallbacks() -> None:
+    report = render_report(_minimal_ctx(), "tiny")
+    assert "_No hotspots identified._" in report
+    assert "_No cross-layer findings recorded._" in report
+    assert "_Keyhole readiness summary unavailable._" in report
+    assert "first recorded snapshot" in report
+    assert "$" not in report
+
+
+# --------------------------------------------------------------------------
+# Hotspots table
+# --------------------------------------------------------------------------
+
+def test_hotspots_table_empty_fallback() -> None:
+    assert render_hotspots_table({"stats_summary": {"top_hotspots": []}}) == \
+        "_No hotspots identified._"
+
+
+def test_hotspots_table_rows_and_header() -> None:
+    out = render_hotspots_table(_full_ctx())
+    assert "| Path | LOC | CCN | Commits |" in out
+    assert "| `scripts/assess_core.py` | 493 | 106 | 14 |" in out
+    assert "| `lib/doc_graph.py` | 514 | 169 | 7 |" in out
+
+
+def test_hotspots_table_missing_metric_renders_question_mark() -> None:
+    ctx = {"stats_summary": {"top_hotspots": [{"path": "x.py"}]}}
+    out = render_hotspots_table(ctx)
+    assert "| `x.py` | ? | ? | ? |" in out
+
+
+def test_hotspots_table_caps_at_ten_rows() -> None:
+    hotspots = [{"path": f"f{i}.py", "loc": 1, "ccn": 1, "commits": 1} for i in range(25)]
+    out = render_hotspots_table({"stats_summary": {"top_hotspots": hotspots}})
+    # 2 header lines + 10 data rows.
+    assert len(out.splitlines()) == 12
+    assert "f9.py" in out
+    assert "f10.py" not in out
+
+
+# --------------------------------------------------------------------------
+# Keyhole summary + findings
+# --------------------------------------------------------------------------
+
+def test_keyhole_summary_consumed_verbatim() -> None:
+    out = render_keyhole_summary(_full_ctx())
+    assert out == "5 structural concerns (5 hidden coupling), 1 safe zone."
+
+
+def test_keyhole_summary_missing_fallback() -> None:
+    assert render_keyhole_summary({}) == "_Keyhole readiness summary unavailable._"
+
+
+def test_findings_section_verbatim() -> None:
+    out = render_findings_section(_full_ctx())
+    assert out.startswith("## Cross-Layer Findings (Keyhole Readiness)")
+    assert "### hidden_coupling" in out
+    assert "Action: investigate the seam" in out
+
+
+def test_findings_section_empty_fallback() -> None:
+    assert render_findings_section({"findings_markdown": "   "}) == \
+        "_No cross-layer findings recorded._"
+    assert render_findings_section({}) == "_No cross-layer findings recorded._"
+
+
+# --------------------------------------------------------------------------
+# Diff section
+# --------------------------------------------------------------------------
+
+def test_diff_no_prior_run() -> None:
+    out = render_diff_section({"prior_stats_exists": False})
+    assert "No prior run to compare against" in out
+
+
+def test_diff_unreliable_is_suppressed_with_note() -> None:
+    ctx = {
+        "prior_stats_exists": True,
+        "diff_reliable": False,
+        "diff_version_note": "prior stats from plugin 1.10.0, current 1.22.0",
+    }
+    out = render_diff_section(ctx)
+    assert out.startswith("_Diff suppressed:")
+    assert "1.10.0" in out
+
+
+def test_diff_unreliable_without_note_falls_back() -> None:
+    out = render_diff_section({"prior_stats_exists": True, "diff_reliable": False})
+    assert "not comparable" in out
+
+
+def test_diff_reliable_renders_all_categories() -> None:
+    out = render_diff_section(_full_ctx())
+    assert "- **Graduated** (left the hotspot list): 1" in out
+    assert "- **New** (entered the hotspot list): 1" in out
+    assert "- **Regressed** (complexity or churn increased): 1" in out
+    assert "- **Persistent** (still in the hotspot list): 1" in out
+    assert "- `old/file.py`" in out
+    assert "- `new/file.py`" in out
+    assert "- `stable/file.py`" in out
+
+
+def test_diff_regressed_shows_deltas() -> None:
+    out = render_diff_section(_full_ctx())
+    assert "- `hot/file.py` (CCN +12, LOC +60)" in out
+
+
+def test_diff_regressed_without_deltas_omits_suffix() -> None:
+    ctx = {
+        "prior_stats_exists": True,
+        "diff_reliable": True,
+        "diff": {"regressed": 1},
+        "diff_detail": {"regressed": [{"path": "x.py", "ccn_delta": 0, "loc_delta": 0}]},
+    }
+    out = render_diff_section(ctx)
+    assert "- `x.py`" in out
+    assert "(CCN" not in out
+
+
+def test_diff_caps_rows_and_reports_overflow() -> None:
+    entries = [{"path": f"f{i}.py"} for i in range(13)]
+    ctx = {
+        "prior_stats_exists": True,
+        "diff_reliable": True,
+        "diff": {"persistent": 13},
+        "diff_detail": {"persistent": entries},
+    }
+    out = render_diff_section(ctx)
+    assert "...and 3 more" in out
+    assert "f9.py" in out
+    assert "f10.py" not in out
+
+
+# --------------------------------------------------------------------------
+# Commit note
+# --------------------------------------------------------------------------
+
+def test_commit_note_clean() -> None:
+    note = _render_commit_note(_full_ctx())
+    assert "Measured at `abc1234`" in note
+    assert '("feat: add the thing")' in note
+    assert "dirty" not in note
+    assert "behind" not in note
+
+
+def test_commit_note_dirty_and_behind() -> None:
+    ctx = {"measured_commit": {
+        "available": True, "head_short": "deadbee", "dirty": True, "behind": 3,
+    }}
+    note = _render_commit_note(ctx)
+    assert "working tree dirty" in note
+    assert "3 commit(s) behind upstream" in note
+
+
+def test_commit_note_unavailable_is_empty() -> None:
+    assert _render_commit_note({"measured_commit": {"available": False}}) == ""
+    assert _render_commit_note({}) == ""
+
+
+# --------------------------------------------------------------------------
+# Honest boundary: must NOT reproduce LLM-only content
+# --------------------------------------------------------------------------
+
+def test_report_omits_llm_only_artifacts() -> None:
+    report = render_report(_full_ctx(), "demo")
+    # The 0-8 layered score and the Top 3 Actions priority narrative are the
+    # LLM's job; the frozen report names the boundary, it does not fake them.
+    assert "## Top 3 Actions" not in report
+    assert "present/partial/missing" not in report
+    assert "/ 8" not in report
+    assert "require LLM judgement" in report
+
+
+# --------------------------------------------------------------------------
+# main() + IO
+# --------------------------------------------------------------------------
+
+def _seed_run_context(repo_root: Path, ctx: dict) -> None:
+    assess_dir = repo_root / ".assess"
+    assess_dir.mkdir(parents=True, exist_ok=True)
+    (assess_dir / "run-context.json").write_text(json.dumps(ctx), encoding="utf-8")
+
+
+def test_load_context_roundtrip(tmp_path: Path) -> None:
+    _seed_run_context(tmp_path, _full_ctx())
+    loaded = load_context(tmp_path)
+    assert loaded["run_date"] == "2026-06-01"
+
+
+def test_main_writes_report_file(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    _seed_run_context(tmp_path, _full_ctx())
+    rc = main([str(tmp_path)])
+    assert rc == 0
+    out_path = tmp_path / ".assess" / "deterministic-report.md"
+    assert out_path.exists()
+    report = out_path.read_text(encoding="utf-8")
+    assert "# Deterministic Assessment Snapshot:" in report
+    assert str(out_path) in capsys.readouterr().out
+
+
+def test_main_stdout_does_not_write_file(tmp_path: Path,
+                                         capsys: pytest.CaptureFixture) -> None:
+    _seed_run_context(tmp_path, _full_ctx())
+    rc = main([str(tmp_path), "--stdout"])
+    assert rc == 0
+    assert not (tmp_path / ".assess" / "deterministic-report.md").exists()
+    out = capsys.readouterr().out
+    assert "# Deterministic Assessment Snapshot:" in out
+
+
+def test_main_no_args_usage_error(capsys: pytest.CaptureFixture) -> None:
+    rc = main([])
+    assert rc == 2
+    assert "Usage:" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Part 2a of the assess-dogfooded effort: the deterministic templated report renderer. Adds `skills/assess/scripts/assess_report.py`, which reads `.assess/run-context.json` and renders a Markdown report from a stdlib `string.Template`. This is the frozen harness - same context in, same Markdown out, zero model tokens - that tasks 7 (CI freeze) and 8 (decomposition parity) build on.

## Changes Made

- `skills/assess/scripts/assess_report.py` - the renderer. Sections:
  - Metrics dashboard (files scored, total LOC, p95/max LOC and CCN, churn window)
  - Top hotspots table (path / LOC / CCN / commits, capped at 10 rows)
  - Keyhole-readiness summary + the six cross-layer findings
  - Regression deltas (graduated / new / regressed / persistent, with CCN/LOC deltas for regressions)
- `skills/assess/tests/test_assess_report.py` - 31 tests.
- `.claude-plugin/plugin.json` - version bump `1.21.0` -> `1.22.0`.

## Technical Details

- **Consume, don't recompute.** `findings_markdown` and `keyhole_summary` are already serialized into `run-context.json` by the wave-2 keyhole core (`assess_core.build_run_context` -> `keyhole_signals`). The renderer copies them verbatim rather than re-deriving findings.
- **Honest boundary.** It does NOT reproduce the 0-8 layered score, the per-layer present/partial/missing prose, or the Top 3 Actions priority narrative - those require LLM judgement and are written elsewhere (SKILL.md). The report names the boundary in a trailing disclaimer.
- **Strict substitution.** `Template.substitute` (not `safe_substitute`) so any template/data drift fails loudly rather than emitting a literal `$placeholder`.
- **Stdlib only.** `json`, `sys`, `pathlib`, `string.Template`, `typing`. No new dependency.
- **Clean interface for downstream tasks.** Input = repo root (`.assess/run-context.json`); output = `.assess/deterministic-report.md`, or `--stdout` to print. `render_report(ctx, repo_name)` is a pure function for direct reuse.
- **Graceful fallbacks.** Empty hotspots/findings, first run (no prior), and an unreliable diff (plugin-version filter mismatch) each render an explicit caveat instead of a broken section. Row caps prevent a pathological repo from bloating the report.

## Testing

- New suite: 31 tests, all passing - template substitution, every section renderer, conditional fallbacks, row caps, commit provenance (clean/dirty/behind/unavailable), the LLM-only boundary, and `main()` IO (file write, `--stdout`, usage error).
- Full `skills/assess` suite: 446 passed.
- `scripts/` suite: 69 passed. Plugin contract suite: 61 passed.
- `ruff check .` clean; `mypy` clean.
- Run locally with `GIT_CONFIG_GLOBAL=/dev/null` to clear the phantom git-config failures.

## Risk Assessment

Low. Net-new script and test file plus a version bump; no existing module is modified, so the deterministic core and golden baselines are untouched.

## Follow-ups (not in this PR)

- Task 7 wires this renderer into the CI freeze / regression gate.
- Task 8 uses it behind the decomposition parity test.

Task Master: assess-dogfooded #6.
