### PR TITLE
chore: Update standalone build pipeline and docs for semantic-compress v2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress makes an LLM-directed document smaller while preserving what it does, in two modes: a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Portable (work in any Claude Code session, also shipped as standalone ZIPs):
 - [`/deslop`](../skills/deslop/SKILL.md) - detect and remove the telltale signs of AI writing. Ships an exhaustive [reference checklist](../skills/deslop/references/full-checklist.md).
 - [`/ghsync`](../skills/ghsync/SKILL.md) - bulk-clone and fast-forward sync every GitHub repo you can access across an org.
 - [`/skill-forge`](../skills/skill-forge/SKILL.md) - harden a skill through judge-panel refinement rounds to a 3-tier promotion gate; refined through its own process. Ships an [example forge report](../skills/skill-forge/references/example-forge-report.md).
-- [`/semantic-compress`](../skills/semantic-compress/SKILL.md) - compress LLM-directed instructions by pointing at core knowledge the model holds and keeping project-specific detail verbatim. Hardened by `/skill-forge`; ships its [forge report](../skills/semantic-compress/references/forge-report.md).
+- [`/semantic-compress`](../skills/semantic-compress/SKILL.md) - compress LLM-directed instructions by pointing at core knowledge the model holds and keeping project-specific detail verbatim. Two modes: a local span-level core->pointer pass, and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill. Hardened by `/skill-forge`; ships its [forge report](../skills/semantic-compress/references/forge-report.md).
 
 Team-orchestration library skills (invoked by the workflow commands, not standalone):
 

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -240,8 +240,12 @@ SKILLS: dict[str, dict] = {
         # Distill mode references the runner harness + skill-forge's A/B
         # equivalence capability (plugin-only). The chat-replace swaps the
         # distill-availability line for an honest degrade note so the ZIP states
-        # distill mode needs the Claude Code CLI; Local Mode ships unchanged.
-        "exclude_dirs": set(),
+        # distill mode needs the Claude Code CLI; Local Mode ships unchanged. The
+        # distill reference docs (distill-loop, transfer-set-design,
+        # distillation-report-template) ride along under references/; their
+        # team/subagent spawn mechanics are wrapped in chat-skip so only the
+        # methodology survives, never a Claude-Code-only tool.
+        "exclude_dirs": {"tests", "__pycache__", ".pytest_cache", ".venv"},
         "replacements": {
             "distill-availability": (
                 "**Distill mode is not available in this standalone build.** It requires the "

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -246,6 +246,31 @@ class TestSemanticCompressBuild:
     def test_forge_report_present(self, sc_zip):
         assert "semantic-compress/references/forge-report.md" in sc_zip.namelist()
 
+    def test_distill_references_present(self, sc_zip):
+        # Distill mode degrades to a CLI-only note in standalone, but the three
+        # distill reference docs still ride along under references/ so the
+        # bundled SKILL.md's relative links resolve.
+        names = sc_zip.namelist()
+        for ref in (
+            "semantic-compress/references/distill-loop.md",
+            "semantic-compress/references/transfer-set-design.md",
+            "semantic-compress/references/distillation-report-template.md",
+        ):
+            assert ref in names, f"{ref} missing from ZIP"
+
+    def test_no_team_infrastructure_leaked(self, sc_zip):
+        # The distill engine docs describe spawning runner subagents (Claude
+        # Code-only); those mechanics are wrapped in chat-skip. No Claude
+        # Code-only tool name may survive into the standalone ZIP.
+        for name, content in _md_contents(sc_zip).items():
+            for tool in ("TeamCreate", "TeamDelete", "SendMessage", "TaskCreate"):
+                assert tool not in content, f"{name}: {tool} leaked"
+        # The A/B harness / skill-forge dependency must appear only in degraded
+        # form: the SKILL.md states distill mode is unavailable standalone.
+        skill_md = sc_zip.read("semantic-compress/SKILL.md").decode("utf-8")
+        assert "Distill mode is not available in this standalone build" in skill_md
+        assert "runner harness" in skill_md
+
     def test_frontmatter_name_correct(self, sc_zip):
         skill_md = sc_zip.read("semantic-compress/SKILL.md").decode("utf-8")
         assert "name: semantic-compress" in skill_md

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,7 @@ Work in any Claude Code session, and are also distributed as standalone ZIPs for
 | `/deslop` | [`deslop/SKILL.md`](./deslop/SKILL.md) | Detect and remove the telltale signs of AI writing; ships a [`references/full-checklist.md`](./deslop/references/full-checklist.md) |
 | `/ghsync` | [`ghsync/SKILL.md`](./ghsync/SKILL.md) | Bulk-clone and fast-forward sync every GitHub repo you can access across an org |
 | `/skill-forge` | [`skill-forge/SKILL.md`](./skill-forge/SKILL.md) | Harden a skill through judge-panel refinement rounds to a 3-tier promotion gate; refined through its own process |
-| `/semantic-compress` | [`semantic-compress/SKILL.md`](./semantic-compress/SKILL.md) | Compress LLM-directed instructions: point at core knowledge the model holds, keep project-specific detail verbatim. Forged by `/skill-forge` |
+| `/semantic-compress` | [`semantic-compress/SKILL.md`](./semantic-compress/SKILL.md) | Compress LLM-directed instructions in two modes: a local core->pointer pass, and an A/B-validated distill loop producing the smallest behaviourally-equivalent document. Point at core knowledge the model holds, keep project-specific detail verbatim. Forged by `/skill-forge` |
 
 ## Assessment helpers
 


### PR DESCRIPTION
## Summary

Closes the build-pipeline + docs work for semantic-compress v2 (distill mode). Group A/B landed the two-mode SKILL.md, the three distill reference docs, the chat-replace/chat-skip markers, and the `standalone_skill_config.py` entry; this PR completes the standalone-build coverage and the doc/manifest closure.

## Changes Made

- **`scripts/standalone_skill_config.py`** - set the `semantic-compress` `exclude_dirs` to `{tests, __pycache__, .pytest_cache, .venv}` (matching the assess/skill-forge entries) and documented that the distill reference docs ride along under `references/` while their subagent spawn mechanics are stripped via chat-skip. The two-mode `standalone_description` (with `VERSION_SUFFIX`) and the `distill-availability` honest-degrade replacement were already present and correct; the replacement key matches the `<!-- chat-replace:distill-availability -->` marker in SKILL.md.
- **`scripts/tests/test_integration.py`** - added two tests to `TestSemanticCompressBuild`:
  - `test_distill_references_present` - the three distill reference docs (`distill-loop.md`, `transfer-set-design.md`, `distillation-report-template.md`) are in the ZIP.
  - `test_no_team_infrastructure_leaked` - no `TeamCreate`/`TeamDelete`/`SendMessage`/`TaskCreate` leaks into any bundled `.md`, and the A/B-harness dependency appears only in degraded form (SKILL.md states distill mode is unavailable standalone).
- **`.claude-plugin/plugin.json`** - version `1.28.0` -> `1.28.1`. Description already reflects the two-mode design; left intact.
- **`skills/README.md`**, **`docs/index.md`** - semantic-compress entries now describe both modes (local core->pointer pass + A/B-validated distill loop).

## Testing

All required suites green locally:
- `scripts/ pytest` - 97 passed (incl. 2 new tests)
- `skills/assess pytest` - 534 passed, 1 skipped
- `plugin contract pytest` - 167 passed
- ruff (skills/assess + scripts) - clean

## Risk Assessment

Low. Build-config + test + doc-only changes; no runtime behaviour. The standalone ZIP build verified to include all distill references with no Claude-Code-only tool leakage.