### PR TITLE
docs: document assess co-change seams (lib + tests)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -1,0 +1,175 @@
+# skills/assess/scripts/lib
+
+Deterministic library modules for the `/assess` engine. No LLM calls anywhere in this
+package - every function is a pure transform of filesystem, git, or pre-computed signal
+data. The LLM reads `run-context.json` after the core finishes; it does not call into
+these modules.
+
+## The assess_core.py -> lib seam
+
+`assess_core.py` is the orchestrator. It imports from almost every module here, calls
+each one in sequence, and assembles the results into `run-context.json`. When the
+orchestrator grows a new signal, reorganizes the context schema, or changes what data
+blocks it needs, the lib modules that supply that data move in the same commit. This
+is cohesion by design: the lib modules exist to serve the orchestrator's data contract,
+so their shape is coupled to it by construction.
+
+Two modules are the identified co-change hotspots in the git history:
+
+- **`doc_graph.py`** - the foundation for Layer 0 navigability. Both `doc_staleness.py`
+  and the understanding analysis in `keyhole_signals.py` depend on its doc->code
+  association edges. When the core adds a navigability signal or changes how it
+  represents doc reachability, `doc_graph.py` is the first file that moves.
+
+- **`keyhole_signals.py`** - the integration barrier between the individual signal
+  modules and the orchestrator. It assembles all five run-context blocks
+  (`behaviour`, `documentation`, `understanding`, `runtime`, `structure`) and emits
+  the six named derived findings. Because it touches every upstream signal, it
+  co-changes with the core on almost every schema or signal-set change.
+
+Seeing these two files in the same commit as `assess_core.py` is expected, not a
+defect. If the core is later decomposed, treat this seam as the natural boundary -
+`doc_graph` and `keyhole_signals` are where the cut-line already lives.
+
+---
+
+## Module reference
+
+### Data collection
+
+**`git_churn.py`**
+Shared git-churn machinery: per-file commit counts over a configurable window, plus
+`git_commit_info` for snapshotting the exact SHA and timestamp at run time. Used by the
+code heatmap, the doc-staleness heatmap, and `doc_staleness.py` - churn is computed
+one way, not three. Pure subprocess + stdlib, no heavy dependencies.
+
+**`change_coupling.py`**
+Three signals derived from `git log`:
+- B1 change-coupling pairs: file pairs that co-change across commits (hidden edges
+  the import graph cannot see).
+- B2 containment ratio: fraction of commits to a module that touch only that module
+  (high = an island safe for keyhole edits).
+- B4 authorship: human/agent/mixed/unknown classification, e-mail-based and
+  deliberately conservative (never labels a human's work "agent" on weak evidence).
+
+All results are JSON-serialisable so `assess_core` can drop them straight into
+`run-context.json`.
+
+### Static analysis
+
+**`structure_graph.py`**
+Python import-graph analysis (Signals A1-A4) via `grimp` + `networkx`:
+- A1 comprehension footprint: direct-dependency surface area for a unit.
+- A2 blob vs modular: strongly-connected components and Newman modularity Q.
+- A3 contracts: front-door vs burrow (internals-reaching) inbound edges.
+- A4 breakup candidates: packages whose sub-modules form separable clusters.
+
+Degrades to `available: False` when `grimp`/`networkx` are absent rather than
+blocking the run.
+
+### Document analysis
+
+**`doc_graph.py`** *(co-change hotspot)*
+Doc link-graph for Layer 0 navigability. Parses `[[wikilinks]]` and
+`[text](relative/path)` links, resolves them to real files, and builds a directed
+graph. Derives PageRank centrality, orphan rate, connectivity, MOC validation, and
+doc->code association edges. The doc->code edges are reused by `doc_staleness.py` and
+`understanding_analysis.py`, making this module a shared dependency for the document
+analysis layer.
+
+**`doc_staleness.py`**
+Doc-staleness metric for Layer 0. Associates each doc with the code it describes via
+nearest-ancestor base-doc rules, computes code churn relative to doc maintenance, and
+emits a signed ratio (high = decaying map). The association logic reuses `doc_graph`'s
+code-link edges.
+
+**`doc_complexity_join.py`**
+Signal C: crosses the complexity treemap against doc staleness to produce a signed
+`doc_value` per unit. Positive = the doc relieves load on the agent's context window;
+negative = the doc is a lying map over complex code (worse than no doc). The join
+multiplies complexity by a signed freshness score so trivial code generates near-zero
+signal regardless of doc state.
+
+### Signal integration
+
+**`keyhole_signals.py`** *(co-change hotspot)*
+Integration barrier between the individual signal modules and `assess_core`. Derives
+the per-directory containment view from the commit-file sets the orchestrator parses
+once and passes in, then assembles all five run-context blocks from the upstream signal
+outputs. Emits the six named derived findings (hidden coupling, bleeding module,
+refactor boundary, orphaned understanding, lying map, etc.) as a structured array.
+Each block build is wrapped in a catch-all so one signal's failure degrades that block
+to `available: False` rather than crashing the run.
+
+**`coupling_analysis.py`**
+B3 static-vs-historical disagreement cross: compares the import-graph view
+(`structure_graph`) against the commit-history view (`change_coupling`) to surface
+hidden coupling (looks modular, bleeds historically), bleeding modules (no static graph
+available), and refactor boundaries (high containment + low external coupling, a safe
+zone for keyhole edits). Looks-coupled-but-never-co-changes is suppressed - the static
+graph already surfaces it.
+
+**`understanding_analysis.py`**
+Signals B4 + D2. Per module: human anchor (has a confirmed human authored it?), intent
+source (is there an externalised spec/doc?), authorship class, and the velocity clock
+(days since the last comprehension event - a human-authored commit - rather than
+calendar age). Primary finding: orphaned understanding - high complexity with no human
+anchor and no externalised spec. Reuses `change_coupling.authorship_analysis` so the
+conservative agent/human classification is defined one way.
+
+### Configuration
+
+**`assess_config.py`**
+Reads the optional per-repo `.assess/config.toml` for `exclude_dirs` and
+`exclude_patterns`. The same two lists feed every scan (heatmap, doc graph, staleness,
+liveness) - consistency is the point. Degrades silently on missing or malformed config
+rather than blocking the run.
+
+### Output and formatting
+
+**`wiki_writer.py`**
+Renders and writes the `.assess/` wiki files (`index.md`, `log.md`,
+`hotspots/*.md`) from string templates. No LLM calls. Pure string formatting + file IO.
+
+**`treemap_render.py`**
+Shared treemap layout and SVG primitives for the code heatmap and the doc-staleness
+heatmap. Pulls `matplotlib`, `squarify`, and `numpy`. Must not be imported by the
+deterministic core (which runs with `networkx` alone) - only by the treemap scripts.
+
+**`ci_workflow.py`**
+Renders the frozen-harness GitHub Action from `templates/assess-gate.yml.template`
+using `string.Template`. Bakes in the toolchain discovered during the current run so
+the workflow is a reproducible contract, not a norm.
+
+**`stats_diff.py`**
+Compares current complexity stats against a prior run and classifies hotspot
+transitions: graduated (was in top list, now absent), regressed (worsened), new, and
+persistent. Pure set operations + arithmetic, no LLM.
+
+### Scoring
+
+**`agent_instructions_grader.py`**
+Heuristic scoring of agent instruction files (CLAUDE.md, AGENTS.md, GEMINI.md,
+.cursorrules, .github/copilot-instructions.md) on signals that correlate with LLM
+usefulness: positive directives, tradeoff phrases, path references, verifiable
+outcomes, and freshness. Pure regex + arithmetic, filename-agnostic.
+
+**`liveness_scan.py`**
+Layer 1 liveness inputs, two tiers:
+- Dead-code tier: runs a language-appropriate static dead-code tool (vulture, ts-prune,
+  staticcheck, etc.) to flag candidate-dead exports within the repo boundary.
+- Observability tier: scores three rungs - instrumented (telemetry emitted), discoverable
+  (runbook present), reachable (agent has an invokable path to runtime state). The
+  reachability rung decides the Layer 1 score.
+
+**`anomaly_detector.py`**
+Inspects a run-context dict for suspicious results (e.g. zero files scored, implausible
+CCN) and returns typed `Anomaly` records. Detail strings are sanitised (counts and
+grades only, no paths or code) so they are safe to include in self-feedback issues.
+
+**`test_pressure/`**
+Layer 1 write-side truth pressure. Two tiers:
+- Mutation tier: runs a mutation-testing tool (mutmut for Python) over a sample of the
+  codebase to measure whether the test suite actually catches changes.
+- Cheap heuristics: test/source ratio, assertion density, and the coverage gap signal -
+  fast proxies that run without a mutation tool.

--- a/skills/assess/tests/README.md
+++ b/skills/assess/tests/README.md
@@ -1,0 +1,75 @@
+# skills/assess/tests
+
+Test suites for the `/assess` deterministic engine. Tests live here, co-located with
+the scripts they pin. When a source module changes, its test file is expected to change
+in the same commit - this is intentional co-change, not accidental coupling.
+
+## Test/source co-change seam
+
+The suites below are expected to move with the engine. A reviewer seeing
+`test_doc_graph.py` and `lib/doc_graph.py` in the same diff is looking at the normal
+edit cycle, not a layering violation. Keep tests co-located.
+
+The two highest-frequency co-change pairs in the git history are:
+
+- **`test_assess_core.py` / `assess_core.py`** - the orchestrator and its end-to-end
+  harness. Every time the core adds a signal or changes the `run-context.json` schema,
+  both files move.
+- **`test_doc_graph.py` / `lib/doc_graph.py`** - the navigability graph is the
+  foundation for Layer 0 and feeds both the staleness and the understanding analysis,
+  so its contract tests are touched on most doc-analysis changes.
+
+---
+
+## Suite / source mapping
+
+### Orchestrator suites
+
+| Suite | Pins |
+|---|---|
+| `test_assess_core.py` | `scripts/assess_core.py` - end-to-end orchestrator; drives `build_run_context` without running lizard/scc |
+| `test_assess_finalize.py` | `scripts/assess_finalize.py` - LLM write-back; placeholder substitution in `log.md` and `hotspots/*.md` |
+| `test_assess_gate.py` | `scripts/assess_gate.py` - CI regression gate; complexity and containment threshold checks and exit codes |
+| `test_assess_report.py` | `scripts/assess_report.py` - deterministic report renderer; template substitution, section renderers, conditional fallbacks |
+| `test_emit_workflow.py` | `scripts/assess_emit_workflow.py` - CLI wrapper for the frozen-harness workflow emitter; default derivation and arg parsing |
+| `test_decomposition_parity.py` | `scripts/assess_core.py` + `scripts/assess_report.py` - parity harness; guards that the deterministic pipeline produces byte-for-byte identical output after the Part 3 SKILL.md decomposition |
+| `test_complexity_treemap.py` | `scripts/complexity-treemap.py` - build-artifact filter, plugin version stamp, and stats-sidecar enrichment (heavy deps are stubbed) |
+
+### lib/ suites
+
+| Suite | Pins |
+|---|---|
+| `test_doc_graph.py` | `lib/doc_graph.py` - doc link-graph, link parsing, orphan detection, connectivity, MOC validation, doc->code edges |
+| `test_keyhole_signals.py` | `lib/keyhole_signals.py` - integration barrier; derivation of the five run-context blocks and the six named derived findings from mocked upstream signal outputs |
+| `test_change_coupling.py` | `lib/change_coupling.py` - B1 change-coupling pairs, B2 containment ratio, B4 authorship; synthetic git histories built in tmp dirs |
+| `test_coupling_analysis.py` | `lib/coupling_analysis.py` - B3 static-vs-historical disagreement; hidden-coupling, bleeding-module, and refactor-boundary classification with mocked inputs |
+| `test_doc_complexity_join.py` | `lib/doc_complexity_join.py` - Signal C: doc_value formula, slop-doc guard, threshold behaviour; mocked complexity-stats and staleness inputs |
+| `test_doc_staleness.py` | `lib/doc_staleness.py` - doc->code association (base-doc, parallel docs/, code links, repo-wide fallback) and churn-relative staleness ratios |
+| `test_structure_graph.py` | `lib/structure_graph.py` - A1 footprint additivity, A2 SCCs and Q range, A3 front-door vs burrow, A4 cut-lines, graceful degradation |
+| `test_understanding_analysis.py` | `lib/understanding_analysis.py` - B4 human anchor + intent source, velocity clock (D2), orphaned-understanding classification; both pure-logic (mocked) and git-integration variants |
+| `test_liveness_scan.py` | `lib/liveness_scan.py` - dead-code tool output parsers, observability rungs, graceful degradation when tools are absent |
+| `test_test_pressure.py` | `lib/test_pressure/` - mutation tier output parsing, cheap heuristics (test/source ratio, assertion density, gap signal) |
+| `test_ci_workflow.py` | `lib/ci_workflow.py` - template substitution (version, branch, tool steps), literal-dollar escaping, YAML well-formedness |
+| `test_stats_diff.py` | `lib/stats_diff.py` - hotspot transition classification (graduated, regressed, new, persistent) and sidecar loading |
+| `test_wiki_writer.py` | `lib/wiki_writer.py` - wiki file rendering (index, log, hotspot pages) and HotspotEntry / LogEntry dataclass behaviour |
+| `test_git_commit_info.py` | `lib/git_churn.py` (`git_commit_info`) - commit snapshot with SHA/timestamp for staleness warnings |
+| `test_instruction_bloat.py` | `lib/agent_instructions_grader.py` - bloat penalty, skills-delegation credit, conservative thresholds |
+
+### Infrastructure suites
+
+| Suite | Pins |
+|---|---|
+| `test_smoke.py` | `lib/__init__.py` - confirms the lib package is importable and `__version__` is set |
+| `test_golden_baseline.py` | `tests/golden.py` + dogfood fixtures - guards the regression baseline scaffolding (fixture completeness, normalization idempotency, loader correctness) used by `test_decomposition_parity.py` |
+
+---
+
+## Running the suite
+
+```bash
+# From skills/assess/ - avoids ~7 phantom git-commit failures from global git config
+GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/ -v
+```
+
+The phantom failures are a local-only artifact of global git commit-template or hook
+configuration. They do not appear in CI.


### PR DESCRIPTION
## Summary

- Add `skills/assess/scripts/lib/README.md` describing each lib module's responsibility and the `assess_core.py` -> `lib` coupling seam. Names `doc_graph.py` and `keyhole_signals.py` as the identified co-change hotspots and explains why their movement with the core is expected.
- Add `skills/assess/tests/README.md` mapping each test suite to the source file(s) it pins, recording the test<->source co-change seam so reviewers know the suites are expected to move with the engine.
- Bump plugin version to 1.24.0.

Both docs address the `/assess` `hidden_coupling` finding: the coupling is real and by design; the right response is to own it with documentation rather than treat it as a defect.

Closes #110
Closes #111