### PR TITLE
docs: add Map-of-Content index to wire orphaned doc trees

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Claude Code plugin: skills, agents, and commands for AI-native development. Runs locally in your Claude Code session, against your own codebase, using whichever model you're already paying for - nothing leaves your machine beyond what Claude Code itself sends.
 
+> **New here?** The [Map of Content](docs/index.md) is the navigation index - one trail to every skill, command, agent, and design doc in this repo. The [`CLAUDE.md`](CLAUDE.md) contract holds the rules for editing it.
+
 The headline pieces are three **skills**:
 
 - **`/assess`** - score any codebase's readiness for AI agent contributors against an 8-layer contract model (navigability, runtime liveness, code design, linters, architecture tests, CI, coverage, review bots, AI project management), with a Codecov-style complexity hotspot SVG and a doc-navigability graph SVG (both colour-blind-safe). Generates a report + the two SVGs and opens a PR in the target repo.
@@ -197,6 +199,8 @@ Spawns a Fibonacci-sized team (default 3) that cycles through De Bono's six hats
 
 ### Skills (auto-discovered by Claude Code)
 
+Full catalog and per-skill base docs: [`skills/README.md`](skills/README.md).
+
 | Skill | Description |
 |-------|-------------|
 | `/assess` | Layered AI-readiness assessment (0-8 contract model) plus a Codecov-style complexity hotspot SVG and a doc-navigability graph SVG (both colour-blind-safe). Ships [`complexity-treemap.py`](skills/assess/scripts/complexity-treemap.py) and [`doc-graph-svg.py`](skills/assess/scripts/doc-graph-svg.py) so the agent runs them with no external setup. Filters build artifacts and generated code by default (opt-out with `--include-artifacts`); warns when one file dominates LOC. Offers to install optional `scc` for repos heavy in markdown/JSON/YAML. Generated PRs include a self-install footer so reviewers can adopt the plugin. |
@@ -205,6 +209,8 @@ Spawns a Fibonacci-sized team (default 3) that cycles through De Bono's six hats
 | `/ghsync` | Bulk clone and keep in sync every GitHub repo you can access across an org - built for onboarding into a new enterprise. Discovers repos through the teams you belong to, deduplicates, then clones new ones and fast-forward syncs existing checkouts and their worktrees into a `<repo>/<repo>-main` + `<repo>/worktree` layout. Org defaults to the directory you run from. Never clobbers local work (uncommitted or off-default-branch repos are fetched, not pulled) and reports every exception in a summary. Ships [`ghsync.sh`](skills/ghsync/scripts/ghsync.sh); needs `gh` + `jq`, supports GitHub Enterprise via `GH_HOST`. |
 
 ### Commands (slash-only, no bundled assets)
+
+Full catalog: [`commands/README.md`](commands/README.md).
 
 Portable:
 
@@ -226,6 +232,8 @@ Workflow (personal setup, opt-in - see [Adapting](#adapting-for-your-workflow)):
 `/tm`, `/issues`, `/fix-pr`, and `/fix-develop` share the `marathon` skill (team orchestration engine: DAG analysis, waves, crash recovery, retrospective) and the `pr-review-merge` skill (review-to-green loop + smart merge) as a single source of truth. Each command supplies a thin work-source adapter; the skills own the execution.
 
 ### Agents (invoked by skills, or directly via `Task(subagent_type=...)`)
+
+Full catalog: [`agents/README.md`](agents/README.md).
 
 The Six Hats team that `/huddle` and `/6hats` orchestrate:
 
@@ -344,11 +352,17 @@ ai-native-toolkit/
 │       └── test_integration.py        # Full-build ZIP content validation
 ├── dist/                              # Generated ZIPs (gitignored; published via CI)
 └── docs/
+    ├── index.md                       # Map of Content - navigation index for the whole repo
+    ├── testing-a-branch-locally.md    # Runbook: test an unmerged branch as a real plugin
+    ├── superpowers/
+    │   └── README.md                  # Design history: plans + specs behind the skills
     ├── example-doc-graph.svg          # Real /assess doc-navigability SVG, before the action sweep (README hero)
     ├── example-doc-graph-after.svg    # Same repo, doc-navigability after the action sweep
     ├── example-heatmap.svg            # Real /assess complexity heatmap, before the action sweep (README hero)
     └── example-heatmap-after.svg      # Same repo, complexity heatmap after the action sweep
 ```
+
+Each subtree has a base doc that the [Map of Content](docs/index.md) links to: [`agents/README.md`](agents/README.md), [`commands/README.md`](commands/README.md), and [`skills/README.md`](skills/README.md).
 
 ## Contributors
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,24 @@
+# Agents
+
+Subagent definitions invoked by the skills, or directly via `Task(subagent_type=...)`. Each file carries the frontmatter contract (`name`, `description`, `model`, `color`) documented in [`CLAUDE.md`](../CLAUDE.md). Back to the [Map of Content](../docs/index.md).
+
+## Six Thinking Hats team
+
+Orchestrated by [`/huddle`](../skills/huddle/SKILL.md) and [`/6hats`](../commands/6hats.md):
+
+| Agent | Role |
+|-------|------|
+| [`white-hat`](./white-hat.md) | Facts and evidence |
+| [`red-hat`](./red-hat.md) | Gut feelings and emotional drivers |
+| [`black-hat`](./black-hat.md) | Risks and critical analysis |
+| [`yellow-hat`](./yellow-hat.md) | Benefits and opportunities |
+| [`green-hat`](./green-hat.md) | Creative alternatives |
+| [`blue-hat`](./blue-hat.md) | Synthesis and recommendation |
+| [`scribe`](./scribe.md) | Structures hat output into actionable documentation |
+
+## Assessment
+
+| Agent | Role |
+|-------|------|
+| [`assess-layer-scorer`](./assess-layer-scorer.md) | Scores a codebase against the [`/assess`](../skills/assess/SKILL.md) 0-8 layered contract model, assigning Present / Partial / Missing per layer with evidence |
+</content>

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,23 @@
+# Commands
+
+Slash commands shipped by the plugin. Portable framework commands work in any Claude Code session; the workflow commands embed one author's personal setup and are opt-in - see [Adapting for your workflow](../README.md#adapting-for-your-workflow) before relying on them. Back to the [Map of Content](../docs/index.md).
+
+## Portable
+
+| Command | Description |
+|---------|-------------|
+| [`/6hats`](./6hats.md) | Solo Six Hats analysis - alias for [`/huddle`](../skills/huddle/SKILL.md) at team size 1 |
+| [`/understand`](./understand.md) | Deep understanding mode (nemawashi) - exhaustive context-gathering before action |
+
+## Workflow (personal setup, opt-in)
+
+| Command | Description |
+|---------|-------------|
+| [`/tm`](./tm.md) | Task Master orchestration - starts, reviews, or cleans up tasks based on current state |
+| [`/issues`](./issues.md) | GitHub-issue marathon - triage open issues, then run agent-ready ones to merge with Agent Teams |
+| [`/fix-pr`](./fix-pr.md) | Autonomous PR fixing loop - iterates on CI failures and review comments until green |
+| [`/fix-develop`](./fix-develop.md) | Autonomous fix loop for failing CI on the repo's default branch |
+| [`/tm-marathon-config-example`](./tm-marathon-config-example.md) | Reference configuration block to drop into a project's `CLAUDE.md` for marathon-mode `/tm` and `/issues` |
+
+`/tm`, `/issues`, `/fix-pr`, and `/fix-develop` share the [`marathon`](../skills/marathon/SKILL.md) and [`pr-review-merge`](../skills/pr-review-merge/SKILL.md) library skills as their single source of truth. Each command supplies a thin work-source adapter; the skills own the execution.
+</content>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,74 @@
+# Map of Content
+
+The navigation index for `ai-native-toolkit`. Every shipped doc in this repo is reachable from here by following links - no directory-walking required. Start at the [README](../README.md) for the project overview, the [CLAUDE.md](../CLAUDE.md) contract for the rules that govern edits, then use the trails below to reach any agent, command, or skill.
+
+## Subtrees at a glance
+
+| Subtree | Entry doc | What lives there |
+|---------|-----------|------------------|
+| Skills | [`skills/`](../skills/README.md) | The plugin's skills - the headline `/assess`, `/huddle`, `/deslop`, plus `/ghsync` and the team-orchestration library skills |
+| Commands | [`commands/`](../commands/README.md) | Slash commands - portable framework commands and opt-in personal workflow commands |
+| Agents | [`agents/`](../agents/README.md) | The Six Thinking Hats team that `/huddle` and `/6hats` orchestrate |
+| Docs | this file | Design history, runbooks, and the rendered example SVGs |
+
+## Skills
+
+The auto-discovered skills, each with its own `SKILL.md` base doc. See [`skills/README.md`](../skills/README.md) for the full catalog.
+
+Portable (work in any Claude Code session, also shipped as standalone ZIPs):
+
+- [`/assess`](../skills/assess/SKILL.md) - score a codebase's readiness for AI agent contributors against the 0-8 layered contract model; emits a complexity hotspot SVG and a doc-navigability graph SVG.
+- [`/huddle`](../skills/huddle/SKILL.md) - structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing.
+- [`/deslop`](../skills/deslop/SKILL.md) - detect and remove the telltale signs of AI writing. Ships an exhaustive [reference checklist](../skills/deslop/references/full-checklist.md).
+- [`/ghsync`](../skills/ghsync/SKILL.md) - bulk-clone and fast-forward sync every GitHub repo you can access across an org.
+
+Team-orchestration library skills (invoked by the workflow commands, not standalone):
+
+- [`marathon`](../skills/marathon/SKILL.md) - parallel agent marathon orchestration: DAG analysis, waves, crash recovery, retrospective.
+- [`pr-review-merge`](../skills/pr-review-merge/SKILL.md) - the PR review-to-green loop plus smart merge.
+
+`/assess` is itself split into three skills - the orchestrator plus two render-time helpers:
+
+- [`assess`](../skills/assess/SKILL.md) - the orchestrator and layered scorer.
+- [`assess-findings`](../skills/assess-findings/SKILL.md) - renders the report from the deterministic `run-context.json` and the layer scorecard.
+- [`assess-pr`](../skills/assess-pr/SKILL.md) - the end-of-run offers (open a PR, track the Top 3 Actions, freeze a CI gate).
+
+## Commands
+
+The slash commands, indexed in [`commands/README.md`](../commands/README.md).
+
+Portable:
+
+- [`/6hats`](../commands/6hats.md) - solo Six Hats analysis, an alias for `/huddle` at team size 1.
+- [`/understand`](../commands/understand.md) - deep understanding mode (nemawashi): exhaustive context-gathering before action.
+
+Personal workflow commands (opt-in - see [Adapting for your workflow](../README.md#adapting-for-your-workflow)):
+
+- [`/tm`](../commands/tm.md) - Task Master orchestration: starts, reviews, or cleans up tasks by current state.
+- [`/issues`](../commands/issues.md) - GitHub-issue marathon: triage open issues, then run agent-ready ones to merge with Agent Teams.
+- [`/fix-pr`](../commands/fix-pr.md) - autonomous PR fixing loop: iterates on CI failures and review comments until green.
+- [`/fix-develop`](../commands/fix-develop.md) - autonomous fix loop for failing CI on the default branch.
+- [`/tm-marathon-config-example`](../commands/tm-marathon-config-example.md) - reference configuration block for marathon-mode `/tm` and `/issues`.
+
+## Agents
+
+The Six Thinking Hats team, indexed in [`agents/README.md`](../agents/README.md):
+
+- [`white-hat`](../agents/white-hat.md) - facts and evidence.
+- [`red-hat`](../agents/red-hat.md) - gut feelings and emotional drivers.
+- [`black-hat`](../agents/black-hat.md) - risks and critical analysis.
+- [`yellow-hat`](../agents/yellow-hat.md) - benefits and opportunities.
+- [`green-hat`](../agents/green-hat.md) - creative alternatives.
+- [`blue-hat`](../agents/blue-hat.md) - synthesis and recommendation.
+- [`scribe`](../agents/scribe.md) - structures hat output into actionable documentation.
+- [`assess-layer-scorer`](../agents/assess-layer-scorer.md) - scores a codebase against the `/assess` layered contract model.
+
+## Docs
+
+- [Testing a branch locally](./testing-a-branch-locally.md) - run an unmerged branch's `SKILL.md` and scripts as a real plugin against a target repo.
+- [Design history](./superpowers/README.md) - the plans and specs behind the skills as they were built.
+- [Code review instructions](../.github/claude-review-instructions.md) - the guidelines the automated reviewer follows on pull requests.
+
+The rendered example SVGs used in the README hero (the doc-navigability graph and the complexity heatmap, before and after the action sweep) live alongside this file in `docs/`.
+</content>
+</invoke>

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,27 @@
+# Design history
+
+The plans and specs behind the skills, captured as they were built. These are historical design records - the shipped behaviour lives in the [skills](../../skills/README.md) and [commands](../../commands/README.md) themselves - but they document the reasoning and trade-offs that produced each feature. Back to the [Map of Content](../index.md).
+
+## Plans
+
+| Plan | Subject |
+|------|---------|
+| [Assess deterministic wiki foundation](./plans/2026-05-22-assess-deterministic-wiki.md) | The compounding `.assess/` wiki foundation |
+| [Assess v1.5 real-use fixes](./plans/2026-05-22-assess-v1.5-real-use-fixes.md) | Feedback fixes from real-world use |
+| [Standalone skill pipeline](./plans/2026-05-23-standalone-skill-pipeline.md) | The standalone-ZIP build pipeline |
+| [Assess truth-pressure signals (read-side)](./plans/2026-05-27-assess-truth-pressure-signals.md) | Read-side truth-pressure foundation |
+| [Huddle broadcast per recipient](./plans/2026-05-27-huddle-broadcast-per-recipient.md) | Team-mode broadcast incompatibility |
+| [Huddle CLI team-mode regression](./plans/2026-05-27-huddle-cli-team-mode-regression.md) | CLI team-mode regression fix |
+| [Assess dismiss false positives](./plans/2026-05-28-assess-dismiss-false-positives.md) | Suppressing false-positive findings |
+| [Assess keyhole readiness](./plans/2026-05-29-assess-keyhole-readiness.md) | Structural legibility (keyhole) signals |
+| [Assess write-side truth-pressure](./plans/2026-05-29-assess-write-side-truth-pressure.md) | Write-side verification signals |
+| [Issues marathon + shared skills](./plans/2026-05-29-issues-marathon-shared-skills.md) | `/issues` marathon and shared marathon skills |
+| [Assess dogfooded - baseline analysis](./plans/2026-05-31-assess-dogfooded-analysis.md) | Phase 0 baseline and seam analysis |
+| [Assess dogfooded - PRD](./plans/2026-05-31-assess-dogfooded.md) | Teeth, a frozen harness, and decomposition |
+
+## Specs
+
+| Spec | Subject |
+|------|---------|
+| [Issues marathon shared-skills design](./specs/2026-05-29-issues-marathon-shared-skills-design.md) | Design for `/issues` via shared marathon skills |
+</content>

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,33 @@
+# Skills
+
+The plugin's skills, auto-discovered by Claude Code from each `<name>/SKILL.md`. Each `SKILL.md` is its subtree's base doc and carries the frontmatter contract (`name`, `description` with a `TRIGGER` clause) documented in [`CLAUDE.md`](../CLAUDE.md). Bundled executables live under `<name>/scripts/`, reference docs under `<name>/references/`. Back to the [Map of Content](../docs/index.md).
+
+## Portable
+
+Work in any Claude Code session, and are also distributed as standalone ZIPs for Claude Desktop and claude.ai web.
+
+| Skill | Base doc | Description |
+|-------|----------|-------------|
+| `/assess` | [`assess/SKILL.md`](./assess/SKILL.md) | Layered AI-readiness assessment (0-8 contract model) plus a complexity hotspot SVG and a doc-navigability graph SVG |
+| `/huddle` | [`huddle/SKILL.md`](./huddle/SKILL.md) | Multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing |
+| `/deslop` | [`deslop/SKILL.md`](./deslop/SKILL.md) | Detect and remove the telltale signs of AI writing; ships a [`references/full-checklist.md`](./deslop/references/full-checklist.md) |
+| `/ghsync` | [`ghsync/SKILL.md`](./ghsync/SKILL.md) | Bulk-clone and fast-forward sync every GitHub repo you can access across an org |
+
+## Assessment helpers
+
+`/assess` is split into an orchestrator plus two render-time helper skills:
+
+| Skill | Base doc | Description |
+|-------|----------|-------------|
+| `assess-findings` | [`assess-findings/SKILL.md`](./assess-findings/SKILL.md) | Renders the report from the deterministic `run-context.json` and the layer scorecard |
+| `assess-pr` | [`assess-pr/SKILL.md`](./assess-pr/SKILL.md) | The end-of-run offers - open a PR, track the Top 3 Actions, freeze a CI gate |
+
+## Team-orchestration library skills
+
+Invoked by the workflow commands ([`/tm`](../commands/tm.md), [`/issues`](../commands/issues.md), [`/fix-pr`](../commands/fix-pr.md), [`/fix-develop`](../commands/fix-develop.md)), never standalone. Excluded from the standalone-ZIP build.
+
+| Skill | Base doc | Description |
+|-------|----------|-------------|
+| `marathon` | [`marathon/SKILL.md`](./marathon/SKILL.md) | Parallel agent marathon orchestration: DAG analysis, waves, crash recovery, retrospective |
+| `pr-review-merge` | [`pr-review-merge/SKILL.md`](./pr-review-merge/SKILL.md) | The PR review-to-green loop plus smart merge |
+</content>


### PR DESCRIPTION
## Summary

Adds a Map-of-Content navigation index so an agent can reach every shipped doc by following a curated trail, not by directory-walking. Closes the highest-leverage Layer 0 (navigability) scorecard gap: before this change 41 docs shared ~2 link edges (90% orphan rate, ~10% reachable).

## Changes Made

- **`docs/index.md`** - the Map of Content. Links each subtree's entry points (`skills/`, `commands/`, `agents/`, `docs/`) and every individual agent, command, skill `SKILL.md`, design plan, and spec.
- **Per-module base docs** - `agents/README.md`, `commands/README.md`, `skills/README.md`, and `docs/superpowers/README.md` (design history). Each indexes its directory's members and links back to the MOC.
- **`README.md`** - wires the root entry point to the MOC: a navigation pointer near the top, base-doc links on the Skills/Commands/Agents section headers, and the new index files reflected in the repository-structure tree.
- **`.claude-plugin/plugin.json`** - version bump to `1.24.0`.

## Technical Details

Layer 0 reachability is a graph property: entry roots are the root-level `README.md`/`CLAUDE.md`, and reachability is a BFS over markdown links. Running the bundled `/assess` doc-graph analyzer (`skills/assess/scripts/lib/doc_graph.py`) over the branch confirms the effect:

| Metric | Before | After |
|--------|--------|-------|
| Orphan rate | 90.2% | 0.0% |
| Reachability | 9.8% | 100% |
| Islands | 38 | 1 |
| Orphaned docs | 37 | 0 |

`docs/index.md` is recognised as a declared MOC and a validated structural hub (out-degree 32), so it is a real map, not a declared-but-unwired one.

## Testing

- `plugin contract pytest` (`tests/test_plugin_contract.py`) - 75 passed (includes `test_internal_links_resolve` over every shipped `SKILL.md`/command file).
- Standalone link-resolution check over all new/edited docs - no dead links.
- `/assess` doc-graph analyzer rerun - metrics above.

## Risk Assessment

Documentation and navigation only - no code, no behaviour change. New links are curated to existing files; the doc-graph confirms no dead links and no new islands.

Closes #112