### PR TITLE
fix: Resolve marathon teammate wake/shutdown contradiction

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on /skill-forge's A/B equivalence harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.29.3",
+  "version": "1.29.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/marathon/SKILL.md
+++ b/skills/marathon/SKILL.md
@@ -235,7 +235,7 @@ Additive files (imports, barrel exports, routes): accept both sides. Same-line c
 1. **Implement using TDD**. Push commits incrementally for backup.
 2. **Before creating PR**, check for existing: `gh pr list --head "<branch-name>" --state all --json number,state,mergedAt`
    - Merged → message lead, wait idle. Open → use it. None → create one.
-3. **Get required checks green, then stand down.** Use the pr-review-merge skill's criteria and thread rules to fix any failing *required* checks and resolve any bot threads already posted, pushing fixes. Then report and go idle. **Do NOT run a `gh pr checks --watch` loop or any background CI watcher** - in marathon mode the lead owns CI watching, the slow `claude-review`/AI-review wait, and the merge. A teammate that watches a slow advisory check sits idle for minutes and floods the lead with idle notifications; that is the lead's job here, not yours. The lead wakes you only if a fix is needed after you stand down.
+3. **Get required checks green, then stand down.** Use the pr-review-merge skill's criteria and thread rules to fix any failing *required* checks and resolve any bot threads already posted, pushing fixes. Then report and go idle. **Do NOT run a `gh pr checks --watch` loop or any background CI watcher** - in marathon mode the lead owns CI watching, the slow `claude-review`/AI-review wait, and the merge. A teammate that watches a slow advisory check sits idle for minutes and floods the lead with idle notifications; that is the lead's job here, not yours. While your PR is not yet at required-green the lead may message you to fix a failing check or thread - respond and push. Once you send REVIEW_CLEAR you are done: the lead does not re-wake you, it spawns a fresh teammate if more work surfaces (one task, one teammate).
 
 ## Communication
 Only message the lead for **meaningful events**:
@@ -252,7 +252,7 @@ Only message the lead for **meaningful events**:
 1. Implement → push incrementally → create PR → message lead PR_CREATED
 2. Fix any failing **required** checks and any already-posted bot threads; push. Do NOT watch CI - the lead owns that.
 3. Message lead REVIEW_CLEAR (required checks green, threads resolved) and stand down. Do not sit through the slow `claude-review`/AI-review window - that wait is the lead's to hold.
-4. The lead owns the claude-review wait + merge, cleans up, and shuts you down at green; it wakes you only if a fix is needed. Approve the shutdown request when received.
+4. The lead owns the claude-review wait + merge, cleans up, and shuts you down at green. After REVIEW_CLEAR you are not re-woken - if more work surfaces the lead spawns a fresh teammate (one task, one teammate). Approve the shutdown request when received.
 """
 )
 ```


### PR DESCRIPTION
## Summary

Follow-up to #140. `claude-review` on #140 caught a real internal contradiction: the teammate-side line *"the lead wakes you only if a fix is needed"* conflicts with the lead-side rules added in the same PR - shut the teammate down **immediately** on REVIEW_CLEAR, and recovery is respawn-fresh ("Never reuse a teammate"). A teammate reading only its own prompt could stay alive expecting a wake, which is the exact idle churn #140 removes. The thread was unresolved at #140's admin-merge; this PR addresses it.

## Change (`skills/marathon/SKILL.md`)

Both teammate lines (Workflow step 3 + Lifecycle step 4) now state the accurate model:
- **Before** required-green: the lead may message you to fix a failing check or thread - respond and push.
- **After** REVIEW_CLEAR: you are done and not re-woken; the lead spawns a fresh teammate if more work surfaces (one task, one teammate).

## Testing

- `plugin contract pytest`: 172 passed.
- Version bumped 1.29.3 -> 1.29.4 (PATCH).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.29.4

* **Documentation**
  * Updated teammate workflow guidance to clarify lead and teammate responsibilities during code review cycles, including CI check handling, merge timing control, and lifecycle expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->