### PR TITLE
feat: capability-driven tool-install offers with Maven liveness (v1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/agents/assess-layer-scorer.md
+++ b/agents/assess-layer-scorer.md
@@ -133,6 +133,17 @@ jq '.dead_code, .observability' "$REPO_ROOT/.assess/run-context.json"
 
 Two `tools[].status` values need handling in the report: `available_not_run` means the tool is present but would **build the project** (`deadcode`/`staticcheck`/`knip` resolve/compile and may write the module cache or hit the network), so a read-only assessment doesn't run it - surface the tool's `reason` (it includes the exact command) as a "run manually to cross-check" follow-up rather than a finding. `timeout` / `tool_absent` likewise degrade, not penalise.
 
+**Capability-driven JVM offers (`capability_offers`).** When the repo is a Maven or Gradle project, `run-context.json` carries a `capability_offers` block and the `dead_code.tools` list includes a `java` entry. This is the capability-driven flow (SKILL.md Step 2b) surfaced to the scorer:
+
+```bash
+jq '.capability_offers' "$REPO_ROOT/.assess/run-context.json"
+```
+
+- `capabilities.liveness.state == "served"` - `mvn dependency:analyze` ran; its coarse module-level candidates (unused declared dependencies) are already merged into `dead_code.candidates`. Score Layer 1's dead-code tier from them as usual, noting the granularity is dependency-level, not per-symbol.
+- `capabilities.liveness.state == "offer"` - Maven detected, analyze not run (a **run-consent** the user can accept in Step 2b). Treat like `available_not_run`: surface the candidate tool as a follow-up, don't penalise.
+- `state == "credited"` (linting/modernization) - a configured pom.xml plugin (`served_by`) already serves it. Credit it in the relevant layer; do **not** report it as missing.
+- `state == "honest_degrade"` - nothing serves the capability yet (module graph, unconfigured linting/modernization, all Gradle capabilities in v1). **Name the capability and its `candidate_tool` in the report** - this is a deliverable, distinct from a silent miss. Never report a honest-degraded capability as simply "absent".
+
 **Observability tier (the decisive one) - three rungs (`observability.rung`, 0-3):**
 
 1. **Instrumented** - telemetry is emitted (OpenTelemetry, Prometheus, Datadog/APM, structured logging). Necessary, not sufficient.

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -120,9 +120,17 @@ If the user picks **Install scc**, run the platform-appropriate command:
 
 If the install fails or the platform isn't covered, fall back to lizard-only and continue - don't block the assessment.
 
-### 2b: Offer to install per-language dead-code tools (one-time per tool)
+### 2b: Offer analysis tools (capability-driven, detect-or-propose)
 
-Layer 1's intra-repo dead-code scan calls a per-language tool (`vulture` for Python, `ts-prune`/`knip` for TS/JS, `staticcheck`/`deadcode` for Go). When the tool is absent, the scan degrades to `tool_absent` and the user has no resolution path inside the skill - they'd have to know which tool fits the language, which package manager to use, and run the install themselves. The same install-offer pattern as Step 2a closes the loop without leaving them to figure it out.
+`/assess` maps each Layer 1/Layer 3 analysis **capability** (liveness/dead-code, static module graph, linting, modernization) to a serving tool. Historically that map was a **hardcoded per-language allowlist** - `vulture` for Python, `ts-prune`/`knip` for TS/JS, `staticcheck`/`deadcode` for Go. The defect that allowlist created: when a repo's language **isn't enumerated**, every capability silently degraded to "unavailable" - the report read "this layer is absent here" rather than "a tool could serve this - install one?". A non-enumerated language was locked out with no resolution path inside the run.
+
+The flow is now **capability-driven detect-or-propose**, in three moves per capability:
+
+1. **Detect** whether a serving tool already exists (on PATH, or configured in build/lint config). If it does, **use it** - and if it's configured in the build, **credit it; never re-offer**.
+2. **Propose** an ecosystem-appropriate candidate when none exists. For an enumerated language this is the table below; for a non-enumerated one **you propose a fitting tool at runtime** (reasoned latitude - you are not locked out because the language isn't in a hardcoded list). Ask the user with the same **AskUserQuestion** pattern.
+3. **Honest-degrade** anything you can detect-but-not-serve: name the capability **and** a candidate tool in the report. This is a deliverable state distinct from both "Present" and a silent "Missing" - never let a capability vanish without naming what would serve it.
+
+The per-language dead-code offer below is the simplest instance (one capability, install-consent). When the tool is absent, the scan degrades to `tool_absent` and the user has no resolution path inside the skill - they'd have to know which tool fits the language, which package manager to use, and run the install themselves. The same install-offer pattern as Step 2a closes the loop without leaving them to figure it out.
 
 Detect languages with cheap `fd` counts (mirroring Step 2a's heuristic - the treemap script's own classification isn't exposed in the stats sidecar, and shelling out is fine here):
 
@@ -171,6 +179,20 @@ touch "$REPO_ROOT/.assess/.no-<tool>"   # e.g. .no-staticcheck
 ```
 
 For multi-language repos with several offers, the AskUserQuestion call lists every language in one prompt rather than serialising. The user answers once and the run proceeds with whichever tools they accepted.
+
+#### JVM / Maven capability offers (v1)
+
+When the deterministic core detects a Maven or Gradle project it emits a `capability_offers` block in `run-context.json` - the first proof of the capability-driven flow on a non-enumerated ecosystem. Read it after Step 2c's core run, before scoring, and act on each capability's `state`:
+
+```bash
+jq '.capability_offers' "$REPO_ROOT/.assess/run-context.json"
+```
+
+- **`liveness` → `state: "offer"`** - Maven was detected but `mvn dependency:analyze` (coarse module-level dead-dependency detection) has not run. The `consent` field names the shape: `run` (`mvn` is on PATH - offer to **run** it against the project; `dependency:analyze` needs a *compiling build*, so this is a **run-consent**, heavier than a static scan) or `install` (`mvn` absent - offer to **install** Maven first). Use **AskUserQuestion** exactly as Step 2b, phrasing the trade-off (a build that resolves dependencies and may hit the network). On accept and a `run` consent, run `mvn dependency:analyze`, capture its output, and re-run the core with the served result so the candidates feed Layer 1. On decline, the capability stays honestly named, not silently dropped.
+- **`linting` / `modernization` → `state: "credited"`** - an already-configured pom.xml plugin serves it (`served_by` lists which: Checkstyle, SpotBugs, PMD, error-prone, OpenRewrite, Modernizer). **Credit it in the report; do not re-offer.**
+- **Any capability → `state: "honest_degrade"`** - nothing serves it yet (module graph, linting/modernization without a configured plugin, and **all** capabilities under Gradle in v1). The block carries a `candidate_tool` and `gloss`. **Name both in the report's Layer 1/Layer 3 prose** ("module-graph analysis is unserved here; `jdeps` would provide it"). Honest-degrade is a deliverable - surfacing the candidate is the point.
+
+**Boundary (v1).** Only Maven liveness is *served*. Module graph (`jdeps`), linting, and modernization honest-degrade; Gradle honest-degrades entirely. The `candidate_tool` values are deterministic defaults - you may propose a better-fitting ecosystem tool at runtime (the detect-or-propose latitude above); that choice is human-judged, not CI-tested. CI tests only **signal consumption**: given a tool's output, the scorecard feeds correctly.
 
 ### 2c: Run the treemap
 

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -698,6 +698,13 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
               "discoverable": {"present": False, "signals": []},
               "reachable": {"present": False, "signals": []}}
     )
+    # Capability-driven JVM offers (issue #113): present only when a Maven/Gradle
+    # project is detected, so non-JVM repos carry no extra key (the run-context
+    # baseline stays stable). Names each unserved capability + a candidate tool
+    # (honest-degrade) and the liveness run/install-consent offer the Step 2
+    # offer-layer turns into an AskUserQuestion.
+    if liveness_ok and isinstance(liveness.get("jvm_capabilities"), dict):
+        ctx["capability_offers"] = liveness["jvm_capabilities"]
 
     # Keyhole-readiness signals (PRD 2026-05-29): the static-structure,
     # behaviour (change-coupling / containment / static-vs-historical),

--- a/skills/assess/scripts/lib/jvm_capabilities.py
+++ b/skills/assess/scripts/lib/jvm_capabilities.py
@@ -1,0 +1,401 @@
+"""JVM/Maven capability-driven analysis offers (issue #113, v1 bounded).
+
+Generalises /assess's tool mapping from a hardcoded per-language allowlist
+(``vulture`` for Python, ``ts-prune`` for TS, ``staticcheck`` for Go) to a
+*capability-driven detect-or-propose* model, proven on ONE capability (liveness)
+in ONE build system (Maven). The defect this fixes is the **non-enumeration
+architecture**: when a repo's language isn't in the allowlist, every analysis
+capability silently degrades to "unavailable" - the report reads "this layer is
+absent here" rather than "a tool could serve this - install one?". JVM is simply
+the first ecosystem to expose it.
+
+For each JVM analysis capability the scan reports a STATE the report and the
+offer-layer (SKILL.md Step 2) act on:
+
+  * ``served``         - liveness, when ``mvn dependency:analyze`` has been run
+                         (run-consent) and its coarse module-level candidates
+                         are fed into the dead-code signal.
+  * ``offer``          - liveness, when Maven is detected but the analyze goal
+                         has not been run. The agent should offer to resolve it
+                         inside the run. ``consent`` distinguishes the shape:
+                         ``run`` when ``mvn`` is already on PATH (a RUN-consent -
+                         ``dependency:analyze`` needs a *compiling build*, not
+                         just an install), ``install`` when ``mvn`` is absent.
+  * ``credited``       - a capability already served by a configured pom.xml
+                         plugin (Checkstyle / SpotBugs / PMD / error-prone /
+                         OpenRewrite); detected and NOT re-offered.
+  * ``honest_degrade`` - a capability nothing serves yet; the report NAMES the
+                         capability and an ecosystem-appropriate candidate tool.
+                         A deliverable distinct from both "Present" and a silent
+                         "Missing" - module graph, linting, modernization, and
+                         every capability under Gradle take this state in v1.
+
+Boundary: the candidate tool named here is the deterministic DEFAULT. The
+assessing agent has latitude to propose a different ecosystem-appropriate tool
+at runtime (SKILL.md Step 2); that choice is human-judged, not CI-tested. CI
+tests SIGNAL CONSUMPTION - given a tool's output, the scorecard feeds correctly.
+
+Out of scope for v1 (fast-follow): healing the module graph (``jdeps``), linting,
+and modernization; Gradle plugin reading and a served Gradle path; non-JVM
+languages benefiting from the same general flow.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from lib.doc_graph import is_excluded_path
+
+# Capabilities a JVM project exposes, in report order. Only ``liveness`` is
+# healed in v1; the rest honest-degrade (or are credited when a plugin serves
+# them).
+JVM_CAPABILITIES = ("liveness", "module_graph", "linting", "modernization")
+
+# Ecosystem-appropriate DEFAULT candidate per capability. The agent may propose
+# an alternative at runtime (reasoned latitude); this is what the deterministic
+# report names so honest-degrade is never silent.
+_CANDIDATE_TOOLS = {
+    "liveness": "mvn dependency:analyze",
+    "module_graph": "jdeps",
+    "linting": "Checkstyle / SpotBugs / error-prone",
+    "modernization": "OpenRewrite",
+}
+
+_CAPABILITY_GLOSS = {
+    "liveness": "coarse module-level dead-dependency detection",
+    "module_graph": "static inter-module dependency graph",
+    "linting": "style and bug-pattern static analysis",
+    "modernization": "automated API / idiom migration",
+}
+
+# pom.xml needles (lowercased) that mean a capability is already served, so the
+# offer-flow CREDITS it rather than re-offering. Coarse on purpose: a substring
+# match against the pom text. error-prone is configured as a compiler
+# annotation-processor (``error_prone_core``), not a standalone plugin, so it is
+# matched by its artifact stem as well as the hyphenated name.
+_PLUGIN_CREDITS = [
+    ("maven-checkstyle-plugin", "linting", "Checkstyle"),
+    ("spotbugs-maven-plugin", "linting", "SpotBugs"),
+    ("findbugs-maven-plugin", "linting", "FindBugs"),
+    ("maven-pmd-plugin", "linting", "PMD"),
+    ("error_prone_core", "linting", "error-prone"),
+    ("error-prone", "linting", "error-prone"),
+    ("rewrite-maven-plugin", "modernization", "OpenRewrite"),
+    ("modernizer-maven-plugin", "modernization", "Modernizer"),
+]
+
+# Cap parsed liveness candidates so a pathological multi-module reactor can't
+# bloat run-context.json (mirrors liveness_scan.MAX_CANDIDATES intent).
+MAX_JVM_CANDIDATES = 50
+
+# Section headers in ``mvn dependency:analyze`` output. Only "unused declared"
+# is surfaced as liveness dead-weight (a declared dependency nothing in the
+# module references - coarse module-level dead code). "Used undeclared" is a
+# build-hygiene signal, counted in a note but not a liveness candidate.
+_UNUSED_DECLARED_HEADER = "unused declared dependencies"
+_USED_UNDECLARED_HEADER = "used undeclared dependencies"
+
+# A Maven coordinate line, after the optional ``[WARNING]``/``[INFO]`` log
+# prefix is stripped: ``group:artifact:type:version:scope`` (>= 4 colons). The
+# leading whitespace under a section header is what Maven uses to nest entries.
+_XML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_LOG_PREFIX_RE = re.compile(r"^\s*\[[A-Z]+\]\s*")
+_COORD_RE = re.compile(
+    r"^([\w.\-]+):([\w.\-]+):[\w.\-]+:[\w.\-]+(?::[\w.\-]+)?\s*$"
+)
+
+
+def _iter_build_files(repo_root: Path, names: set[str],
+                      extra_exclude_dirs: set[str] | None = None,
+                      extra_exclude_patterns: list[str] | None = None,
+                      ) -> list[Path]:
+    """Build files matching ``names``, skipping vendored / build / fixture dirs
+    and any user-supplied exclude (so a fixture ``pom.xml`` under
+    ``tests/fixtures/`` never makes a Python repo look like a Maven project)."""
+    from lib.assess_config import is_user_excluded
+    extra_dirs = extra_exclude_dirs or set()
+    extra_pats = extra_exclude_patterns or []
+    out: list[Path] = []
+    for name in names:
+        for path in repo_root.rglob(name):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(repo_root)
+            if is_excluded_path(rel):
+                continue
+            if is_user_excluded(rel, extra_dirs, extra_pats):
+                continue
+            out.append(path)
+    return out
+
+
+def detect_build_system(repo_root: Path,
+                        extra_exclude_dirs: set[str] | None = None,
+                        extra_exclude_patterns: list[str] | None = None,
+                        ) -> tuple[str | None, list[str]]:
+    """Return ``(build_system, sorted_relative_build_files)``.
+
+    Maven wins when both are present - it is the served path in v1, so a
+    polyglot repo with a ``pom.xml`` still gets the liveness offer. Gradle is
+    detected (so it honest-degrades with a named candidate) but has no served
+    path in v1.
+    """
+    repo_root = repo_root.resolve()
+    poms = _iter_build_files(
+        repo_root, {"pom.xml"},
+        extra_exclude_dirs=extra_exclude_dirs,
+        extra_exclude_patterns=extra_exclude_patterns,
+    )
+    if poms:
+        return "maven", sorted(str(p.relative_to(repo_root)) for p in poms)
+    gradles = _iter_build_files(
+        repo_root, {"build.gradle", "build.gradle.kts"},
+        extra_exclude_dirs=extra_exclude_dirs,
+        extra_exclude_patterns=extra_exclude_patterns,
+    )
+    if gradles:
+        return "gradle", sorted(str(p.relative_to(repo_root)) for p in gradles)
+    return None, []
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def detect_configured_plugins(repo_root: Path, build_files: list[str]) -> dict[str, list[str]]:
+    """Map ``capability -> [served_by, ...]`` for plugins already configured in
+    the given Maven ``build_files``.
+
+    Coarse: a lowercased substring match against each pom's text. Crediting an
+    already-configured tool (so it isn't re-offered) is low-harm if over-eager,
+    and a precise XML parse would add a dependency for marginal gain in v1.
+    """
+    served: dict[str, list[str]] = {}
+    for rel in build_files:
+        # Strip XML comments first: an explanatory comment ("no error-prone yet")
+        # must not credit a tool the build doesn't actually configure.
+        text = _XML_COMMENT_RE.sub(" ", _read((repo_root / rel))).lower()
+        if not text:
+            continue
+        for needle, capability, label in _PLUGIN_CREDITS:
+            if needle in text:
+                served.setdefault(capability, [])
+                if label not in served[capability]:
+                    served[capability].append(label)
+    return served
+
+
+def parse_dependency_analyze(stdout: str, pom_path: str = "pom.xml") -> list[dict]:
+    """Parse ``mvn dependency:analyze`` output into coarse liveness candidates.
+
+    Surfaces *unused declared dependencies* - a dependency a module declares but
+    nothing in it references, i.e. dead weight at module granularity. Returns
+    the same ``{path, line, kind, symbol}`` shape as the per-symbol dead-code
+    tier so the existing ``dead_code`` consumers need no change. ``path`` is the
+    pom that declared it; ``symbol`` is the ``group:artifact`` coordinate.
+    """
+    out: list[dict] = []
+    in_unused = False
+    for raw in stdout.splitlines():
+        lowered = raw.lower()
+        if _UNUSED_DECLARED_HEADER in lowered:
+            in_unused = True
+            continue
+        if _USED_UNDECLARED_HEADER in lowered:
+            in_unused = False
+            continue
+        if not in_unused:
+            continue
+        stripped = _LOG_PREFIX_RE.sub("", raw).strip()
+        m = _COORD_RE.match(stripped)
+        if not m:
+            # A non-coordinate line ends the unused-declared block.
+            if stripped:
+                in_unused = False
+            continue
+        out.append({
+            "path": pom_path,
+            "line": 0,
+            "kind": "unused declared dependency",
+            "symbol": f"{m.group(1)}:{m.group(2)}",
+        })
+    return out
+
+
+def count_used_undeclared(stdout: str) -> int:
+    """Count *used undeclared dependencies* - a build-hygiene signal noted
+    alongside the liveness candidates but not itself dead weight."""
+    count = 0
+    in_block = False
+    for raw in stdout.splitlines():
+        lowered = raw.lower()
+        if _USED_UNDECLARED_HEADER in lowered:
+            in_block = True
+            continue
+        if _UNUSED_DECLARED_HEADER in lowered:
+            in_block = False
+            continue
+        if not in_block:
+            continue
+        stripped = _LOG_PREFIX_RE.sub("", raw).strip()
+        if _COORD_RE.match(stripped):
+            count += 1
+        elif stripped:
+            in_block = False
+    return count
+
+
+def _liveness_capability(build_system: str, mvn_on_path: bool,
+                         analyze_output: str | None,
+                         pom_path: str) -> dict:
+    """Build the ``liveness`` capability entry, the only one healed in v1."""
+    cap: dict[str, Any] = {
+        "candidate_tool": _CANDIDATE_TOOLS["liveness"],
+        "gloss": _CAPABILITY_GLOSS["liveness"],
+    }
+    # Gradle has no served liveness path in v1 - honest-degrade with a named
+    # candidate rather than a silent miss.
+    if build_system != "maven":
+        cap.update({
+            "state": "honest_degrade",
+            "consent": None,
+            "candidate_count": 0,
+            "candidates": [],
+            "note": ("Gradle liveness is deferred to a fast-follow; Maven is the "
+                     "served path in v1. A candidate tool is named so the "
+                     "capability degrades honestly rather than silently."),
+        })
+        return cap
+    if analyze_output is not None:
+        candidates = parse_dependency_analyze(analyze_output, pom_path=pom_path)[:MAX_JVM_CANDIDATES]
+        used_undeclared = count_used_undeclared(analyze_output)
+        cap.update({
+            "state": "served",
+            "consent": "run",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+            "used_undeclared_count": used_undeclared,
+            "note": ("Coarse module-level liveness from `mvn dependency:analyze`: "
+                     f"{len(candidates)} unused declared dependency(ies), "
+                     f"{used_undeclared} used-undeclared. Dependency granularity, "
+                     "not per-symbol - it flags dead weight a module declares but "
+                     "never references."),
+        })
+        return cap
+    # Maven detected, analyze not run: OFFER. Consent shape depends on whether
+    # mvn is already invokable (run-consent) or must be installed first.
+    cap.update({
+        "state": "offer",
+        "consent": "run" if mvn_on_path else "install",
+        "candidate_count": 0,
+        "candidates": [],
+        "note": (
+            "`mvn dependency:analyze` needs a compiling build (resolves deps, "
+            "may hit the network), so a read-only assessment does not run it by "
+            "default. " + (
+                "Offer to RUN it against the project (run-consent)."
+                if mvn_on_path else
+                "Maven is not on PATH; offer to INSTALL it, then run the analyze "
+                "goal (install-consent)."
+            )
+        ),
+    })
+    return cap
+
+
+def _credited_or_degraded(capability: str, served: dict[str, list[str]]) -> dict:
+    """Build a non-liveness capability entry: credited when a configured plugin
+    serves it, otherwise honest-degrade with a named candidate."""
+    cap: dict[str, Any] = {
+        "candidate_tool": _CANDIDATE_TOOLS[capability],
+        "gloss": _CAPABILITY_GLOSS[capability],
+    }
+    if capability in served:
+        cap.update({
+            "state": "credited",
+            "served_by": served[capability],
+            "note": (f"Already served by configured {', '.join(served[capability])} "
+                     "in pom.xml - detected and credited, not re-offered."),
+        })
+    else:
+        cap.update({
+            "state": "honest_degrade",
+            "note": (f"No configured tool serves {capability} "
+                     f"({_CAPABILITY_GLOSS[capability]}); v1 names a candidate "
+                     "rather than healing it. Honest-degrade is a deliverable, "
+                     "not a silent miss."),
+        })
+    return cap
+
+
+def scan_jvm_capabilities(repo_root: Path, *,
+                          run_build_tools: bool = False,
+                          analyze_output: str | None = None,
+                          mvn_on_path: bool | None = None,
+                          extra_exclude_dirs: set[str] | None = None,
+                          extra_exclude_patterns: list[str] | None = None,
+                          ) -> dict:
+    """Capability-driven JVM scan. Never raises - degrades to ``available: False``.
+
+    ``analyze_output`` lets a caller (and CI's consumption test) feed canned
+    ``mvn dependency:analyze`` output without invoking Maven, so the SERVED path
+    is exercised deterministically. With ``run_build_tools=True`` and ``mvn`` on
+    PATH and no ``analyze_output`` supplied, the analyze goal is run for real
+    (opt-in run-consent). The default scan stays read-only: liveness reports the
+    ``offer`` state instead.
+    """
+    repo_root = repo_root.resolve()
+    build_system, build_files = detect_build_system(
+        repo_root,
+        extra_exclude_dirs=extra_exclude_dirs,
+        extra_exclude_patterns=extra_exclude_patterns,
+    )
+    if build_system is None:
+        return {"available": False, "build_system": None, "build_files": []}
+
+    if mvn_on_path is None:
+        mvn_on_path = shutil.which("mvn") is not None
+    pom_path = build_files[0] if build_files else "pom.xml"
+
+    # Opt-in run-consent: actually run the analyze goal when asked and possible.
+    if (build_system == "maven" and analyze_output is None
+            and run_build_tools and mvn_on_path):
+        analyze_output = _run_dependency_analyze(repo_root)
+
+    served = (detect_configured_plugins(repo_root, build_files)
+              if build_system == "maven" else {})
+
+    capabilities = {
+        "liveness": _liveness_capability(
+            build_system, mvn_on_path, analyze_output, pom_path),
+        "module_graph": _credited_or_degraded("module_graph", served),
+        "linting": _credited_or_degraded("linting", served),
+        "modernization": _credited_or_degraded("modernization", served),
+    }
+    return {
+        "available": True,
+        "build_system": build_system,
+        "build_files": build_files,
+        "capabilities": capabilities,
+    }
+
+
+def _run_dependency_analyze(repo_root: Path) -> str | None:
+    """Run ``mvn dependency:analyze`` (opt-in run-consent). Returns combined
+    stdout/stderr, or ``None`` on any failure - the scan then falls back to the
+    offer state rather than crashing the assessment."""
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["mvn", "-q", "dependency:analyze"],
+            cwd=str(repo_root), capture_output=True, text=True,
+            timeout=300, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return (proc.stdout or "") + (proc.stderr or "")

--- a/skills/assess/scripts/lib/liveness_scan.py
+++ b/skills/assess/scripts/lib/liveness_scan.py
@@ -520,28 +520,83 @@ def scan_observability(repo_root: Path,
     )
 
 
+def _merge_jvm_liveness(dead_code: dict, jvm: dict) -> None:
+    """Fold the JVM liveness capability into the existing ``dead_code`` block so
+    the per-symbol dead-code consumers (the ``runtime`` block, the report) see
+    Maven candidates without a schema change. The full capability-offer detail
+    (honest-degrade + crediting) rides separately on ``jvm_capabilities``.
+
+    A ``served`` Maven liveness contributes its coarse module-level candidates
+    and flips ``available``; an ``offer`` contributes only a tool entry so the
+    block records "a tool could serve this" rather than a silent miss.
+    """
+    liveness = jvm.get("capabilities", {}).get("liveness", {})
+    state = liveness.get("state")
+    tool = liveness.get("candidate_tool", "mvn dependency:analyze")
+    if state == "served":
+        candidates = liveness.get("candidates", [])
+        existing = dead_code.setdefault("candidates", [])
+        existing.extend(candidates)
+        dead_code["candidate_count"] = len(existing)
+        if candidates:
+            dead_code["available"] = True
+        dead_code.setdefault("tools", []).append({
+            "language": "java", "tool": tool, "status": "ran",
+            "reason": f"{len(candidates)} unused-declared-dependency candidate(s)",
+        })
+    elif state == "offer":
+        consent = liveness.get("consent")
+        dead_code.setdefault("tools", []).append({
+            "language": "java", "tool": tool,
+            "status": "available_not_run",
+            "reason": liveness.get("note", "Maven liveness offer pending"),
+            "consent": consent,
+        })
+    elif state == "honest_degrade":
+        dead_code.setdefault("tools", []).append({
+            "language": "java", "tool": tool,
+            "status": "honest_degrade",
+            "reason": liveness.get("note", "no served liveness path"),
+        })
+
+
 def scan_liveness(repo_root: Path, run_dead_code: bool = True,
                   run_build_tools: bool = False,
                   extra_exclude_dirs: set[str] | None = None,
                   extra_exclude_patterns: list[str] | None = None,
                   ) -> dict:
-    """Top-level Layer 1 scan: dead-code candidates + observability rungs.
+    """Top-level Layer 1 scan: dead-code candidates + observability rungs, plus
+    the capability-driven JVM offer block when a Maven/Gradle project is found.
 
     `run_build_tools` defaults to False so the scan stays read-only - build-
-    mutating dead-code tools are reported as available-but-not-run.
+    mutating dead-code tools (and `mvn dependency:analyze`, a run-consent goal)
+    are reported as available-but-not-run / offer rather than executed.
     `extra_exclude_dirs` and `extra_exclude_patterns` come from
-    `.assess/config.toml` / `--exclude` and apply to both the dead-code
-    scan and the observability tree walk.
+    `.assess/config.toml` / `--exclude` and apply to the dead-code scan, the
+    observability tree walk, and JVM build-file detection alike.
     """
-    return {
-        "dead_code": scan_dead_code(
-            repo_root, run=run_dead_code, run_build_tools=run_build_tools,
-            extra_exclude_dirs=extra_exclude_dirs,
-            extra_exclude_patterns=extra_exclude_patterns,
-        ).as_dict(),
+    from lib.jvm_capabilities import scan_jvm_capabilities
+
+    dead_code = scan_dead_code(
+        repo_root, run=run_dead_code, run_build_tools=run_build_tools,
+        extra_exclude_dirs=extra_exclude_dirs,
+        extra_exclude_patterns=extra_exclude_patterns,
+    ).as_dict()
+    jvm = scan_jvm_capabilities(
+        repo_root, run_build_tools=run_build_tools,
+        extra_exclude_dirs=extra_exclude_dirs,
+        extra_exclude_patterns=extra_exclude_patterns,
+    )
+    if jvm.get("available"):
+        _merge_jvm_liveness(dead_code, jvm)
+    result = {
+        "dead_code": dead_code,
         "observability": scan_observability(
             repo_root,
             extra_exclude_dirs=extra_exclude_dirs,
             extra_exclude_patterns=extra_exclude_patterns,
         ).as_dict(),
     }
+    if jvm.get("available"):
+        result["jvm_capabilities"] = jvm
+    return result

--- a/skills/assess/tests/fixtures/maven_project/Sample.java
+++ b/skills/assess/tests/fixtures/maven_project/Sample.java
@@ -1,0 +1,11 @@
+package com.example.assess;
+
+/** Minimal source so the fixture registers as a Java project. */
+public final class Sample {
+    private Sample() {
+    }
+
+    public static String greet(String name) {
+        return "hello, " + name;
+    }
+}

--- a/skills/assess/tests/fixtures/maven_project/dependency-analyze-output.txt
+++ b/skills/assess/tests/fixtures/maven_project/dependency-analyze-output.txt
@@ -1,0 +1,15 @@
+[INFO] Scanning for projects...
+[INFO]
+[INFO] -------------< com.example.assess:synthetic-maven-fixture >-------------
+[INFO] Building synthetic-maven-fixture 1.0.0
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO]
+[INFO] --- maven-dependency-plugin:3.6.1:analyze (default-cli) @ synthetic-maven-fixture ---
+[WARNING] Used undeclared dependencies found:
+[WARNING]    org.slf4j:slf4j-api:jar:2.0.12:compile
+[WARNING] Unused declared dependencies found:
+[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
+[WARNING]    com.google.guava:guava:jar:33.0.0-jre:compile
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------

--- a/skills/assess/tests/fixtures/maven_project/pom.xml
+++ b/skills/assess/tests/fixtures/maven_project/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic Maven fixture for issue #113 signal-consumption tests.
+
+  Exercises the capability-driven offer flow:
+    * a configured maven-checkstyle-plugin  -> linting is CREDITED, not re-offered
+    * no SpotBugs / PMD / error-prone        -> linting still credited (Checkstyle)
+    * no OpenRewrite / Modernizer            -> modernization HONEST-DEGRADES
+    * no jdeps wiring                         -> module_graph HONEST-DEGRADES
+    * pom.xml present, mvn liveness           -> liveness OFFER (run-consent)
+  This pom is deliberately not built by CI; tests feed canned analyze output.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.assess</groupId>
+  <artifactId>synthetic-maven-fixture</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.0.0-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.12</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- A configured analysis tool: /assess must CREDIT this, not re-offer linting. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <configLocation>checkstyle.xml</configLocation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/skills/assess/tests/test_jvm_capabilities.py
+++ b/skills/assess/tests/test_jvm_capabilities.py
@@ -1,0 +1,223 @@
+"""Signal-consumption tests for the capability-driven JVM offer flow (#113).
+
+The CI contract is *signal consumption*: given a tool's output (canned
+``mvn dependency:analyze`` text), the deterministic core feeds the scorecard
+correctly. The agent's runtime tool *choice* is human-judged and not tested
+here. A synthetic Maven fixture under ``tests/fixtures/maven_project/`` stands in
+for the real Helidon repo CI cannot reach.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.jvm_capabilities import (
+    count_used_undeclared,
+    detect_build_system,
+    detect_configured_plugins,
+    parse_dependency_analyze,
+    scan_jvm_capabilities,
+)
+from lib.liveness_scan import scan_liveness
+
+FIXTURE = Path(__file__).parent / "fixtures" / "maven_project"
+
+
+def _write(root: Path, rel: str, text: str = "x") -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _analyze_output() -> str:
+    return (FIXTURE / "dependency-analyze-output.txt").read_text(encoding="utf-8")
+
+
+# ── parsing dependency:analyze (the consumed signal) ───────────────────────
+
+def test_parse_dependency_analyze_extracts_unused_declared() -> None:
+    candidates = parse_dependency_analyze(_analyze_output(), pom_path="pom.xml")
+    symbols = {c["symbol"] for c in candidates}
+    assert symbols == {
+        "org.apache.commons:commons-lang3",
+        "com.google.guava:guava",
+    }
+    # Used-undeclared (slf4j) is NOT a liveness dead-weight candidate.
+    assert "org.slf4j:slf4j-api" not in symbols
+    for c in candidates:
+        assert c["kind"] == "unused declared dependency"
+        assert c["path"] == "pom.xml"
+
+
+def test_used_undeclared_counted_but_not_a_candidate() -> None:
+    assert count_used_undeclared(_analyze_output()) == 1
+
+
+def test_parse_empty_output_is_no_candidates() -> None:
+    assert parse_dependency_analyze("[INFO] BUILD SUCCESS\n") == []
+
+
+def test_parse_stops_at_section_boundary() -> None:
+    # An unused block followed by a non-coordinate line must not bleed into it.
+    text = (
+        "[WARNING] Unused declared dependencies found:\n"
+        "[WARNING]    a.b:c:jar:1.0:compile\n"
+        "[INFO] BUILD SUCCESS\n"
+        "    d.e:f:jar:2.0:compile\n"  # outside the block - ignored
+    )
+    syms = {c["symbol"] for c in parse_dependency_analyze(text)}
+    assert syms == {"a.b:c"}
+
+
+# ── build-system detection ─────────────────────────────────────────────────
+
+def test_detect_maven_in_fixture() -> None:
+    system, files = detect_build_system(FIXTURE)
+    assert system == "maven"
+    assert "pom.xml" in files
+
+
+def test_detect_gradle(tmp_path: Path) -> None:
+    _write(tmp_path, "build.gradle", "plugins { id 'java' }")
+    _write(tmp_path, "src/Main.java", "class Main {}")
+    system, files = detect_build_system(tmp_path)
+    assert system == "gradle"
+    assert "build.gradle" in files
+
+
+def test_maven_wins_over_gradle_when_both_present(tmp_path: Path) -> None:
+    _write(tmp_path, "pom.xml", "<project/>")
+    _write(tmp_path, "build.gradle", "plugins {}")
+    system, _ = detect_build_system(tmp_path)
+    assert system == "maven"
+
+
+def test_detect_none_for_non_jvm(tmp_path: Path) -> None:
+    _write(tmp_path, "main.py", "x = 1")
+    system, files = detect_build_system(tmp_path)
+    assert system is None
+    assert files == []
+
+
+def test_fixture_pom_excluded_when_under_tests_fixtures(tmp_path: Path) -> None:
+    # A pom under tests/fixtures/ must not make a repo look like a Maven project
+    # (the auto-exclude that keeps the assess run-context baseline stable).
+    _write(tmp_path, "tests/fixtures/sample/pom.xml", "<project/>")
+    system, _ = detect_build_system(tmp_path)
+    assert system is None
+
+
+# ── plugin crediting ───────────────────────────────────────────────────────
+
+def test_configured_checkstyle_is_credited() -> None:
+    served = detect_configured_plugins(FIXTURE, ["pom.xml"])
+    assert served.get("linting") == ["Checkstyle"]
+    # Nothing configures modernization in the fixture.
+    assert "modernization" not in served
+
+
+def test_error_prone_compiler_arg_credits_linting(tmp_path: Path) -> None:
+    _write(tmp_path, "pom.xml",
+           "<project><build><plugins><plugin>"
+           "<artifactId>maven-compiler-plugin</artifactId>"
+           "<configuration><annotationProcessorPaths><path>"
+           "<artifactId>error_prone_core</artifactId></path>"
+           "</annotationProcessorPaths></configuration>"
+           "</plugin></plugins></build></project>")
+    served = detect_configured_plugins(tmp_path, ["pom.xml"])
+    assert served.get("linting") == ["error-prone"]
+
+
+# ── capability scan: states ────────────────────────────────────────────────
+
+def test_maven_liveness_offers_run_consent_when_mvn_present() -> None:
+    result = scan_jvm_capabilities(FIXTURE, mvn_on_path=True)
+    liveness = result["capabilities"]["liveness"]
+    assert liveness["state"] == "offer"
+    assert liveness["consent"] == "run"
+    assert liveness["candidate_tool"] == "mvn dependency:analyze"
+
+
+def test_maven_liveness_offers_install_consent_when_mvn_absent() -> None:
+    result = scan_jvm_capabilities(FIXTURE, mvn_on_path=False)
+    liveness = result["capabilities"]["liveness"]
+    assert liveness["state"] == "offer"
+    assert liveness["consent"] == "install"
+
+
+def test_served_liveness_feeds_candidates() -> None:
+    result = scan_jvm_capabilities(
+        FIXTURE, mvn_on_path=True, analyze_output=_analyze_output())
+    liveness = result["capabilities"]["liveness"]
+    assert liveness["state"] == "served"
+    assert liveness["candidate_count"] == 2
+    assert liveness["used_undeclared_count"] == 1
+
+
+def test_linting_credited_module_graph_and_modernization_degrade() -> None:
+    result = scan_jvm_capabilities(FIXTURE, mvn_on_path=True)
+    caps = result["capabilities"]
+    assert caps["linting"]["state"] == "credited"
+    assert caps["linting"]["served_by"] == ["Checkstyle"]
+    # Honest-degrade is a deliverable: state set AND a candidate tool named.
+    assert caps["module_graph"]["state"] == "honest_degrade"
+    assert caps["module_graph"]["candidate_tool"] == "jdeps"
+    assert caps["modernization"]["state"] == "honest_degrade"
+    assert caps["modernization"]["candidate_tool"] == "OpenRewrite"
+
+
+def test_every_capability_names_a_candidate_tool() -> None:
+    # No capability may be silently absent - each carries a candidate.
+    caps = scan_jvm_capabilities(FIXTURE, mvn_on_path=True)["capabilities"]
+    for name, cap in caps.items():
+        assert cap.get("candidate_tool"), f"{name} has no candidate tool"
+        assert cap.get("gloss"), f"{name} has no gloss"
+
+
+def test_gradle_honest_degrades_liveness(tmp_path: Path) -> None:
+    _write(tmp_path, "build.gradle", "plugins { id 'java' }")
+    _write(tmp_path, "src/Main.java", "class Main {}")
+    result = scan_jvm_capabilities(tmp_path, mvn_on_path=True)
+    assert result["build_system"] == "gradle"
+    liveness = result["capabilities"]["liveness"]
+    assert liveness["state"] == "honest_degrade"
+    assert liveness["candidate_tool"] == "mvn dependency:analyze"
+
+
+def test_non_jvm_repo_reports_unavailable(tmp_path: Path) -> None:
+    _write(tmp_path, "main.py", "x = 1")
+    result = scan_jvm_capabilities(tmp_path)
+    assert result == {"available": False, "build_system": None, "build_files": []}
+
+
+# ── integration: scan_liveness merges JVM signal ───────────────────────────
+
+def test_scan_liveness_attaches_jvm_block_and_offer_tool() -> None:
+    result = scan_liveness(FIXTURE, run_dead_code=False)
+    assert "jvm_capabilities" in result
+    java_tools = [t for t in result["dead_code"]["tools"]
+                  if t.get("language") == "java"]
+    assert len(java_tools) == 1
+    assert java_tools[0]["status"] == "available_not_run"
+    assert java_tools[0]["consent"] in {"run", "install"}
+
+
+def test_scan_liveness_served_merges_candidates_into_dead_code(monkeypatch) -> None:
+    # Drive the served path by stubbing the analyze run so dead_code carries the
+    # Maven candidates the runtime block (static_reachability) consumes.
+    import lib.jvm_capabilities as jc
+
+    monkeypatch.setattr(jc, "_run_dependency_analyze",
+                        lambda root: _analyze_output())
+    monkeypatch.setattr(jc.shutil, "which", lambda _: "/usr/bin/mvn")
+    result = scan_liveness(FIXTURE, run_dead_code=False, run_build_tools=True)
+    dc = result["dead_code"]
+    java_candidates = [c for c in dc["candidates"]
+                       if c["kind"] == "unused declared dependency"]
+    assert len(java_candidates) == 2
+    assert dc["available"] is True
+
+
+def test_non_jvm_scan_liveness_has_no_jvm_key(tmp_path: Path) -> None:
+    _write(tmp_path, "main.py", "x = 1")
+    result = scan_liveness(tmp_path, run_dead_code=False)
+    assert "jvm_capabilities" not in result


### PR DESCRIPTION
Closes #113

## Summary

Generalises `/assess`'s **hardcoded per-language tool allowlist** (`vulture`/`ts-prune`/`staticcheck`) into a **capability-driven detect-or-propose** flow, proven on ONE capability (liveness) in ONE build system (Maven). The defect fixed is the **non-enumeration architecture**: a repo whose language isn't enumerated silently degraded every analysis capability to "unavailable", with no resolution path inside the run. JVM is the first ecosystem to expose it.

## What's HEALED vs HONEST-DEGRADED

| Capability | v1 state | Tool |
|------------|----------|------|
| **Liveness / dead-code** | **HEALED (served)** | `mvn dependency:analyze` - coarse module-level unused-declared-dependency detection, merged into the `dead_code` signal |
| Static module graph | honest-degrade | `jdeps` (named, not served) |
| Linting | credited *or* honest-degrade | configured pom plugin credited (Checkstyle/SpotBugs/PMD/error-prone); else `Checkstyle / SpotBugs / error-prone` named |
| Modernization | credited *or* honest-degrade | `OpenRewrite` named |
| **Gradle (all capabilities)** | honest-degrade | named candidate, no served path in v1 |

**Honest-degrade is a deliverable, not a no-op** - each unserved capability is named with a candidate tool in `run-context.json`'s new `capability_offers` block, a state distinct from both "Present" and a silent "Missing".

## Changes

- **`lib/jvm_capabilities.py`** (new) - Maven/Gradle root detection, pom plugin reading (configured tools credited, not re-offered), `dependency:analyze` parsing, and the per-capability state model (`served` / `offer` / `credited` / `honest_degrade`).
- **`lib/liveness_scan.py`** - `scan_liveness` runs the JVM scan, merges served Maven liveness candidates into `dead_code`, and attaches the `jvm_capabilities` block.
- **`assess_core.py`** - surfaces `capability_offers` in `run-context.json`, gated on JVM detection so non-JVM baselines are unchanged.
- **`SKILL.md` Step 2b** - reframed as capability-driven detect-or-propose (3 moves: detect / propose / honest-degrade), with a JVM/Maven offers subsection covering the run-consent vs install-consent shapes.
- **`agents/assess-layer-scorer.md`** - Layer 1 scoring consumes `capability_offers`.

## Consent shapes

The liveness offer is a **run-consent** when `mvn` is on PATH (`dependency:analyze` needs a compiling build that resolves dependencies and may hit the network) and an **install-consent** when `mvn` is absent. The offer-flow abstraction covers both.

## Testing boundary

CI exercises **signal consumption** against a synthetic Maven fixture (`tests/fixtures/maven_project/`): given a tool's output, the scorecard feeds correctly. The agent's runtime tool *choice* (reasoned latitude for non-enumerated languages) is **human-judged, not CI-tested** - the real Helidon repo validates end-to-end locally. 21 new tests in `test_jvm_capabilities.py`.

## Risk Assessment

Low. The new block is additive and present only when a Maven/Gradle project is detected; non-JVM run-context output (and both golden baselines) are byte-for-byte unchanged. `mvn dependency:analyze` is never run by default (read-only assessment); it runs only on opt-in run-consent.

## Local verification

- `skills/assess pytest`: 525 passed, 1 skipped
- `scripts/ pytest`: 70 passed
- `plugin contract pytest`: 71 passed
- `ruff + mypy gates`: clean

Plugin version bumped to 1.24.0.