### PR TITLE
fix: credit Maven/Gradle/JVM idioms in instruction-grader verifiable_outcomes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/agent_instructions_grader.py
+++ b/skills/assess/scripts/lib/agent_instructions_grader.py
@@ -57,9 +57,12 @@ VERIFIABLE_PATTERNS = [
     # that merely mentions Maven or Gradle is not credited.
     r"\bmvn\s+(?:-\S+\s+)*(?:clean\s+)?(?:test|verify|install|integration-test)\b",  # mvn test / verify
     r"-Dtest=\S",                                                                     # mvn test -Dtest=Class#method
-    r"\b\.?/?gradlew?\s+(?:-\S+\s+)*(?:test|build|check|clean|assemble)\b",           # gradle / ./gradlew test|build|check
+    r"(?:^|\s)\.?/?gradlew?\s+(?:-\S+\s+)*(?:test|build|check|clean|assemble)\b",     # gradle / ./gradlew test|build|check
     r"--tests\s+\S",                                                                  # gradle test --tests Foo
-    r"\brg\s+(?:-{1,2}[\w-]+\s+)*['\"]?\S",                                           # ripgrep verification recipes
+    # ripgrep verification recipes - require a flag or a quoted query so that
+    # bare prose mentions ("use rg to find things", "rg or grep") are not
+    # credited, only an actual runnable search command.
+    r"\brg\s+(?:(?:-{1,2}[\w-]+\s+)+\S|(?:-{1,2}[\w-]+\s+)*['\"]\S)",
 ]
 
 # Size/bloat metrics with CONSERVATIVE thresholds.

--- a/skills/assess/scripts/lib/agent_instructions_grader.py
+++ b/skills/assess/scripts/lib/agent_instructions_grader.py
@@ -7,7 +7,8 @@ correlate with usefulness to an LLM contributor:
     positive_directives: "Use X", "Prefer Y", "Default to Z" (positive framing)
     tradeoff_phrases:    "because", "over X", "instead of", "rather than"
     path_references:     file paths like src/foo/bar.py, tests/..., etc.
-    verifiable_outcomes: "Working if", "verify:", "success criteria"
+    verifiable_outcomes: "Working if", "verify:", "success criteria", or a
+                         runnable verification command (mvn/gradle/rg)
     freshness:           days since last git modification
 
 No LLM calls. Pure regex + arithmetic. Deterministic.
@@ -43,10 +44,22 @@ PATH_PATTERN = re.compile(
 )
 
 VERIFIABLE_PATTERNS = [
+    # Phrase-based outcomes (JS/Python/general prose idioms).
     r"\bworking if\b",
     r"\bverify:\b",
     r"\bsuccess criteria\b",
     r"\bacceptance criteria\b",
+    # Runnable verification commands (issue #116). A CLAUDE.md that hands the
+    # agent an exact command to confirm an outcome is just as "verifiable" as
+    # one that spells out "success criteria" in prose - the original idiom set
+    # only credited JS/Python phrasing and scored Maven/Gradle/JVM files zero.
+    # Kept high-precision (a tool name plus a real subcommand/flag) so prose
+    # that merely mentions Maven or Gradle is not credited.
+    r"\bmvn\s+(?:-\S+\s+)*(?:clean\s+)?(?:test|verify|install|integration-test)\b",  # mvn test / verify
+    r"-Dtest=\S",                                                                     # mvn test -Dtest=Class#method
+    r"\b\.?/?gradlew?\s+(?:-\S+\s+)*(?:test|build|check|clean|assemble)\b",           # gradle / ./gradlew test|build|check
+    r"--tests\s+\S",                                                                  # gradle test --tests Foo
+    r"\brg\s+(?:-{1,2}[\w-]+\s+)*['\"]?\S",                                           # ripgrep verification recipes
 ]
 
 # Size/bloat metrics with CONSERVATIVE thresholds.

--- a/skills/assess/tests/test_agent_instructions_grader.py
+++ b/skills/assess/tests/test_agent_instructions_grader.py
@@ -115,6 +115,23 @@ def test_jvm_patterns_do_not_false_match_prose() -> None:
     assert count_verifiable_outcomes(prose) == 0
 
 
+def test_rg_prose_mention_is_not_credited() -> None:
+    # A bare reference to ripgrep without a runnable recipe (no flag, no
+    # quoted query) must not count as a verifiable outcome.
+    prose = (
+        "# Guidelines\n\n"
+        "You can use rg to find things, and rg or grep are both useful. "
+        "The rg tool is fast.\n"
+    )
+    assert count_verifiable_outcomes(prose) == 0
+
+
+def test_rg_recipe_with_flag_is_credited() -> None:
+    # A real ripgrep recipe (flag-driven, unquoted query) is verifiable.
+    text = "# Guidelines\n\nCheck for leftovers: `rg -n TODO src/main/java`.\n"
+    assert count_verifiable_outcomes(text) >= 1
+
+
 def test_grade_returns_letter_grade(good_text: str, bad_text: str) -> None:
     good = grade_instructions(good_text, freshness_days=10)
     bad = grade_instructions(bad_text, freshness_days=10)

--- a/skills/assess/tests/test_agent_instructions_grader.py
+++ b/skills/assess/tests/test_agent_instructions_grader.py
@@ -58,6 +58,63 @@ def test_verifiable_outcomes_only_in_good(good_text: str, bad_text: str) -> None
     assert count_verifiable_outcomes(bad_text) == 0
 
 
+# --- JVM / build-tool verifiable outcomes (issue #116) --------------------
+# The detector was calibrated for JS/Python phrasing and credited zero
+# verifiable outcomes to Maven/Gradle CLAUDE.md files that contain runnable
+# verification (mvn/gradle/gradlew test, -Dtest=, rg recipes). Recognise
+# those idioms while keeping JS/Python phrase recognition intact.
+
+MAVEN_INSTRUCTIONS = """# Project Guidelines
+
+## Verifying a change
+
+- Run the focused test: `mvn test -Dtest=PaymentServiceTest#refundsAreIdempotent`.
+- Run the full verification gate before opening a PR: `mvn verify`.
+- Confirm no stray TODOs slipped in: `rg "TODO" src/main/java`.
+"""
+
+GRADLE_INSTRUCTIONS = """# Project Guidelines
+
+## Verifying a change
+
+- Run the focused test: `./gradlew test --tests com.example.PaymentServiceTest`.
+- Build and check everything: `./gradlew build check`.
+- Confirm logging uses the wrapper: `rg "System.out" src`.
+"""
+
+
+def test_maven_instructions_score_nonzero_verifiable_outcomes() -> None:
+    # Success criterion for issue #116: a Maven CLAUDE.md with runnable
+    # mvn/rg verification must score a NON-ZERO verifiable_outcomes.
+    assert count_verifiable_outcomes(MAVEN_INSTRUCTIONS) >= 1
+    grade = grade_instructions(MAVEN_INSTRUCTIONS, freshness_days=10)
+    assert grade.subscores["verifiable_outcomes"] >= 1
+
+
+def test_gradle_instructions_score_nonzero_verifiable_outcomes() -> None:
+    assert count_verifiable_outcomes(GRADLE_INSTRUCTIONS) >= 1
+    grade = grade_instructions(GRADLE_INSTRUCTIONS, freshness_days=10)
+    assert grade.subscores["verifiable_outcomes"] >= 1
+
+
+def test_jvm_idioms_do_not_regress_js_python_recognition(good_text: str, bad_text: str) -> None:
+    # Existing phrase-based recognition stays intact: the good JS/Python
+    # fixture still credits a verifiable outcome, the bad one still none.
+    assert count_verifiable_outcomes(good_text) >= 1
+    assert count_verifiable_outcomes(bad_text) == 0
+
+
+def test_jvm_patterns_do_not_false_match_prose() -> None:
+    # High precision: prose that merely mentions Maven/Gradle without a
+    # runnable command must not be credited as a verifiable outcome.
+    prose = (
+        "# Guidelines\n\n"
+        "This is a Maven project that uses Gradle elsewhere. "
+        "We care about testing and verifying our work generally.\n"
+    )
+    assert count_verifiable_outcomes(prose) == 0
+
+
 def test_grade_returns_letter_grade(good_text: str, bad_text: str) -> None:
     good = grade_instructions(good_text, freshness_days=10)
     bad = grade_instructions(bad_text, freshness_days=10)


### PR DESCRIPTION
## Summary

The instruction-grader's `verifiable_outcomes` signal recognised only JS/Python prose idioms (`working if`, `verify:`, `success criteria`, `acceptance criteria`). On the first Java/JVM `/assess` run, an A-grade (80) Maven `CLAUDE.md` scored `verifiable_outcomes: 0` despite containing runnable verification - `mvn test -Dtest=Class#method`, `mvn verify`, and `rg` recipes.

## Changes Made

- Extended `VERIFIABLE_PATTERNS` in `skills/assess/scripts/lib/agent_instructions_grader.py` with high-precision Maven/Gradle/JVM command idioms:
  - `mvn test|verify|install|integration-test` (with optional `clean`/flags)
  - `-Dtest=` (focused Maven test selector)
  - `gradle`/`./gradlew test|build|check|clean|assemble`
  - `--tests` (Gradle test filter)
  - `rg` verification recipes
- Patterns require a tool name plus a real subcommand/flag, so prose that merely mentions Maven or Gradle is not credited.
- Updated the module docstring to reflect the broadened signal.

## Technical Details

This is the only source file changed. `assess_core.py`, `complexity-treemap.py`, and capability/liveness code are untouched.

## Testing

- New TDD tests in `tests/test_agent_instructions_grader.py`:
  - Maven `CLAUDE.md` scores non-zero `verifiable_outcomes` (the issue's success criterion)
  - Gradle `CLAUDE.md` scores non-zero `verifiable_outcomes`
  - JS/Python recognition does not regress (good fixture still credited, bad fixture still zero)
  - Prose mentioning Maven/Gradle without a runnable command is not credited (precision guard)
- Full `skills/assess` suite: 508 passed, 1 skipped (golden baseline unchanged).
- `ruff` + `mypy` gates pass.

## Risk Assessment

Low. Additive regex patterns to one deterministic module; existing behaviour preserved and regression-tested. No golden-output changes.

Closes #116

**Version bump note:** title is `fix:` but the bump is MINOR (1.23.2 -> 1.24.0). Intentional - Maven/Gradle CLAUDE.md scores on the `verifiable_outcomes` signal shift materially (0 -> up to 15 pts), so PATCH would understate user-visible impact per the CLAUDE.md versioning table.