### PR TITLE
fix: rank hotspots by per-function CCN for class-per-file languages

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -491,6 +491,36 @@ def _read_plugin_version() -> str:
         return "unknown"
 
 
+# Weight of the per-function worst case in the hotspot composite. The effective
+# complexity is a weighted geometric mean of the file aggregate and the file's
+# worst single function, leaning toward the per-function offender (issue #115).
+PER_FUNCTION_WEIGHT = 0.7
+
+
+def _effective_ccn(ccn: float, max_fn_ccn: float | None) -> float:
+    """Complexity used to rank hotspots, re-weighted toward the worst function.
+
+    The treemap hue and the ``ccn`` field stay file-aggregate, but the hotspot
+    composite ranks on this value instead. For class-per-file languages
+    (Java/Kotlin/C#) a broad coordinator class spreads complexity across many
+    small methods, so its aggregate over-ranks it above a genuinely complex
+    single method living in a leaner file (issue #115: an aggregate-107 / worst-
+    function-14 coordinator out-ranked a ccn-28 DAO method). Blending toward
+    ``max_fn_ccn`` corrects that.
+
+    ``max_fn_ccn <= ccn`` always (it is the largest term of the sum), so the
+    effective value never exceeds the aggregate. For single-function-dominant
+    files (Python/Go, where ``max_fn_ccn`` is at or near the aggregate) the blend
+    collapses back to the aggregate, so their ranking is unchanged. scc-scored
+    files have no function breakdown (``max_fn_ccn is None``) and keep the raw
+    aggregate.
+    """
+    if not max_fn_ccn:  # None (scc) or 0 -> no usable per-function signal
+        return ccn
+    w = PER_FUNCTION_WEIGHT
+    return float(max_fn_ccn ** w * ccn ** (1.0 - w))
+
+
 def write_stats(files: list[tuple[Path, int, float, str]],
                 aux_data: dict[Path, int] | None,
                 aux_label: str | None,
@@ -500,10 +530,13 @@ def write_stats(files: list[tuple[Path, int, float, str]],
 
     Consumed by the /assess skill: percentiles drive Layer 3 (linter) scoring,
     top hotspot lists become the named files in the actions table.
-    Composite hotspot score = sqrt(ccn) * sqrt(1 + commits): a sub-linear
-    geometric mean of complexity and recent churn. Both axes are damped, so a
-    complex-AND-active file leads, a frozen-but-complex file ranks below it, and
-    a trivially-simple-but-churny file can't top the list on churn alone.
+    Composite hotspot score = sqrt(effective_ccn) * sqrt(1 + commits): a
+    sub-linear geometric mean of complexity and recent churn. Both axes are
+    damped, so a complex-AND-active file leads, a frozen-but-complex file ranks
+    below it, and a trivially-simple-but-churny file can't top the list on churn
+    alone. ``effective_ccn`` re-weights the file aggregate toward the worst
+    single function (see ``_effective_ccn``) so a broad coordinator class can't
+    out-rank a genuinely complex single method (issue #115).
 
     The ``ccn`` block and every row's ``ccn`` field are **file-level aggregates**
     (sum of per-function complexity). A per-function linter threshold (cyclop 15,
@@ -554,7 +587,12 @@ def write_stats(files: list[tuple[Path, int, float, str]],
             # (no git), so a missing value is distinct from a real 0.
             "commits": int(churn) if aux_data else None,
             "source": src,
-            "_score": math.sqrt(ccn) * math.sqrt(1.0 + churn),
+            # Ranked on the per-function-weighted effective complexity, not the
+            # raw aggregate, so a coordinator class can't out-rank the genuine
+            # single-method offender (issue #115). The `ccn` field above stays
+            # file-aggregate for the hue and the Layer 3 comparison.
+            "_score": math.sqrt(_effective_ccn(ccn, max_fn(path)))
+            * math.sqrt(1.0 + churn),
         })
 
     def strip(rows: list[dict]) -> list[dict]:

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -169,6 +169,85 @@ def test_write_stats_scc_file_has_null_max_fn_ccn(treemap, tmp_path):
     assert stats["fn_ccn"]["function_count"] == 0
 
 
+def test_hotspot_rank_favours_per_function_offender(treemap, tmp_path):
+    """Issue #115: for a class-per-file language the hotspot composite must rank
+    on the worst single function, not the file aggregate, so a broad coordinator
+    class can't bury a genuinely complex single method.
+
+    Real shape from the first Java/JVM run: a coordinator at aggregate ccn 107
+    whose worst method is only 14 (not a violation) out-ranked a DAO at ccn 28
+    that is one complex method. With equal churn the DAO must now lead."""
+    root = tmp_path
+    coordinator = root / "Coordinator.java"  # broad: ccn 107, worst method 14
+    dao = root / "Dao.java"                   # one genuinely complex method
+    files = [
+        (coordinator, 600, 107.0, "lizard"),
+        (dao, 200, 28.0, "lizard"),
+    ]
+    # Many small methods summing to 107, worst single = 14.
+    coordinator_fns = [14.0, 13.0, 12.0, 11.0, 10.0, 10.0, 9.0,
+                       9.0, 8.0, 6.0, 5.0]
+    assert sum(coordinator_fns) == 107.0
+    dao_fns = [28.0]  # the single complex method is the whole file's ccn
+    aux_data = {coordinator: 5, dao: 5}  # equal churn isolates the ccn re-weight
+    out = root / "stats.json"
+    treemap.write_stats(
+        files, aux_data, "commits (last 12mo)", root, out,
+        fn_ccn_by_path={coordinator: coordinator_fns, dao: dao_fns},
+    )
+    stats = json.loads(out.read_text())
+    hotspots = stats["top_hotspots"]
+
+    # The true per-function offender ranks at or above the coordinator class.
+    assert hotspots[0]["path"] == "Dao.java"
+    # The aggregate is still reported faithfully - only the ranking changed.
+    by_path = {h["path"]: h for h in hotspots}
+    assert by_path["Coordinator.java"]["ccn"] == 107.0
+    assert by_path["Coordinator.java"]["max_fn_ccn"] == 14.0
+    # The complexity-only rank (treemap hue) stays aggregate-driven.
+    assert stats["top_complex"][0]["path"] == "Coordinator.java"
+
+
+def test_hotspot_rank_unchanged_for_single_function_per_file(treemap, tmp_path):
+    """Must-not-regress guard (issue #115): for single-function-per-file
+    languages (Python/Go) the aggregate is the worst function, so the
+    per-function re-weight is a no-op and the existing ranking is preserved -
+    the more-complex-and-equally-churned file still leads."""
+    root = tmp_path
+    complex_go = root / "complex.go"   # one big function, ccn 40
+    simple_go = root / "simple.go"     # one small function, ccn 8
+    files = [
+        (complex_go, 300, 40.0, "lizard"),
+        (simple_go, 120, 8.0, "lizard"),
+    ]
+    # aggregate == worst function: the per-function weight collapses to aggregate.
+    aux_data = {complex_go: 10, simple_go: 10}
+    out = root / "stats.json"
+    treemap.write_stats(
+        files, aux_data, "commits (last 12mo)", root, out,
+        fn_ccn_by_path={complex_go: [40.0], simple_go: [8.0]},
+    )
+    stats = json.loads(out.read_text())
+    hotspots = stats["top_hotspots"]
+
+    # Ranking is unchanged: the genuinely complex file still leads.
+    assert hotspots[0]["path"] == "complex.go"
+    # And it matches the aggregate-only rank - no per-function divergence here.
+    assert stats["top_complex"][0]["path"] == "complex.go"
+
+
+def test_effective_ccn_collapses_to_aggregate_without_per_function_data(treemap):
+    """`_effective_ccn` returns the raw aggregate when there is no per-function
+    signal (scc files: max_fn_ccn is None), and when the worst function already
+    equals the aggregate (single-function file) - the two no-regression paths."""
+    assert treemap._effective_ccn(50.0, None) == 50.0   # scc: no breakdown
+    assert abs(treemap._effective_ccn(40.0, 40.0) - 40.0) < 1e-9  # single fn
+    # A coordinator (aggregate >> worst fn) is pulled below its aggregate but
+    # never below the worst function itself.
+    eff = treemap._effective_ccn(107.0, 14.0)
+    assert 14.0 < eff < 107.0
+
+
 def test_assess_dir_is_self_excluded_by_default(treemap):
     """A prior run's run-context.json must not be scored on the next run -
     the script's own output directory is in EXCLUDE_DIRS. Otherwise re-runs


### PR DESCRIPTION
## Summary

The hotspot composite score (`sqrt(ccn) * sqrt(1 + commits)`) ranked on the **file-aggregate** CCN. For class-per-file languages (Java/Kotlin/C#), complexity spreads across many small methods, so a broad coordinator class over-ranked a genuinely complex single method living in a leaner file. Observed on the first Java/JVM run: an aggregate-107 / worst-function-14 coordinator (not a per-function violation) ranked above a ccn-28 DAO method that is one complex method.

## Changes Made

- Add `_effective_ccn(ccn, max_fn_ccn)` in `complexity-treemap.py`: a weighted geometric mean of the file aggregate and the file's worst single function (`max_fn_ccn ** 0.7 * ccn ** 0.3`), leaning toward the per-function offender.
- Re-weight the hotspot composite `_score` onto this effective CCN. The treemap hue, the row `ccn` field, and the Layer 3 per-function comparison all keep the raw file-aggregate - only hotspot **ranking** changes.
- Updated the `write_stats` docstring to describe the per-function-weighted composite.

## Technical Details

`max_fn_ccn <= ccn` always (it is the largest term of the sum), so the effective value never exceeds the aggregate and the worst function is a floor it never drops below.

- **Class-per-file (Java/Kotlin/C#):** aggregate >> worst function, so the blend pulls a coordinator's score down toward its real per-function complexity, surfacing the true single-method offender at or above it.
- **Single-function-per-file (Python/Go):** the worst function is the aggregate, so the blend collapses back to the aggregate - ranking is unchanged.
- **scc-scored files:** no function breakdown (`max_fn_ccn is None`), so they keep the raw aggregate.

Builds on #58, which fixed the *labelling* but left the *ranking* aggregate-driven.

## Testing

- `test_hotspot_rank_favours_per_function_offender` - a coordinator (aggregate 107 / worst 14) and a DAO (ccn 28) with equal churn; the DAO now ranks first, while `top_complex` (hue) stays aggregate-driven.
- `test_hotspot_rank_unchanged_for_single_function_per_file` - Python/Go regression guard: the more-complex equally-churned file still leads.
- `test_effective_ccn_collapses_to_aggregate_without_per_function_data` - the two no-regression paths (scc `None`, single-function equal-to-aggregate).
- Full `skills/assess` suite: 507 passed, 1 skipped (golden baselines unchanged). ruff + mypy gates green.

## Risk Assessment

Low. Contained to `complexity-treemap.py` ranking; the aggregate remains the reported value everywhere else, so downstream consumers reading `ccn`/`max_fn_ccn` are unaffected - only `top_hotspots` ordering shifts, in the intended direction.

Closes #115
