### PR TITLE
fix: Publish per-version standalone-skills release for immutable releases

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/workflows/build-standalone-skills.yml
+++ b/.github/workflows/build-standalone-skills.yml
@@ -45,17 +45,29 @@ jobs:
         if: steps.version-check.outputs.build == 'true' || github.event_name == 'workflow_dispatch'
         run: bash scripts/build-standalone-skills.sh
 
-      - name: Publish to standalone-skills-latest release
+      - name: Publish per-version standalone-skills release
         if: steps.version-check.outputs.build == 'true' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          TAG="standalone-skills-v${VERSION}"
 
-          gh release delete standalone-skills-latest --yes 2>/dev/null || true
-          gh release create standalone-skills-latest \
-            --title "Standalone skill ZIPs — latest (v${VERSION})" \
-            --notes "Standalone skill ZIPs for Claude Desktop and claude.ai. Install via Settings → Customize → Skills → Upload Skill. Rebuilt automatically on every plugin version bump." \
+          # GitHub immutable releases permanently reserve a tag once it has backed a
+          # release, so the old rolling "delete standalone-skills-latest then recreate
+          # it" pattern can never succeed again (HTTP 422: tag_name was used by an
+          # immutable release). Publish a unique immutable release per version instead:
+          # one create call carrying all assets, no delete, no post-hoc asset edits
+          # (both forbidden under immutability). Idempotent on re-run: if the release
+          # already exists it is immutable, so skip rather than try to overwrite.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists (immutable) — nothing to publish."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "Standalone skill ZIPs — v${VERSION}" \
+            --notes "Standalone skill ZIPs for Claude Desktop and claude.ai, built from plugin v${VERSION}. Install via Settings → Customize → Skills → Upload Skill. A new release is published on every plugin version bump; find the newest at https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills" \
             --latest=false \
             dist/standalone-skills/*.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ bash scripts/build-standalone-skills.sh --dest ~/Desktop  # custom output dir
 - `scripts/tests/test_integration.py` - full-build ZIP content validation (forbidden strings, expected files)
 - Run: `cd scripts && uv run --with pytest pytest -v`
 
-**CI:** `.github/workflows/build-standalone-skills.yml` triggers on `plugin.json` version bumps and publishes to the `standalone-skills-latest` rolling release. `.github/workflows/tests.yml` now runs both the `skills/assess/` suite and the `scripts/` suite on every PR and push.
+**CI:** `.github/workflows/build-standalone-skills.yml` triggers on `plugin.json` version bumps and publishes a per-version immutable release tagged `standalone-skills-v<version>` (one create call, no delete - GitHub immutable releases permanently reserve a tag once it has backed a release, so the old rolling `standalone-skills-latest` delete-and-recreate pattern can never succeed again). The newest is always at `releases?q=standalone-skills`. `.github/workflows/tests.yml` now runs both the `skills/assess/` suite and the `scripts/` suite on every PR and push.
 
 **Marker rules:**
 - `<!-- chat-skip:start/end -->` - wraps content to remove entirely (plugin path resolution, `$ARGUMENTS`, agent-orchestration infrastructure, namespaced slash commands)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The ZIPs are rebuilt automatically from the same source on every plugin version 
 
 ### Install (claude.ai web - verified path)
 
-1. Download `assess.zip`, `huddle.zip`, and `deslop.zip` from the [standalone-skills-latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/tag/standalone-skills-latest).
+1. Download `assess.zip`, `huddle.zip`, and `deslop.zip` from the [newest standalone-skills release](https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills&expanded=true) (a fresh `standalone-skills-vX.Y.Z` release is published on every plugin version bump; pick the one at the top).
 2. Open https://claude.ai/customize/skills (or sidebar → Customize → Skills).
 3. Click the **+** at the top right of the Skills column.
 4. Hover **Create skill →** then click **Upload a skill**.
@@ -136,7 +136,7 @@ Claude Desktop has the same Skills uploader under Settings; the flow is analogou
 
 The Skills UI has a built-in **Replace** option - use it instead of uninstalling and re-uploading (Replace preserves any in-progress chats that reference the skill).
 
-1. Download the new `assess.zip` / `huddle.zip` / `deslop.zip` from [standalone-skills-latest](https://github.com/bjcoombs/ai-native-toolkit/releases/tag/standalone-skills-latest).
+1. Download the new `assess.zip` / `huddle.zip` / `deslop.zip` from the [newest standalone-skills release](https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills&expanded=true) (the top `standalone-skills-vX.Y.Z` entry).
 2. In Customize → Skills, click the skill you want to upgrade.
 3. Open the three-dot menu (⋮) in the top right of the detail pane.
 4. Click **Replace** and select the new `.zip`.


### PR DESCRIPTION
## Summary

The `Build and publish standalone skill ZIPs` workflow has failed on every push to `main` since immutability took effect (last success was the final pre-immutability run). The ZIPs build fine; the **publish** step fails with:

```
HTTP 422: tag_name was used by an immutable release
```

## Root cause

GitHub **immutable releases** are now enabled on this repo (`v1.23.0` reports `isImmutable: true`). Once a tag has backed an immutable release, GitHub **permanently reserves that `tag_name`** — even after the release is deleted. The workflow's rolling pattern (`gh release delete standalone-skills-latest` then `gh release create standalone-skills-latest`) can therefore never succeed again: the tag is reserved for good.

## Fix

Publish a **unique immutable release per version** instead:

- Tag `standalone-skills-v<version>`, a single `gh release create` call carrying all ZIPs.
- **No delete, no post-hoc asset edits** — both are forbidden under immutability.
- Idempotent: if the release already exists (immutable), skip rather than overwrite.

Because there's no longer one rolling tag, the README install links and `CLAUDE.md` now point at the filtered releases listing [`releases?q=standalone-skills`](https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills&expanded=true), which always surfaces the newest standalone release at the top.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses.
- `bash scripts/build-standalone-skills.sh` — builds all 3 ZIPs locally.
- The merge of this PR bumps `plugin.json` 1.23.1 → 1.23.2, which will trigger the workflow and create `standalone-skills-v1.23.2` — the first run of the new scheme, proving the fix end to end.

## Notes

- The orphaned `standalone-skills-latest` git tag (now backing no release) can be deleted manually at your convenience: `git push --delete origin standalone-skills-latest`. Not required for this fix.

---

_Diagnosed and fixed after `/assess` dogfooding surfaced the red build on main._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.23.2

* **Documentation**
  * Updated standalone skill ZIP installation instructions to reference versioned releases
  * Updated CI documentation for new release tagging approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->