### PR TITLE
feat: Add A/B equivalence capability to skill-forge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress compresses LLM-directed instructions by pointing at core knowledge the model already holds and keeping project-specific detail verbatim. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/skill-forge/SKILL.md
+++ b/skills/skill-forge/SKILL.md
@@ -72,6 +72,10 @@ One change per round isolates a single hypothesis, so every round's delta is cau
 
 A strict hierarchy, not a menu: **Gate 1 - Objective** (every case passes Fidelity; hard), **Gate 2 - Panel confidence** (all green and no `HIGH`-severity dissent), **Gate 3 - Diminishing returns** (the round produced measurable gain), and the **budget** escape hatch that always terminates. Promote if and only if Gate 1 and Gate 2 both pass; otherwise stop with the best-so-far artifact and a report naming the unmet gate. The Gate 1 Fidelity bar, the Gate 3 "measurable gain" rule, and the promotion decision are spelled out in [gate-hierarchy](references/gate-hierarchy.md).
 
+## A/B equivalence (library capability for other skills)
+
+A thin, transform-agnostic capability that compares two versions of a document (original = teacher, candidate = student) across a transfer set and returns per-case `equivalent | candidate-regressed | candidate-diverged` verdicts plus a per-case efficiency signal - it answers "does the candidate still do what the original did?", not "is this skill good?". It reuses the runner unchanged and adds one focused compare-two-transcripts judge, separate from the five lenses; it is a **library capability other skills compose** (e.g. `semantic-compress` gates a distillation on it, as `marathon` composes `pr-review-merge`) and does **not** change the forge's own five-lens gate hierarchy above. Contract and schema: [ab-equivalence](references/ab-equivalence.md); the judge prompt: [equivalence-judge-prompt](references/equivalence-judge-prompt.md).
+
 ## Execution modes
 
 <!-- chat-skip:start -->

--- a/skills/skill-forge/references/ab-equivalence.md
+++ b/skills/skill-forge/references/ab-equivalence.md
@@ -1,0 +1,103 @@
+# A/B equivalence - a transform-agnostic behavioural-equivalence capability
+
+A thin capability that compares two versions of an LLM-directed document - an `original` (the teacher) and a `candidate` (the student) - across a transfer set, and returns a per-case verdict on whether the candidate still induces the behaviour the original induced.
+
+It is **transform-agnostic**: it judges *behavioural equivalence between two versions* and neither knows nor cares which transform produced the candidate. It therefore serves every optimizer transform that claims to preserve behaviour - compression today, directive-clarity next - not just compression. It is a **library capability** other skills compose (as `marathon` composes `pr-review-merge`): `semantic-compress` invokes it to gate a distillation. It does **not** change skill-forge's own five-lens quality gate hierarchy - that hierarchy judges *absolute quality* ("is this skill good?"); A/B equivalence judges *sameness between two versions* ("does the candidate still do what the original did?"). They are different questions answered by different judges.
+
+## Input contract
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| `original` | yes | Path to the teacher document - the version whose behaviour is the equivalence target. |
+| `candidate` | yes | Path to the student document - the transformed version under test. |
+| `transfer_set` | yes | Array of cases drawn from the skill-forge test taxonomy (happy / edge / adversarial / composition - see `test-taxonomy.md`). The transfer set *is* the operational definition of the behaviour being preserved, so its breadth bounds the safety of the conclusion. |
+
+The caller (e.g. `semantic-compress`) owns deriving and confirming the transfer set; this capability consumes it. A thin transfer set yields a weak equivalence claim - the caller is responsible for flagging coverage, and the output records it.
+
+## Mechanism
+
+For each case in the transfer set:
+
+1. Run the **existing** runner (`runner-prompt.md`, unchanged - the same pure-wrapper prompt the forge loop uses) once with `original` as the skill draft, on the case input, producing the **teacher transcript**.
+2. Run the same runner once with `candidate` as the skill draft, on the **identical** case input, producing the **candidate transcript**.
+3. Hand both transcripts to the **equivalence judge** (`equivalence-judge-prompt.md` - a focused compare-two-transcripts judge, separate from the five quality lenses), which emits the per-case verdict and efficiency signal.
+
+The runner and runner-prompt are reused verbatim; nothing about how a single version is executed changes. The only new component is the equivalence judge, which compares two transcripts rather than scoring one against an intent.
+
+### Baseline caching (the teacher is captured once)
+
+The `original` never changes across a multi-round transform loop, so its transcript per case is **captured once and reused across every round**. Only the candidate is re-run each round. This is a hard rule, not an optimization: re-running the teacher each round wastes runner budget and risks introducing teacher-side noise that the judge would mistake for a candidate change. The caller passes the cached teacher transcripts back in on rounds >= 2; this capability re-runs only the candidate. A budget ceiling on candidate re-runs belongs to the caller's loop, not here.
+
+<!-- chat-skip:start -->
+Execution follows the same mode selection as the forge loop (see SKILL.md): the runner pair per case can be spawned as parallel runner subagents (phased mode) or worked sequentially by a single agent (solo mode). The equivalence judge runs as one more focused judge in whatever mode the harness is in. No persistent team is required - the judge holds no across-round memory of its own; the cached teacher transcript is the only state carried between rounds, and the caller owns it.
+<!-- chat-skip:end -->
+
+## Verdict categories
+
+Per case, the judge returns exactly one verdict:
+
+| Verdict | Meaning | What it must cite |
+|---------|---------|-------------------|
+| `equivalent` | The candidate induced every behaviour and discipline the original induced. Incidental wording differences with no behavioural consequence are still `equivalent`. | Nothing required beyond the verdict. |
+| `candidate-regressed` | A behaviour or discipline the original induced is **absent** in the candidate. This is the failing verdict. | The **specific behaviour lost** - the discipline, step, or output the original produced and the candidate did not. |
+| `candidate-diverged` | The candidate behaves **differently** but no behaviour the original induced was lost - a different-but-not-worse change (including incidental improvements). | The **difference** - what the candidate did differently. Not necessarily worse; documented for the caller's judgement. |
+
+The regressed-vs-diverged decision rule is the load-bearing distinction and is stated authoritatively in `equivalence-judge-prompt.md`:
+
+- **regressed** = a behaviour or discipline the original induced is **missing** from the candidate (essence lost).
+- **diverged** = the candidate did something **different**, but every behaviour the original induced is **still present** (nothing lost).
+
+When uncertain whether a delta is a loss or merely a difference, the judge defaults to `candidate-regressed` - a false regression costs one add-back round; a false `equivalent` ships a behaviour-losing transform undetected.
+
+## Efficiency signal (alongside every verdict)
+
+Independent of the verdict, the judge records an **efficiency signal** per case - how directly the runner acted on each version versus how much it had to unpack or reinterpret the instruction before acting:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `original_directness` | integer 1-5 | How directly the runner acted on the **original**: 5 = acted immediately, no reinterpretation; 1 = had to unpack, infer, or work around the instruction heavily before acting. |
+| `candidate_directness` | integer 1-5 | The same measure for the **candidate**. |
+| `interpretation_notes` | string | What the runner had to unpack or reinterpret on each version - the qualitative evidence behind the two scores. |
+
+The signal is read from the runner self-report (`runner-prompt.md`): *steps followed / skipped*, *ambiguities hit and how resolved*, *improvisation beyond the skill*, and *any point it wanted to deviate but followed literally* all reveal how much interpretive work each version forced.
+
+Why it exists: compression's gate is **strict no-regression** (sameness alone). But the optimizer family includes transforms that claim *behaviour-preserving-but-lighter* - the next one, directive-clarity, rewrites instructions the model has to unpack into directives that name the action. Such a transform can only be validated if the harness **measures the lightness, not just the sameness**: its gate is no-regression **and** a measured efficiency gain (`candidate_directness` > `original_directness` with no `candidate-regressed`). Recording the signal here, on every A/B run, is what lets those future transforms prove a measured gain instead of asserting one. Compression ignores the gain and gates on no-regression alone; both read the same signal.
+
+## Output schema
+
+```json
+{
+  "cases": [
+    {
+      "case_id": "string",
+      "verdict": "equivalent|candidate-regressed|candidate-diverged",
+      "behaviour_delta": "string",
+      "efficiency_signal": {
+        "original_directness": 1,
+        "candidate_directness": 1,
+        "interpretation_notes": "string"
+      }
+    }
+  ],
+  "summary": {
+    "pass": true,
+    "regressions": 0,
+    "divergences": 0,
+    "equivalents": 0
+  }
+}
+```
+
+- `case_id` - the transfer-set case identifier.
+- `verdict` - one of the three categories above.
+- `behaviour_delta` - for `candidate-regressed`, the specific behaviour lost; for `candidate-diverged`, the difference observed; empty (or `""`) for `equivalent`.
+- `efficiency_signal` - the per-case directness scores and notes described above.
+- `summary.regressions` / `divergences` / `equivalents` - counts of each verdict across `cases`.
+- **`summary.pass` is `true` if and only if zero cases are `candidate-regressed`.** Divergences do not fail the run - they are surfaced for the caller's judgement. This encodes the strict no-regression gate: the candidate is accepted only when it loses nothing.
+
+## What this capability does not do
+
+- It does not derive or confirm the transfer set - the caller does, and signs off on coverage.
+- It does not decide whether the candidate is good in absolute terms - that is the five-lens forge gate, a different run.
+- It does not add back lost behaviour or regenerate candidates - on a regression it names what was lost; the caller's loop acts on that.
+- It does not gate on the efficiency signal - it records it. Whether a measured efficiency gain is required is the calling transform's gate, not this capability's.

--- a/skills/skill-forge/references/equivalence-judge-prompt.md
+++ b/skills/skill-forge/references/equivalence-judge-prompt.md
@@ -1,0 +1,113 @@
+# The equivalence-judge prompt
+
+A focused compare-two-transcripts judge, separate from the five quality lenses. The five lenses score one transcript against an intent ("is this skill good?"); this judge compares **two** transcripts against each other ("does the candidate still do what the original did?"). It is the only new component A/B equivalence adds - the runner and runner-prompt are reused unchanged.
+
+It is filled once per transfer-set case: drop in the case input, the teacher transcript, and the candidate transcript, and send it to a fresh-context judge. The judge emits one structured verdict per case, conforming to the output schema in `ab-equivalence.md`.
+
+## The comparison rubric
+
+The judge does **not** read the two transcripts for prose similarity - textual sameness is irrelevant. It compares them on three behavioural dimensions, drawn from the runner self-report fields (`runner-prompt.md`):
+
+1. **Outputs produced.** Did the candidate produce every output the original produced (the *output produced* field on both)? An output the original produced and the candidate did not is a loss.
+2. **Disciplines enforced.** Did the candidate enforce every discipline, rule, or guard the original enforced (read from *steps followed / skipped*, *improvisation beyond the skill*, and *any point it wanted to deviate but followed literally*)? A discipline the original held the runner to and the candidate let slide is a loss.
+3. **Steps followed.** Did the candidate lead the runner through the same load-bearing steps in a behaviourally-equivalent order (read from *steps followed / skipped*)? A step the original induced and the candidate dropped is a loss; a re-ordering with no behavioural consequence is not.
+
+A behaviour counts as *induced by the original* only if it actually appears in the teacher transcript - the judge compares observed behaviour to observed behaviour, never the candidate against what the original document *says* it should do. (That latter question is Fidelity's, judged against intent, not this judge's.)
+
+## The regressed-vs-diverged decision rule
+
+The single load-bearing decision. Apply it after the three-dimension comparison:
+
+- **`candidate-regressed`** - on any of the three dimensions, a behaviour, discipline, output, or step that the original **induced** is **absent** from the candidate transcript. Essence lost. Cite the specific behaviour lost in `behaviour_delta`. This is the only failing verdict.
+- **`candidate-diverged`** - the candidate did something **different** on some dimension, but **every** behaviour the original induced is **still present** in the candidate transcript. Nothing the original did was lost; the candidate merely also did something else, or did it differently (including doing it *better*). Cite the difference in `behaviour_delta`. Not a failure - surfaced for the caller's judgement.
+- **`equivalent`** - the candidate induced every behaviour the original induced and introduced no behaviourally-significant difference. Incidental wording differences with no behavioural consequence are `equivalent`, not `diverged`. `behaviour_delta` is empty.
+
+Decision order: first check for any loss (a behaviour present in the teacher transcript, absent in the candidate). **If any loss exists, the verdict is `candidate-regressed`** - even if the candidate also improved elsewhere; a regression is never excused by an unrelated gain. Only if there is no loss do you choose between `diverged` (a behaviourally-significant difference remains) and `equivalent` (none does).
+
+**Tie-break toward regression.** When you cannot decide whether a delta is a genuine loss or merely a difference, default to `candidate-regressed`. A false regression costs the caller one add-back round; a false `equivalent` ships a behaviour-losing transform undetected. The asymmetry is deliberate - the strict no-regression gate is only as trustworthy as this judge's conservatism.
+
+## The efficiency signal
+
+Alongside the verdict, score how directly the runner acted on each version - independent of whether behaviour was preserved:
+
+- `original_directness` (1-5): how directly the runner acted on the **original** - 5 = acted immediately with no reinterpretation; 1 = had to unpack, infer, or work around the instruction heavily before acting.
+- `candidate_directness` (1-5): the same measure for the **candidate**.
+- `interpretation_notes`: what the runner had to unpack or reinterpret on each version, citing the *ambiguities hit*, *improvisation*, and *wanted to deviate but followed literally* self-report fields as evidence.
+
+Score directness from how much interpretive work each transcript shows the runner doing **before** it could act - not from document length. A shorter document that forced more reinterpretation is *less* direct, not more. The verdict and the efficiency signal are independent: a candidate can be `equivalent` yet more direct (the case a lightness-claiming transform needs), or `equivalent` with no directness change (the typical compression case).
+
+## Structured output
+
+Emit one object per case, conforming to the `cases[]` element schema in `ab-equivalence.md`:
+
+```json
+{
+  "case_id": "string",
+  "verdict": "equivalent|candidate-regressed|candidate-diverged",
+  "behaviour_delta": "string",
+  "efficiency_signal": {
+    "original_directness": 1,
+    "candidate_directness": 1,
+    "interpretation_notes": "string"
+  }
+}
+```
+
+- `behaviour_delta`: the specific behaviour lost (`candidate-regressed`), the difference observed (`candidate-diverged`), or empty (`equivalent`).
+- Every field is required; a missing field makes the case unjudgeable. The caller aggregates these into the run-level `summary` (`pass` = zero `candidate-regressed`).
+
+## Template
+
+```text
+You are an equivalence judge. You compare two runner transcripts produced from
+the SAME input by two versions of a document - an ORIGINAL (teacher) and a
+CANDIDATE (student) - and decide whether the candidate still induces the
+behaviour the original induced. You are NOT scoring quality, and NOT comparing
+either transcript against what the document says it should do. You compare
+observed behaviour to observed behaviour.
+
+--- TEST-CASE INPUT (identical for both runs) ---
+<the case input both runners received>
+--- END TEST-CASE INPUT ---
+
+--- TEACHER TRANSCRIPT (from the ORIGINAL document) ---
+<the original version's runner transcript and self-report>
+--- END TEACHER TRANSCRIPT ---
+
+--- CANDIDATE TRANSCRIPT (from the CANDIDATE document) ---
+<the candidate version's runner transcript and self-report>
+--- END CANDIDATE TRANSCRIPT ---
+
+Compare on three dimensions: outputs produced, disciplines enforced, steps
+followed. Then apply the decision rule:
+
+- candidate-regressed: any behaviour/discipline/output/step the TEACHER
+  transcript shows is ABSENT from the candidate. Essence lost. The only failing
+  verdict. Cite the specific behaviour lost.
+- candidate-diverged: the candidate did something different, but EVERY behaviour
+  the teacher induced is still present. Nothing lost. Cite the difference.
+- equivalent: every teacher behaviour present, no behaviourally-significant
+  difference. Empty behaviour_delta.
+
+Check for loss FIRST: any loss => candidate-regressed, even alongside an
+unrelated gain. When unsure whether a delta is loss or mere difference, default
+to candidate-regressed.
+
+Also score the efficiency signal (independent of the verdict): how directly the
+runner acted on each version (1-5), from how much it had to unpack/reinterpret
+before acting - read the ambiguities, improvisation, and wanted-to-deviate
+fields. Not from document length.
+
+Emit exactly this JSON object (all fields required):
+
+{
+  "case_id": "<this case's id>",
+  "verdict": "equivalent | candidate-regressed | candidate-diverged",
+  "behaviour_delta": "<behaviour lost | difference observed | empty>",
+  "efficiency_signal": {
+    "original_directness": <1-5>,
+    "candidate_directness": <1-5>,
+    "interpretation_notes": "<what each version forced the runner to unpack>"
+  }
+}
+```


### PR DESCRIPTION
## Summary

Adds a thin, transform-agnostic **A/B equivalence** capability to `skill-forge` (TM task #1 of the `semantic-compress-v2` marathon). It compares two versions of an LLM-directed document - an `original` (teacher) and a `candidate` (student) - across a transfer set and returns per-case behavioural-equivalence verdicts plus a per-case efficiency signal.

This is a **library capability** that `semantic-compress` (later waves) composes to gate a distillation on strict no-regression A/B evidence - exactly as `marathon` composes `pr-review-merge`. It does **not** change skill-forge's existing five-lens quality gate hierarchy: that hierarchy judges absolute quality ("is this skill good?"); A/B equivalence judges sameness between two versions ("does the candidate still do what the original did?").

## Changes Made

- **`skills/skill-forge/references/ab-equivalence.md`** (new) - input contract (`original`, `candidate`, `transfer_set`), mechanism (reuses the existing runner verbatim, once per version per case, then a focused equivalence judge), explicit baseline caching (teacher captured once, reused across rounds), verdict categories (`equivalent | candidate-regressed | candidate-diverged`), the per-case efficiency signal (`original_directness`/`candidate_directness`/`interpretation_notes`), and the output schema. `summary.pass` is true iff zero `candidate-regressed`.
- **`skills/skill-forge/references/equivalence-judge-prompt.md`** (new) - a focused compare-two-transcripts judge, separate from the five lenses, with a three-dimension comparison rubric (outputs produced, disciplines enforced, steps followed), an explicit regressed-vs-diverged decision rule (regressed = a behaviour the original induced is absent; diverged = different but nothing lost), a conservative tie-break toward regression, and the structured output template.
- **`skills/skill-forge/SKILL.md`** - one-line mode entry marking the capability as a library capability for composition by other skills; preserves the existing gate hierarchy.
- **`.claude-plugin/plugin.json`** - version bump 1.26.0 -> 1.27.0.

## Technical Details

- **Transform-agnostic + efficiency signal**: the judge knows nothing about which transform produced the candidate, so it serves every optimizer transform. Alongside the equivalence verdict it records how directly the runner acted on each version vs how much it had to unpack/reinterpret - the measurement future lightness-claiming transforms (directive-clarity) need to validate a measured efficiency gain, not just sameness. Compression gates on no-regression alone; both read the same signal.
- **Standalone build markers**: agent-orchestration / runner-invocation detail in `ab-equivalence.md` is wrapped in `chat-skip` markers, mirroring how skill-forge marks its runner infra; the core contract/schema/rubric survive as standalone text.

## Testing

- `scripts/` pytest: 95 passed (standalone build + transform; the skill-forge ZIP forbidden-string and balanced-marker checks cover the new files).
- `plugin contract` pytest: 163 passed (internal-links + tool-envelope checks now cover `ab-equivalence.md` and `equivalence-judge-prompt.md`).
- `skills/assess` pytest: 534 passed, 1 skipped (markdown-only change, no assess impact).

## Risk Assessment

Low. Markdown-only addition to `skill-forge` references plus a one-line SKILL.md entry and a version bump. No change to the existing forge loop, runner prompt, or five-lens gate hierarchy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added A/B equivalence capability to compare original and candidate documents across transfer sets, returning behavioral equivalence verdicts (equivalent, regressed, diverged) and efficiency signals.

* **Documentation**
  * Added comprehensive guides for A/B equivalence functionality, including decision frameworks and behavioral comparison specifications.

* **Chores**
  * Updated plugin version to 1.27.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjcoombs/ai-native-toolkit/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->