### PR TITLE
docs: strip leaked tool-envelope tags from Map-of-Content docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/agents/README.md
+++ b/agents/README.md
@@ -21,4 +21,3 @@ Orchestrated by [`/huddle`](../skills/huddle/SKILL.md) and [`/6hats`](../command
 | Agent | Role |
 |-------|------|
 | [`assess-layer-scorer`](./assess-layer-scorer.md) | Scores a codebase against the [`/assess`](../skills/assess/SKILL.md) 0-8 layered contract model, assigning Present / Partial / Missing per layer with evidence |
-</content>

--- a/commands/README.md
+++ b/commands/README.md
@@ -20,4 +20,3 @@ Slash commands shipped by the plugin. Portable framework commands work in any Cl
 | [`/tm-marathon-config-example`](./tm-marathon-config-example.md) | Reference configuration block to drop into a project's `CLAUDE.md` for marathon-mode `/tm` and `/issues` |
 
 `/tm`, `/issues`, `/fix-pr`, and `/fix-develop` share the [`marathon`](../skills/marathon/SKILL.md) and [`pr-review-merge`](../skills/pr-review-merge/SKILL.md) library skills as their single source of truth. Each command supplies a thin work-source adapter; the skills own the execution.
-</content>

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,5 +70,3 @@ The Six Thinking Hats team, indexed in [`agents/README.md`](../agents/README.md)
 - [Code review instructions](../.github/claude-review-instructions.md) - the guidelines the automated reviewer follows on pull requests.
 
 The rendered example SVGs used in the README hero (the doc-navigability graph and the complexity heatmap, before and after the action sweep) live alongside this file in `docs/`.
-</content>
-</invoke>

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -24,4 +24,3 @@ The plans and specs behind the skills, captured as they were built. These are hi
 | Spec | Subject |
 |------|---------|
 | [Issues marathon shared-skills design](./specs/2026-05-29-issues-marathon-shared-skills-design.md) | Design for `/issues` via shared marathon skills |
-</content>

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,4 +30,3 @@ Invoked by the workflow commands ([`/tm`](../commands/tm.md), [`/issues`](../com
 |-------|----------|-------------|
 | `marathon` | [`marathon/SKILL.md`](./marathon/SKILL.md) | Parallel agent marathon orchestration: DAG analysis, waves, crash recovery, retrospective |
 | `pr-review-merge` | [`pr-review-merge/SKILL.md`](./pr-review-merge/SKILL.md) | The PR review-to-green loop plus smart merge |
-</content>


### PR DESCRIPTION
## Summary

Follow-up to #120. The Map-of-Content docs merged in #120 each ended with a stray `</content>` tool-call envelope tag (and `docs/index.md` also had a `</invoke>` tag) - leaked Write-tool XML residue that renders as visible text in any non-HTML markdown viewer and ships into the standalone skill ZIPs. This strips them. Flagged as MUST FIX by the automated reviewer on #120, but #120 merged before the fix was pushed.

## Changes Made

- Removed the trailing `</content>` line from `agents/README.md`, `commands/README.md`, `skills/README.md`, `docs/superpowers/README.md`, and `docs/index.md`.
- Removed the trailing `</invoke>` line from `docs/index.md`.
- `.claude-plugin/plugin.json` - version bump to `1.24.1`.

## Technical Details

The tags were inert trailing text - all internal links still resolved and the doc-graph reachability gains from #120 are unaffected. This is purely cosmetic-residue removal so the navigation surface reads cleanly.

## Testing

- `plugin contract pytest` (`tests/test_plugin_contract.py`) - 75 passed.
- `grep -E '</content>|</invoke>'` over all five files - no matches remain.

## Risk Assessment

Documentation only, removal of stray text. No behaviour change, no link change.

Refs #112