### PR TITLE
docs: Anchor the north-star thesis (18-month-engineer) in README, CLAUDE.md, and the assess report

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,14 @@ Source for the `ai-native-toolkit` Claude Code plugin. Two portable skills (`/as
 
 The deliverable is markdown: agents, commands, skills. It also ships a Python deterministic core under `skills/assess/scripts/` (plus `lib/`) and a standalone-skill build pipeline under `scripts/`. There is no application runtime, but there are pytest suites (`skills/assess/`, `scripts/`), a ruff + mypy lint gate, and a standalone-ZIP build step - all enforced in CI.
 
+## North star
+
+Everything here serves one goal: make an AI contributor feel like an engineer who has been in the org eighteen months, not a brand-new hire. The difference is *externalized context*, not capability. An AI is structurally always the new hire - each session starts with an empty head and one narrow context window - so the codebase has to supply the tenure: a navigable map, load-bearing contracts made explicit, complexity made *locally* legible so the relevant slice fits one keyhole.
+
+The safety half is non-negotiable: the goal is **legibility you can trust, not omniscience you can't.** An agent fluent about code nobody can verify is the dangerous failure, not the win. Answers must stay anchored to code a human can spot-check.
+
+**Use this as the feature test.** Judge any change to a skill or report by: does it make a fresh agent more tenured on day one, *and* keep its answers verifiable? Prefer honest-degrade over impressive-but-wrong, local comprehension over global, and "ground the claim in the file" over a fluent narrative.
+
 ## Versioning
 
 The plugin follows [semver](https://semver.org). Version lives in `.claude-plugin/plugin.json` under `.version`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A Claude Code plugin: skills, agents, and commands for AI-native development. Ru
 
 > **New here?** The [Map of Content](docs/index.md) is the navigation index - one trail to every skill, command, agent, and design doc in this repo. The [`CLAUDE.md`](CLAUDE.md) contract holds the rules for editing it.
 
+## Why this exists
+
+When you hand work to an AI, does it behave like a brand-new hire, or like an engineer who has been in the org eighteen months? The difference isn't capability - both can write correct code. It's *externalized context*: knowing where things live, which contracts are load-bearing, where the minefields are, and why the weird thing is weird. An AI contributor is structurally always the new hire - every session starts with an empty head, seeing the codebase through one narrow context window. So the whole question becomes: **how much of the tenured engineer's implicit map has the codebase made explicit and navigable?** The more it has, the more a fresh agent behaves like it has been here eighteen months.
+
+The aim is not an AI that comprehends complexity humans no longer can, trusted blindly - an agent fluent about code nobody can verify is the dangerous case, not the goal. The aim is a codebase legible enough that the *relevant slice* fits one context window, where the agent's answers stay anchored to code you can still check in ten seconds. **Legibility you can trust, not omniscience you can't.** `/assess` measures the distance to that.
+
 The headline pieces are three **skills**:
 
 - **`/assess`** - score any codebase's readiness for AI agent contributors against an 8-layer contract model (navigability, runtime liveness, code design, linters, architecture tests, CI, coverage, review bots, AI project management), with a Codecov-style complexity hotspot SVG and a doc-navigability graph SVG (both colour-blind-safe). Generates a report + the two SVGs and opens a PR in the target repo.

--- a/skills/assess-findings/SKILL.md
+++ b/skills/assess-findings/SKILL.md
@@ -54,6 +54,8 @@ _Generated <YYYY-MM-DD>._
 
 ## How to read this report
 
+**What this is ultimately measuring.** When you hand work to an AI here, does it behave like a brand-new hire or like an engineer who has been in the org eighteen months? The difference isn't capability - it's *externalized context*: knowing where things live, which contracts are load-bearing, where the minefields are. An AI contributor is structurally always the new hire - it starts every session with an empty head, seeing one narrow slice through its context window - so this report scores how much of the tenured engineer's implicit map the codebase has made explicit and navigable. The aim is not an AI that comprehends what humans no longer can and is trusted blindly (that is the dangerous case); it is a codebase legible enough that the relevant slice fits one context window and the agent's answers stay anchored to code you can still verify. **Legibility you can trust, not omniscience you can't.**
+
 This is an improvement roadmap, not a verdict. It measures one thing: **is the codebase kept honest, not just scaffolded.** It pairs three views:
 
 - **Where the codebase is today** — the complexity heatmap shows current complexity and churn. Vivid red = complex AND actively changing = the files most likely to bite an agent (or a human) next week.


### PR DESCRIPTION
## Summary

Makes the toolkit's guiding aim explicit and durable across the three surfaces a reader meets it: the repo front door (README), the contract agents edit under (CLAUDE.md), and the artifact `/assess` produces for other repos (the report).

The thesis: when you hand work to an AI, does it behave like a brand-new hire or an engineer who has been in the org eighteen months? The difference is *externalized context*, not capability. An AI contributor is structurally always the new hire - empty head, one narrow context window per session - so the codebase must supply the tenure. `/assess` measures the distance to that.

Paired with the non-negotiable safety half: **legibility you can trust, not omniscience you can't.** The goal is a locally-legible codebase whose agent answers stay anchored to verifiable code - not an AI trusted blindly on code no human can check.

## Changes Made

- **README.md** - new `## Why this exists` section after the Map-of-Content callout.
- **CLAUDE.md** - new `## North star` section, framed as the feature test: judge any change by whether it makes a fresh agent more tenured on day one *and* keeps its answers verifiable.
- **skills/assess-findings/SKILL.md** - opens 'How to read this report' with the same thesis, so every generated report carries it (it complements the existing legacy-transition lens, which already asks 'what happens when the people who understood the code are gone').
- **.claude-plugin/plugin.json** - 1.24.2 -> 1.24.3 (doc-only, PATCH).

## Testing

- `tests/test_plugin_contract.py`: 138 passed.
- `plugin.json` parses; version bumped per the same-PR rule.

## Risk Assessment

Documentation and prose only; no code paths, scripts, or skill behaviour changed. The report edit adds a leading framing paragraph and does not touch the deterministic findings section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.24.3.

* **Documentation**
  * Added guiding principles for code edit operations emphasizing legibility and verifiability.
  * Added explanation of the toolkit's core motivation and external context framing.
  * Clarified what assessment measurements indicate regarding codebase trustworthiness for AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->