### PR TITLE
fix: address skill-forge review feedback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/docs/superpowers/plans/2026-06-02-skill-forge.md
+++ b/docs/superpowers/plans/2026-06-02-skill-forge.md
@@ -21,7 +21,7 @@
 
 ## File Structure
 
-```
+```text
 skills/skill-forge/
   SKILL.md                              # orchestrator: roles, loop, gate, modes, bootstrap, guards
   references/

--- a/docs/superpowers/specs/2026-06-02-skill-forge-design.md
+++ b/docs/superpowers/specs/2026-06-02-skill-forge-design.md
@@ -123,10 +123,12 @@ each one before round 1. Fidelity never judges against an unconfirmed ASSUMED cl
 
 ## The judge panel: five lenses
 
-Huddle's professional lenses, repointed at skill quality. The panel scales **2 -> 3 -> 5**
-lenses by stakes (huddle's Fibonacci team-sizing, capped at the five lenses below): 2 for a
-quick check, 3 for the default forge, all 5 for a deep one. Confidence is **not** a lens - it
-is the stopping decision in Gate 2, not an artifact perspective.
+Huddle's professional lenses, repointed at skill quality. The panel runs **all five by
+default**; the lead drops to 3 (Fidelity, Adversarial, Usability) for an explicit quick check
+or 2 for a fast gut check, and a self-forge always uses all five. (This default was reconciled
+from 3 to 5 during skill-forge's own self-forge, which found that a 3-lens default silently
+dropped the Compression and Trigger lenses - see the shipped example forge report.) Confidence
+is **not** a lens - it is the stopping decision in Gate 2, not an artifact perspective.
 
 **Behavioural vs static evidence.** Four lenses judge runner *transcripts* - observed
 behaviour. The fifth, Trigger/routing, judges the skill *text* directly, because

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -194,6 +194,11 @@ class TestSkillForge:
         skill_md = forge_zip.read("skill-forge/SKILL.md").decode("utf-8")
         assert "name: skill-forge" in skill_md
 
+    def test_zip_is_deterministic(self, tmp_path):
+        zf1 = _build("skill-forge", tmp_path / "run1")
+        zf2 = _build("skill-forge", tmp_path / "run2")
+        assert Path(zf1.filename).read_bytes() == Path(zf2.filename).read_bytes()
+
 
 # ── deslop ──────────────────────────────────────────────────────────────────
 

--- a/skills/skill-forge/SKILL.md
+++ b/skills/skill-forge/SKILL.md
@@ -97,11 +97,11 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 
 The team lifecycle follows `marathon`'s idioms - the lead delegates and never executes, runner teammates are ephemeral (spawned per round, shut down after), and the judge panel is the one persistent team. As illustrative text (do not treat the snippets below as live tool calls):
 
-```
+```text
 TeamCreate(team_name: "forge-<skill-slug>", description: "skill-forge panel for <skill>")
 ```
 
-```
+```text
 # spawn one judge per active lens (persistent) and one runner per test case (ephemeral)
 Agent(subagent_type: "general-purpose", team_name: "forge-<skill-slug>", name: "fidelity", prompt: "<lens brief>")
 ```

--- a/skills/skill-forge/references/runner-prompt.md
+++ b/skills/skill-forge/references/runner-prompt.md
@@ -6,7 +6,7 @@ The lead fills this template per runner - one runner per test case per round. Th
 
 ## Template
 
-```
+```text
 You are a test runner. Apply the following skill to the following input, exactly
 as the skill instructs.
 


### PR DESCRIPTION
## Summary

Follow-up to #127 addressing the CodeRabbit review feedback (the PR had already merged, so these land separately).

## Changes

- **Spec/contract reconciliation (the one that mattered).** The design spec still said the default forge uses 3 lenses, but the shipped contracts (`SKILL.md` + `judge-lenses.md`) define the default as all 5 - a change the skill's *own self-forge* made when it found that a 3-lens default silently dropped the Compression and Trigger lenses. Updated the spec to default-5 with a provenance note pointing to the example forge report.
- **MD040 fence tags.** Added `text` language tags to four unlabelled code fences: the plan's file-structure block, the runner-prompt template, and the two illustrative `TeamCreate`/`Agent` snippets in `SKILL.md`.
- **Deterministic ZIP test.** Added `test_zip_is_deterministic` to `TestSkillForge`, matching the existing `assess`/`deslop` build-parity checks.
- Version bump to 1.25.1 (PATCH - docs + test).

## Testing

- Standalone suite: 86 passed (TestSkillForge now 13, including the new parity test).
- Plugin contract suite: 154 passed.
- `bash scripts/build-standalone-skills.sh skill-forge` builds clean.

## Risk

Doc + test only. No skill behaviour change - the contracts already shipped default-5; this aligns the spec to them.