### PR TITLE
feat: Add gratuitous cross-reference tell to deslop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress makes an LLM-directed document smaller while preserving what it does, in two modes: a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -104,6 +104,16 @@ AI invents plausible-looking sources, dead URLs, fake DOIs, or attributes claims
 
 **Fix:** Verify every citation actually exists and supports the claim. Never let an unverifiable reference through. If you can't confirm a source, remove the claim or flag it explicitly.
 
+### 13. Gratuitous cross-references
+
+Naming a sibling skill, command, or concept as analogy or aside when the reader doesn't need to understand it to follow the instructions. The reference adds comprehension cost ("what's `marathon` - do I need to read that first?") with no behavioural payoff; the sentence would instruct identically without it.
+
+> "This dispersal works **exactly as `marathon` composes `pr-review-merge`.**"
+
+Distinct from a load-bearing composition pointer the reader must actually follow ("composes `skill-forge`'s A/B equivalence capability") - that one is legitimate, don't flag it.
+
+**Fix:** Cut the analogy. If the reader genuinely needs the referenced skill, make it a declared dependency, not a passing mention. This is prose-level judgment only - it catches decorative name-drops, not whether a document's real composition graph is correct.
+
 ## Output formats
 
 **When editing:** Return the cleaned text. If the user wants to see what changed, follow with a short bullet list of the categories you hit and why - quote the worst offenders.

--- a/skills/deslop/references/full-checklist.md
+++ b/skills/deslop/references/full-checklist.md
@@ -38,6 +38,18 @@ Exhaustive companion to SKILL.md, adapted from Wikipedia's "Signs of AI writing"
 
 **A11. Date-handling tells.** Vague or self-dating temporal references that will rot or that hide a missing fact: "in recent years," "currently," "to date," "as of this writing," "the latest," present-tense claims about things that change, round-number estimates with false precision. Also inconsistent or silently US-default date formats (Month DD, YYYY) where the document otherwise uses DMY/ISO. Distinct from D3 (chatbot knowledge-cutoff disclaimers): this is the prose itself failing to anchor a time-bound fact. **Fix:** anchor to a specific, sourced, dated fact ("as of the 2021 census"), or remove the claim; match the document's established date format.
 
+**A12. Gratuitous cross-references.** Names a sibling skill, command, or concept as analogy or aside when the reader doesn't need to understand that reference to follow the document's instructions. The reference adds comprehension cost ("what's `marathon` - do I need to read that first?") without contributing behaviour; the sentence would instruct identically without it. Distinct from a load-bearing composition pointer ("composes `skill-forge`'s A/B equivalence capability"), which the reader MUST follow to use the document - that one is legitimate, don't flag it. *Watch:* "exactly as X does Y", "similar to how Z works", "like the X skill", "in the style of Y", "mirrors the approach in Z" - when illustrative rather than instructional. **Fix:** cut the analogy; if the reference is load-bearing, make it explicit via the document's declared dependencies. *Advisory and prose-level only: it flags apparent decorative references from textual context and can't see the document's real dependency graph, so it surfaces candidates for human judgment, not violations.*
+
+Decorative (flag):
+- "This dispersal works exactly as `marathon` composes `pr-review-merge`" - the dispersal is understandable without knowing `marathon`.
+- "Similar to how the `huddle` skill gathers perspectives" - an illustrative aside, not a required pre-read.
+- "In the style of `assess`'s tiered severity model" - the severity model is described inline; the name adds nothing.
+
+Load-bearing (do NOT flag):
+- "Composes `skill-forge`'s A/B equivalence capability for behavioural validation" - the reader must understand `skill-forge` to use this.
+- "Inherits the transfer-set format from `semantic-compress`'s distill mode" - a functional dependency.
+- "See `assess`'s severity-tier table for rating guidance" - an explicit pointer to a required reference.
+
 ---
 
 ## B. Language and grammar tells


### PR DESCRIPTION
## Summary

Adds a new tell to the `/deslop` skill: **gratuitous cross-references** - naming a sibling skill, command, or concept as analogy or aside when the reader doesn't need to understand that reference to follow the document's instructions. It adds comprehension cost ("what's `marathon` - do I need to read that first?") with no behavioural payoff.

The crucial distinction: this is separate from **load-bearing composition pointers** the reader MUST follow (e.g. "composes `skill-forge`'s A/B equivalence capability"), which are legitimate and are explicitly NOT flagged.

## Changes Made

- `skills/deslop/references/full-checklist.md`: new tell **A12** (follows A11 date-handling) with the decorative-vs-load-bearing distinction, watch-phrases, fix, the advisory prose-level-only boundary, and the decorative→flag / load-bearing→don't-flag example lists.
- `skills/deslop/SKILL.md`: summary **tell 13** placed after tell 12, before Output formats, matching the existing tell format (heading, one-line description, blockquote example, Fix).
- `.claude-plugin/plugin.json`: version bump 1.28.3 → 1.28.4.

## Technical Details

- **Advisory, not a gate.** The decorative/load-bearing line is genuine prose judgment; the tell surfaces candidates for human review, matching deslop's "patterns are signals, not crimes" philosophy. The entry states the prose-level-only boundary explicitly: it works on textual patterns and cannot see the document's actual dependency graph.
- The canonical decorative example is the marathon analogy removed in task 13 ("exactly as marathon composes pr-review-merge").
- Skill names are written as inline code (not clickable links) to satisfy the internal-links contract test.
- The additions were self-deslopped: no em dashes, no rule-of-three, no puffery in the new tell text.

## Testing

All required suites green locally:
- `skills/assess pytest`: 534 passed, 1 skipped
- `scripts/ pytest`: 97 passed (includes standalone-build integration tests)
- `plugin contract pytest`: 169 passed (includes `test_internal_links_resolve`)

## Risk Assessment

Low. Documentation-only additions to a prose-pattern skill; no code paths or scripts changed. The skill-name examples are prose illustrations, not plugin-only infra, so no `chat-skip` markers are needed and the standalone ZIP is unaffected.