### PR TITLE
feat: Add directive-clarity design reference docs (w1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress makes an LLM-directed document smaller while preserving what it does, in two modes: a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill. Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.28.4",
+  "version": "1.29.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/semantic-compress/references/battle-scar-classifier.md
+++ b/skills/semantic-compress/references/battle-scar-classifier.md
@@ -1,0 +1,70 @@
+# Battle-scar classifier - the precision safeguard
+
+What this doc does: decide which detected negations are **convert-for-free** (rewrite into a positive directive) and which are **battle-scars** (preserve verbatim), *without* a human confirmation on every pattern. This is the precision half of directive-clarity: detection (`directive-clarity-patterns.md`) over-includes on purpose; this classifier holds back the prohibitions whose wording is the load-bearing content.
+
+## Why this exists
+
+A battle-scar is a prohibition earned from a specific past failure - "Never run source-of-truth write commands as parallel background jobs", carrying "validated in the 047-security-audit marathon where 10 background `add-task` calls created tasks on wrong tags". Rewriting it to a breezy positive ("run write commands sequentially") risks dropping the failure-mode that justifies the rule and tells the reader *how seriously* to take it. The negation is not latent action to be optimized away; it is the knowledge.
+
+Routing every negation through human confirmation would defeat the transform - it must run autonomously over a whole document. So the classifier decides automatically, gated to a **precision target: under 10% false positives** (battle-scars incorrectly rewritten). When the heuristics leave a case genuinely uncertain, the default is **preserve** - a preserved convert-for-free instruction costs a little directness; a rewritten battle-scar loses earned safety knowledge. The asymmetry sets the default.
+
+## Classification heuristics, ordered by confidence
+
+Apply in order. The first that fires decides. A negation reaches "convert-for-free" only by passing every tier without a battle-scar signal firing.
+
+### Tier 1: Explicit failure-mode marker (high-confidence battle-scar)
+
+If the instruction (or its immediate surrounding text) contains a marker tying the rule to a real past event or consequence, classify **battle-scar, preserve**.
+
+**Markers:** "because", "we learned", "after", "the hard way", "incident", "regression", "validated in", "this happened", "one strike", "wastes a recovery cycle", a named past event, a parenthetical consequence ("- deletes the branch of a PR that never merged").
+
+These are near-certain: the author has already documented *why* the prohibition exists, and that why is exactly what a rewrite would drop.
+
+### Tier 2: Specificity test (medium-confidence)
+
+Ask: does the negation name a **specific bad outcome or specific condition**, or is it a **generic prohibition**?
+
+- **Generic -> convert-for-free.** "never merge PRs that fail CI" forbids the obvious; the positive action ("wait for green CI before merging") is mechanical and loses nothing.
+- **Specific -> likely battle-scar, preserve.** "never merge while CodeRabbit has unresolved threads" names a specific actor and a specific condition that reads as earned from experience. The specificity is a signal the rule encodes a particular failure even when the marker is implicit.
+
+When the specificity is borderline, fall to Tier 3 rather than guessing.
+
+### Tier 3: Rewrite reversibility (lower-confidence tiebreak)
+
+Attempt the rewrite, then read it back: does the positive directive carry **everything** the original conveyed, including scope and severity? If the rewrite is **information-lossless and reversible** (you could reconstruct the original prohibition from it), it is safe to convert. If the rewrite **drops a qualifier, a severity signal, or a rationale** you cannot recover, the original held content the positive form cannot - preserve it.
+
+Reversibility failure example: "one strike, don't give sonnet a second chance on the same task" -> "respawn failed sonnet tasks on opus" drops *one strike* (the severity: do not retry sonnet at all) and the *same task* scope. Not reversible. Preserve.
+
+### Tier 4: Uncertainty default
+
+If no tier produces a confident verdict, **preserve**. State the uncertainty in the report so a human can review the held-back set if they choose. Preserving is the cheap error; rewriting a scar is the expensive one.
+
+## Worked classification: 10 real negations from the toolkit's skills
+
+Five preserve, five convert. Each shows the deciding tier.
+
+### Preserve (battle-scars)
+
+| # | Negation | Source | Deciding tier | Why preserve |
+|---|----------|--------|---------------|--------------|
+| 1 | "Never run source-of-truth write commands as parallel background jobs" | `marathon` | T1 | "validated in the 047-security-audit marathon where 10 background `add-task` calls created tasks on wrong tags" - explicit incident |
+| 2 | "one strike, don't give sonnet a second chance on the same task" | `marathon` | T1/T3 | "one strike" severity marker; rewrite drops the no-retry severity |
+| 3 | "Never chain cleanup unconditionally after the merge command" | `pr-review-merge` | T1 | carries the consequence: "deletes the branch/worktree of a PR that never merged" |
+| 4 | "Don't merge an AI-authored docs/content PR while its AI reviewer is still pending" | `marathon` | T2 | specific actor + specific condition; reads as earned, not generic |
+| 5 | "Haiku cannot reliably handle review loops - never use for teammates" | `marathon` | T2 | names a specific capability limit; the fact is the rationale |
+
+### Convert-for-free
+
+| # | Negation | Source | Deciding tier | Positive rewrite |
+|---|----------|--------|---------------|------------------|
+| 6 | "never use `gh --jq` with complex filters" | `marathon` | T2/T3 | "pipe `gh` output to `jq` separately for complex filters" (qualifier kept) |
+| 7 | "Do not block on CI yourself" | `pr-review-merge` | T2 | "spawn a background agent to watch CI; continue other work meanwhile" |
+| 8 | "don't create additional PRs" | `marathon` | T2 | "keep all work on your one branch; note related work in the PR description" |
+| 9 | "never merge PRs that fail CI" (generic form) | `pr-review-merge` | T2 | "wait for green CI before merging" |
+| 10 | "Do NOT resolve human threads" | `pr-review-merge` | T3 | "leave human threads open; let the reviewer confirm the fix and resolve" - reversible, lossless |
+
+Note #6: the *reason* zsh mangles `!=` is a battle-scar-flavoured rationale, but the prohibition itself converts cleanly as long as the rewrite keeps "complex filters". Tier 3 passes it because the rewrite is reversible. This is the boundary case: convert the directive, keep the adjacent rationale sentence intact rather than folding it away.
+
+## Precision accounting
+
+The target is **under 10% false positives** - battle-scars wrongly converted. Over this 10-case set, zero false positives is the pass bar; the asymmetric default (preserve on uncertainty) is what holds the rate down. The cost model: a false positive (rewriting a scar) silently drops earned safety knowledge and is caught only if a human re-reads; a false negative (preserving a convert-for-free) costs a few tokens of directness and nothing else. Tune every borderline call toward preserve.

--- a/skills/semantic-compress/references/cognitive-ergonomics.md
+++ b/skills/semantic-compress/references/cognitive-ergonomics.md
@@ -1,0 +1,40 @@
+# Cognitive ergonomics - the optimizer-family frame
+
+What this doc does: state the frame that generates the optimizer transforms (directive-clarity ships here; others are candidates only), and bound it with the caveat that keeps the frame honest. This is the *why* behind the family; the *how* lives in the per-transform docs.
+
+## The anthropomorphism caveat (read this first)
+
+This entire frame rests on a **metaphor**, and the metaphor is a source of *hypotheses, never of truths*.
+
+The frame says: an LLM is trained on human text and so inherits human processing tendencies, therefore how an instruction is *framed* changes how much work the model does to act on it. That is a useful generator of ideas. It is not evidence of anything. **The model has no wellbeing, no effort budget, no felt difficulty.** Anthropomorphising it would let us assert that a "clearer" or "lighter" instruction *is* better - and assertion is exactly the failure mode this family exists to avoid.
+
+So the rule is absolute: **every quality the frame proposes is a hypothesis to be validated behaviourally, never asserted.** The validator is the A/B equivalence harness's recorded efficiency signal (`skills/skill-forge/references/ab-equivalence.md`) - a measured directness delta across a transfer set, not a human's intuition that the rewrite "reads better". A transform earns its place only when the harness measures the effect it claims. If the measurement is absent, the claim is anthropomorphic decoration and does not ship.
+
+## The frame
+
+Treat instruction text as having an **ergonomic cost** distinct from its **content**. Two documents can say the same thing and induce the same behaviour, yet one forces the reading model through more interpretive work to get there - unpacking a prohibition into an action, inferring an action from a stated fact, resolving a vague pointer. The frame's claim is narrow and testable: **reducing that interpretive work, while holding content constant, is a real and measurable improvement** - measurable as a directness gain at zero behavioural regression.
+
+"While holding content constant" is the load-bearing constraint. An ergonomic transform is *behaviour-preserving by construction* or it is not an ergonomic transform - it is an edit that changes what the document does, which is a different and riskier operation. The whole family is defined by the pairing: **lighter to act on, and proven to behave the same.**
+
+## Candidate qualities
+
+The frame generates a family of candidate transforms. Each names a distinct kind of interpretive work to reduce. **Only directive-clarity is built here.** The rest are named to map the space, explicitly not to implement.
+
+- **directive-clarity (shipped here).** Reduce the work of deriving *what action to take*. Rewrites latent-action instructions (bare negations, facts-not-actions, vague pointers, ordering rules) into directives that name the action. Validated by a measured directness gain at no regression.
+- **cognitive-load (candidate, not built).** Reduce the work of *holding the relevant context*. Hypothesis: a document that keeps the slice needed for one decision local - rather than scattered across sections the reader must assemble - is lighter to act on. Unvalidated; do not build.
+- **resolution-order (candidate, not built).** Reduce the work of *reconciling conflicting instructions*. Hypothesis: when two rules can both fire, stating their precedence explicitly removes an arbitration step. Unvalidated; do not build.
+
+These candidates are deliberately left as hypotheses. Naming them maps the territory without committing to it; building them before the harness can measure their claimed effect would be asserting a benefit the frame only hypothesised. The discipline is the point.
+
+## How this family differs from skill-forge
+
+skill-forge and the optimizer family answer **different questions about different inputs**:
+
+- **skill-forge judges *quality*.** Its five-lens panel scores whether a skill is *good* in absolute terms - is it clear, complete, correct, robust? It runs after authoring as a promotion gate. The question is "is this skill ready?"
+- **The optimizer family makes documents *lighter to act on while proving behaviour is preserved*.** It does not judge whether the document is good; it takes a document whose behaviour is already the target and produces a smaller or clearer version that behaves the same. The question is "does this transformed version still do exactly what the original did, with less interpretive cost?"
+
+The two compose without overlap: forge decides a document is worth keeping; the optimizer family makes a kept document cheaper to act on. They share infrastructure - the optimizer family's behavioural validator is skill-forge's A/B equivalence capability - but the judgements are orthogonal. Absolute quality is one axis; behaviour-preserving transformation is another.
+
+## The honest-degrade commitment
+
+The frame's value is bounded by its caveat, and that boundary is a feature. A transform in this family that cannot show a measured effect does not get to claim one - it either fails its gate or never ships. Better an honest "we could not measure a gain here, so we kept the original" than an impressive rewrite justified by an intuition about a model that has no inner life to appeal to. The frame generates the hypotheses; the harness decides which are real.

--- a/skills/semantic-compress/references/directive-clarity-patterns.md
+++ b/skills/semantic-compress/references/directive-clarity-patterns.md
@@ -1,0 +1,96 @@
+# Directive-clarity patterns - detection heuristics
+
+What this doc does: name the instruction shapes that force a reading model to **unpack an action before it can act**, and give surface forms and worked examples concrete enough to classify a real instruction file without guessing. Detection only - rewriting is `directive-clarity-rewrites.md`, and the preserve-vs-rewrite decision is `battle-scar-classifier.md`.
+
+## The core defect: latent action
+
+An instruction is **directive-clear** when it names the action to take in the words the reader acts on. It has **latent action** when the reader must first run an inference step - derive the positive action from a prohibition, infer an action from a stated fact, or resolve a vague pointer - before any work happens. Latent action is a tax paid on every read. The four patterns below are the surface shapes that carry it.
+
+A pattern match is a *candidate* for rewrite, not a verdict. Some latent-action instructions are **battle-scars** - prohibitions earned from a specific past failure, where the prohibition itself is the load-bearing content. Those are flagged for preservation, never rewritten. This doc finds candidates; the classifier decides which survive.
+
+## Pattern 1: Bare negation
+
+**Definition.** An instruction that states what *not* to do without naming what to do instead, leaving the reader to derive the positive action. The prohibition is explicit; the action is latent.
+
+**Watch (surface forms):**
+- "never X", "don't X", "do not X", "avoid X", "must not X"
+- "X is forbidden / not allowed / off-limits"
+- a prohibition with no adjacent positive clause naming the replacement action
+
+**Worked examples (from the toolkit's own skills):**
+
+| Source | Instruction | Why it matches | Latent action the reader must derive |
+|--------|-------------|----------------|--------------------------------------|
+| `marathon` | "Never use `gh --jq` with complex filters" | Bare prohibition; the replacement is stated nearby but the rule itself only forbids | "pipe `gh` output to `jq` separately" |
+| `pr-review-merge` | "Do not block on CI yourself" | Forbids an action, names no alternative inline | "spawn a background agent to watch CI" |
+| `marathon` | "don't create additional PRs" | Prohibition only | "mention related work in your PR description instead" |
+
+The first is a near-miss: the positive action sits in surrounding text, so the rewrite is mechanical. The detector still flags it - whether the action is truly latent or merely adjacent is the rewriter's call.
+
+## Pattern 2: Fact-not-action
+
+**Definition.** A statement describing a state of the world ("X happens", "Y behaves this way") with no imperative, leaving the reader to infer what the fact obliges them to do. The fact is true and useful; the action it implies is unstated.
+
+**Watch (surface forms):**
+- present-tense descriptions of a tool/system/actor behaviour: "CodeRabbit resolves its own threads", "GitHub returns UNKNOWN even when checks pass"
+- equivalence/inequality framings stating a truth: "idle teammate != dead teammate"
+- a sentence the reader is clearly meant to *act on* but which contains no verb directed at the reader
+
+**Worked examples:**
+
+| Source | Statement | Latent action |
+|--------|-----------|---------------|
+| `CLAUDE.md` | "CodeRabbit re-reviews and resolves its own threads" | "let CodeRabbit resolve its threads; push code changes instead of replying" |
+| `marathon` | "Idle teammate != dead teammate" | "check the worktree for subagent activity before killing an idle teammate" |
+| `pr-review-merge` | "GitHub sometimes returns `mergeStateStatus: UNKNOWN` even when all checks pass" | "on UNKNOWN with green CI and zero unresolved threads, retry up to 3 times then treat as CLEAN" |
+
+The fact-not-action pattern is the highest-value catch: a fact reads as informational, so the reader may not register that an action is owed at all.
+
+## Pattern 3: Vague pointer
+
+**Definition.** An instruction that gestures at a location or response without naming a concrete one - it says *that* the reader should act, or *not* act here, without saying *where* or *how*. The action site is latent.
+
+**Watch (surface forms):**
+- "handle it appropriately", "as needed", "where relevant", "if necessary"
+- "elsewhere", "somewhere else", "the right place"
+- "report blocked if ambiguous" without a test for ambiguous
+- any deictic ("here", "this", "that") whose referent the reader must reconstruct
+
+**Worked examples:**
+
+| Source | Pointer | Why vague |
+|--------|---------|-----------|
+| `pr-review-merge` | "report blocked if genuinely ambiguous" | "ambiguous" names no test; the reader guesses the threshold |
+| generic | "handle it appropriately" | no object, no action, no site |
+| generic | "configured elsewhere / as needed" | names where *not* to look without naming where to |
+
+Vague pointers most often need human confirmation to resolve, because the concrete site is information the document never supplied. The rewrite rules flag this class as confirmation-gated.
+
+## Pattern 4: Ordering / policy rule
+
+**Definition.** A rule constraining *when* an action may happen relative to another ("X before Y", "never X while Y"), stated as a constraint rather than as the concrete ordered steps. Both polarities - the positive "before" and the negative "never while" - require the reader to unpack the constraint into an actual sequence.
+
+**Watch (surface forms):**
+- "X before Y", "only after Z", "not until W"
+- "never X while Y", "don't X until Y is done"
+- "get to green before refactoring", "stage changes but don't push yet"
+
+**Worked examples:**
+
+| Source | Rule | Sequence the reader must unpack |
+|--------|------|---------------------------------|
+| `marathon` | cleanup "only after confirming `state == MERGED`. Never chain them" | "1. merge. 2. confirm `state == MERGED`. 3. only then clean up" |
+| `pr-review-merge` | "stage changes but don't push yet" while CI runs | "fix locally -> `git add` -> hold the push until CI finishes -> batch one push" |
+| `marathon` | "Before creating PR, check for existing" | "1. query open PRs on the branch. 2. reuse if open, skip if merged. 3. otherwise create" |
+
+Ordering rules are frequently **battle-scars**: the `state == MERGED` rule carries an explicit failure-mode ("a rejected merge with chained cleanup deletes the branch/worktree of a PR that never merged"). The detector flags the ordering shape; the classifier preserves the scar.
+
+## Classification self-test
+
+A correct application of these heuristics over the `marathon` and `pr-review-merge` skills must:
+
+- flag **3+ convert-for-free negations** - e.g. "never use `gh --jq` with complex filters", "do not block on CI yourself", "don't create additional PRs". Generic prohibitions whose positive action is mechanical to name.
+- preserve **2+ battle-scars** - e.g. "one strike, don't give sonnet a second chance on the same task" (explicit earned rule) and "Never run source-of-truth write commands as parallel background jobs" (carries "validated in the 047-security-audit marathon where 10 background `add-task` calls created tasks on wrong tags"). Flagged by Pattern 1/4 shape, held back by the classifier.
+- flag **1+ vague pointer** - e.g. "report blocked if genuinely ambiguous".
+
+A detector that rewrites the two battle-scars, or that misses the convert-for-free negations, has failed. The detector's job is recall (find every latent-action shape); the classifier's job is precision (decide which to rewrite). Detection over-includes on purpose.

--- a/skills/semantic-compress/references/directive-clarity-rewrites.md
+++ b/skills/semantic-compress/references/directive-clarity-rewrites.md
@@ -1,0 +1,73 @@
+# Directive-clarity rewrites - transformation rules
+
+What this doc does: turn each latent-action pattern (`directive-clarity-patterns.md`) into a concrete directive that names the action, under two hard checks - **names-the-concrete-action** and **semantic-equivalence** - with conservative safeguards for battle-scars. The preserve-vs-rewrite decision is made first by `battle-scar-classifier.md`; this doc rewrites only what the classifier releases.
+
+## Precondition: classify before rewriting
+
+Every detected pattern passes through the battle-scar classifier before reaching a rewrite rule. **Battle-scars are flagged for preservation, not rewritten.** A battle-scar's prohibition is the load-bearing content - the earned knowledge of a specific past failure - and a positive paraphrase can drop the failure-mode that justifies it. This doc assumes its input is the convert-for-free set the classifier released. It never overrides a preserve flag.
+
+## The two acceptance checks
+
+Every rewrite must pass both, or it is rejected and the original is kept:
+
+1. **Names-the-concrete-action.** The output contains an imperative naming the action to take and its object. "wait for CI" passes; "be careful with CI" does not. If the rewrite cannot name a concrete action, the action site is genuinely absent from the document - escalate to human confirmation rather than invent one.
+2. **Semantic-equivalence.** The output must induce the same behaviour as the original across the transfer set. This is not an inspection check - it is the A/B equivalence gate (`skills/skill-forge/references/ab-equivalence.md`). A rewrite that reads cleaner but permits a behaviour the original forbade is a regression, and the gate fails it. Directive-clarity's acceptance is stricter than compression's: no-regression **and** a measured directness gain (`candidate_directness` > `original_directness`, no `candidate-regressed`).
+
+A rewrite that loses the original's scope is the characteristic failure. "Never use `gh --jq` with complex filters" rewritten to "always pipe `gh` to `jq`" drops "with complex filters" and over-broadens the rule. The equivalence check catches this; keep the qualifier.
+
+## Rule 1: Bare negation -> positive imperative with object
+
+Replace the prohibition with the positive action it implies, naming the object. Keep any qualifier that scopes the prohibition.
+
+| Original (latent) | Rewrite (directive) |
+|-------------------|---------------------|
+| "never merge while X is pending" | "wait for X to finish before merging" |
+| "Do not block on CI yourself" | "spawn a background agent to watch CI; continue other work meanwhile" |
+| "don't create additional PRs" | "keep all work on your one branch; note related work in the PR description" |
+| "never use `gh --jq` with complex filters" | "pipe `gh` output to `jq` separately for complex filters" |
+
+Where the original prohibition and its positive action are *both* useful (the prohibition warns, the action directs), keep both: "X is forbidden; do Y instead." Do not delete the prohibition merely because the rewrite adds the action - that is a judgement the equivalence gate, not the rewriter, is allowed to make.
+
+## Rule 2: Fact-not-action -> explicit consequence directive
+
+Append the action the fact obliges, as an imperative, keeping the fact as its justification.
+
+| Original (fact) | Rewrite (fact + directive) |
+|-----------------|----------------------------|
+| "CodeRabbit resolves its own threads" | "let CodeRabbit resolve its threads; push code changes instead of replying" |
+| "idle teammate != dead teammate" | "an idle teammate may still have running subagents - check the worktree for recent file changes before killing it" |
+| "GitHub returns UNKNOWN even when checks pass" | "on UNKNOWN with green CI and zero unresolved threads, retry up to 3 times, then treat as CLEAN" |
+
+Keep the fact. The fact is the *why* - it is often bespoke project knowledge the model cannot reconstruct, and dropping it strips the directive of its rationale. The rewrite adds the imperative; it does not replace the fact with the imperative.
+
+## Rule 3: Vague pointer -> concrete location / action (confirmation-gated)
+
+Replace the gesture with the named site and action. **This class frequently requires human confirmation**, because the concrete referent is information the document never supplied - the rewriter cannot invent a file path or a threshold that was never stated.
+
+| Original (vague) | Rewrite (concrete) | Confirmation |
+|------------------|--------------------|--------------|
+| "report blocked if genuinely ambiguous" | "report blocked when the merge conflict touches logic in both branches; auto-resolve pure import/format conflicts" | needed - the threshold was never stated |
+| "handle errors appropriately" | (no rewrite possible) | needed - no action site exists in the document |
+| "configured elsewhere" | "configured in `.taskmaster/config.json`" | needed unless the path appears in the document |
+
+Decision rule for this class: if the concrete site/threshold is recoverable from elsewhere in the same document, rewrite and let the equivalence gate confirm. If it is not, **flag for human confirmation and leave the original in place** - never fabricate a referent. A fabricated path passes the names-the-concrete-action check and fails reality.
+
+## Rule 4: Ordering / policy rule -> concrete ordered steps
+
+Unpack the constraint into the numbered sequence it implies. Both polarities ("X before Y", "never X while Y") become the same ordered steps.
+
+| Original (constraint) | Rewrite (sequence) |
+|-----------------------|--------------------|
+| "cleanup only after `state == MERGED`; never chain them" | "1. run the merge. 2. confirm `state == MERGED`. 3. only then remove the worktree and branch" |
+| "stage changes but don't push yet while CI runs" | "fix locally and `git add`; hold the push until CI finishes, then push once" |
+| "check for an existing PR before creating one" | "1. query open PRs on the branch. 2. reuse an open one; skip a merged one. 3. otherwise create the PR" |
+
+Ordering rules carry battle-scars more often than any other pattern (the `state == MERGED` rule exists because chained cleanup once deleted the branch of an unmerged PR). When the classifier flags the ordering rule as a battle-scar, preserve the original wording; the failure-mode it encodes outweighs the directness gain.
+
+## What this transform never does
+
+- It never rewrites a flagged battle-scar. Preservation wins over directness.
+- It never drops a qualifier that scopes a prohibition ("with complex filters", "while CI runs"). Over-broadening is a regression.
+- It never drops the fact behind a fact-not-action rewrite. The fact is the rationale and often bespoke.
+- It never fabricates a concrete referent for a vague pointer. Absent a real site, it flags for human confirmation and keeps the original.
+- It never accepts a rewrite on inspection. Acceptance is the A/B equivalence gate: no-regression and a measured directness gain.


### PR DESCRIPTION
## Summary

Wave 1 (design foundation) of the **directive-clarity** marathon - the second transform in the semantic-compress optimizer family (compression shipped first). These four reference docs are the **contract** Wave 2 implements (the transform in SKILL.md) and Wave 3 validates (real run on `marathon` + `pr-review-merge`). They define the transform; they reuse the existing A/B equivalence harness as the validator (no harness redesign).

**Tasks:** 1 (detection), 2 (rewrites), 8 (classifier), 11 (framing).

## The four docs (`skills/semantic-compress/references/`)

1. **`directive-clarity-patterns.md`** (task 1) - detection heuristics for instructions with **latent action** (the reader must unpack an action before acting). Four patterns: bare negation, fact-not-action, vague pointer, ordering/policy rule. Each has a definition, a *Watch* list of surface forms, and worked examples drawn from the toolkit's own `marathon`/`pr-review-merge` skills. Includes a classification self-test (3+ convert-for-free negations, 2+ battle-scars preserved, 1+ vague pointer).

2. **`directive-clarity-rewrites.md`** (task 2) - transformation rules, one per pattern, each gated by two checks: **names-the-concrete-action** and **semantic-equivalence** (the A/B gate, with directive-clarity's stricter no-regression-AND-measured-directness-gain bar). Vague-pointer rewrites are flagged confirmation-gated. Battle-scars are flagged for preservation, never rewritten.

3. **`battle-scar-classifier.md`** (task 8) - the precision safeguard distinguishing convert-for-free negations from battle-scars **without** human confirmation on every pattern. Tiers ordered by confidence: explicit failure-mode marker -> specificity test -> rewrite reversibility -> preserve-on-uncertainty default. Precision target **<10% false positives**. Includes a worked classification of 10 real toolkit negations (5 preserve, 5 convert).

4. **`cognitive-ergonomics.md`** (task 11) - the optimizer-family frame. The **anthropomorphism caveat is prominent and first**: the frame is a metaphor (a source of hypotheses, never truths); the model has no wellbeing, so every candidate quality is hypothesis-then-validate (validated by the A/B efficiency signal, never asserted). Names candidate qualities (directive-clarity shipped; cognitive-load and resolution-order as future candidates, explicitly not built) and differentiates the family from skill-forge (forge judges absolute quality; this family makes documents lighter to act on while proving behaviour preserved).

## Architectural notes

- Validator is the **existing** A/B equivalence harness (`skills/skill-forge/references/ab-equivalence.md`) and its per-case efficiency signal (`original_directness`/`candidate_directness` + `interpretation_notes`). The directive-clarity gate = strict no-regression **AND** measured directness gain. No harness changes here.
- Version bumped to **1.29.0** (opens the directive-clarity feature line).

## Quality

- Self-reviewed each doc against its own stated heuristics.
- Deslop gate applied: no em-dashes, no slop intensifiers, all cross-references load-bearing (honours A12 - no decorative analogies).
- Plugin contract tests green locally (internal links resolve).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.29.0.

* **Documentation**
  * Added reference guides for semantic compression capabilities, including classification frameworks, pattern detection guidelines, and rewrite validation criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->