### PR TITLE
docs: Restore three orphaned design specs to main

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on /skill-forge's A/B equivalence harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.29.4",
+  "version": "1.29.6",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -26,3 +26,6 @@ The plans and specs behind the skills, captured as they were built. These are hi
 |------|---------|
 | [Issues marathon shared-skills design](./specs/2026-05-29-issues-marathon-shared-skills-design.md) | Design for `/issues` via shared marathon skills |
 | [skill-forge design](./specs/2026-06-02-skill-forge-design.md) | Judge-panel skill-hardening harness, refined through its own process |
+| [semantic-compress distillation design](./specs/2026-06-03-semantic-compress-distillation-design.md) | semantic-compress v2 holistic distillation - produce the smallest document that passes A/B behavioural equivalence |
+| [instruction optimizer directive-clarity design](./specs/2026-06-03-instruction-optimizer-directive-clarity-design.md) | Directive-clarity transform - first A/B-validated member of the instruction cognitive-ergonomics family |
+| [skill-forge hardening + A/B-extraction design](./specs/2026-06-03-skill-forge-hardening-and-ab-extraction-design.md) | Extract A/B-equivalence into a standalone library skill and apply five B1-B5 hardening changes to skill-forge |

--- a/docs/superpowers/specs/2026-06-03-instruction-optimizer-directive-clarity-design.md
+++ b/docs/superpowers/specs/2026-06-03-instruction-optimizer-directive-clarity-design.md
@@ -1,0 +1,63 @@
+# Design: instruction optimizer - cognitive-ergonomics family, directive-clarity first
+
+Date: 2026-06-03
+Status: Follow-up stage - depends on the semantic-compress v2 distillation harness
+Predecessor: `2026-06-03-semantic-compress-distillation-design.md`
+
+## Why this is a separate, later spec
+
+The v2 distillation spec builds the **first** behaviour-preserving transform (compress) and the **A/B harness** that validates it. This spec is the **second stage**: it adds a second transform (directive-clarity) and names the umbrella it belongs to. It is deliberately split off so the harness ships and proves itself before the family expands - each transform must earn its place by A/B, not by being designed in up front.
+
+## The frame: instruction cognitive-ergonomics
+
+An LLM is trained on human text and inherits human processing biases, so how an instruction is *framed* changes how much work the model does to act on it - independent of what the instruction says. This is a useful **metaphor** (the model has no wellbeing) drawn from cognitive science and CBT: it is a *source of hypotheses* about instruction quality, never a source of truths. Candidate qualities it generates:
+
+- **Directive clarity** - the instruction names the action to take (vs a negation, a bare fact, a vague pointer, or an ordering rule the model must convert into an action).
+- **Cognitive load** - the instruction fits the model's working context (vs sprawling, requiring the model to hold too much at once).
+- **Goal clarity** - a concrete next action (behavioural activation) vs vague avoidance.
+- **Consistency** - no contradictory rules the model must reconcile (dissonance).
+
+Each is a **hypothesis, A/B-validated before it ships**, exactly because anthropomorphising would otherwise let us assert benefits that are not real. The frame's value is generating candidates; the A/B harness is what earns them in. This spec ships **only directive-clarity**; the others are named as future candidates, not built.
+
+## The evidence: the directive-clarity A/B preview
+
+Before this spec, a manual A/B tested the hypothesis "positive framing beats negative framing for LLM instructions." Two versions of the same PR-handling rule set - identical rules and specificity, only the voice differing (negative gotchas vs positive directions) - were run on the same task; each runner reported where it had to *unpack* a rule into an action.
+
+The result **refined** the hypothesis rather than confirming it:
+
+- A positive *imperative with a concrete object and example* (`pipe gh to jq, filter with == "FAILURE"`) was acted on immediately.
+- A positive *fact* ("CodeRabbit resolves its own threads") needed exactly as much unpacking as a negative prohibition - the model still had to derive "so I don't reply, I just push."
+- An *ordering* rule ("get to green before refactoring" / "never refactor while red") needed unpacking in **both** polarities.
+- The single worst rule was the **vague** one ("resolution is elsewhere") - it named where not to act without naming where to - regardless of polarity.
+
+**Conclusion: the lever is directive clarity, not positive polarity.** Stating the concrete action bakes in the model's pre-thinking; a bare negation, a positive fact, a vague pointer, and an ordering rule all leave the model to derive the action. Positive phrasing helps mainly as a *proxy* for naming the action.
+
+Caveats kept honest: this was n=1, a crafted pair, with self-reported unpacking. It is a directional first read, not proof - which is exactly why the shipped transform is gated by the real harness over many cases.
+
+## Transform #2: directive-clarity
+
+A behaviour-preserving optimizer transform (it belongs to `semantic-compress`'s optimizer family, gated by the v2 A/B harness):
+
+1. **Detect** instructions that force the model to unpack an action: bare negations, facts-not-actions, vague pointers ("handle it appropriately", "elsewhere"), and ordering/policy rules stated without their concrete consequence.
+2. **Rewrite** each into a concrete directive that names the action - **conservatively**: a negation that already implies one clear action ("never merge while X pending" -> "wait for X before merging") converts for free; a negation that encodes a *specific failure mode* (a battle-scar: "never give sonnet a second chance on the same task") may lose its specificity if positivised, so it is kept unless the rewrite provably preserves it.
+3. **A/B-validate** with the harness: behaviour preserved (strict no-regression) **and** a measured efficiency gain (less unpacking / more direct action). A rewrite that preserves behaviour but shows no efficiency gain is not worth the change; a rewrite that regresses behaviour is reverted.
+
+**Negation density is a smell, not a rule.** The transform never blanket-removes negatives. It flags instructions that make the model derive the action and proposes directive rewrites, each earning its place by the A/B. This respects that some negatives are the cheapest, most precise encoding of a hard-won lesson.
+
+## Relationship to the rest of the toolkit
+
+- **Composes the v2 harness.** This transform adds no new testing machinery; it uses the transform-agnostic A/B-equivalence capability (with the efficiency signal) that v2 adds to `skill-forge`.
+- **Distinct from `skill-forge`.** Directive-clarity preserves output behaviour and only lowers cognitive cost - a refactor, not a quality change. If a rewrite changes what the agent does, that is a `skill-forge` concern, not this one.
+- **A real first target exists.** The toolkit's own battle-scar skills (`marathon`, `pr-review-merge`) are negation-dense, while the user's global `CLAUDE.md` already preaches "express what TO do, not what to avoid" - so the toolkit is an immediate, honest test corpus for whether directive-clarity rewrites preserve the battle-scars' protective behaviour.
+
+## Non-goals
+
+- Not building the whole cognitive-ergonomics family - only directive-clarity. Low-load, goal-clarity, and consistency are named future candidates, each to be A/B-tested before it ships.
+- Not blanket de-negation. Negatives that encode a specific failure mode and resist behaviour-preserving rewrite stay.
+- Not a `skill-forge` lens. This is a fixing transform, not a flagging lens (a lens may follow if detection-without-fix proves useful).
+
+## Open questions for the plan
+
+- The efficiency metric: how the harness quantifies "less unpacking" objectively (runner reasoning length? a directness rubric the equivalence judge scores? error-rate on the task?) beyond the self-report used in the preview.
+- Detection precision: how the transform distinguishes a convert-for-free negation from a battle-scar that must stay, without a human in the loop.
+- Whether directive-clarity and compress run as independent passes or a single combined optimizer pass over a document.

--- a/docs/superpowers/specs/2026-06-03-semantic-compress-distillation-design.md
+++ b/docs/superpowers/specs/2026-06-03-semantic-compress-distillation-design.md
@@ -1,0 +1,102 @@
+# Design: `semantic-compress` v2 - holistic, A/B-validated distillation
+
+Date: 2026-06-03
+Status: Approved for implementation planning
+
+## Problem
+
+`semantic-compress` v1 is a **local, textual** operation: find a span that explains a concept the model already knows, replace it with a pointer. Tested across four corpora (this toolkit, Matt Pocock's skills, an algorithms README, the gstack giants), it is precise but near-noop in practice - the "long-form-unnamed concept" pattern barely occurs in deliberately-authored documents, and the operation cannot, by construction, compress a whole document: you cannot preserve a global, behavioural property with local text edits.
+
+The actual need is **holistic** compression: make the document itself smaller while keeping what it *does*. And the essence of a document directed at an LLM is **behavioural, not textual** - the behaviour it induces in the reading model across the tasks it is meant to handle. You cannot tell by reading whether a smaller version preserved that behaviour, because introspection is biased: asked "will this behave the same?", the model guesses optimistically. The only ground truth is **A/B behavioural testing** - run the original and the candidate on the same inputs and compare what they actually do.
+
+This was validated empirically before this spec: an aggressive ~50% distillation of a TDD skill, A/B-tested, preserved all five of its disciplines (and faithfully preserved its gaps) - and we could not have known that without running it. The cut text was behaviourally inert; only the A/B proved it.
+
+## Goal
+
+Expand `semantic-compress` into a **holistic distillation** capability: produce the smallest document that behaves the same as the original, with acceptance gated on **A/B behavioural equivalence** measured by `skill-forge`. The local core->pointer move is retained as an inner micro-operation; the headline becomes the distill loop.
+
+## Non-goals
+
+- **Not removing the local mode.** v1's span-level core->pointer stays as an inner move.
+- **Not a new skill.** This expands `semantic-compress` (the user's explicit choice); it does not add a third skill to the family.
+- **Not model training.** "Distillation" is the conceptual analogue (context/prompt distillation: a smaller artifact that reproduces behaviour over a transfer set). No model weights are touched.
+- **Not absolute-quality forging.** The gate is equivalence-to-the-original, not "is this skill good" - that is `skill-forge`'s existing job. A faithful distillation preserves the original's flaws; improving the skill is a separate `skill-forge` run.
+
+## Core principle (encoded as a hard rule)
+
+**A compression is never accepted on inspection - only on behavioural evidence from an A/B run.** Introspection about behaviour is structurally unreliable; execution is the only arbiter. The skill must refuse to output a compressed document that has not passed an A/B equivalence run against the original.
+
+## Architecture
+
+`semantic-compress` drives the loop and **composes `skill-forge`** for the behavioural test, exactly as `marathon` composes `pr-review-merge`. Two roles split cleanly:
+
+- **`semantic-compress` owns compression**: deriving/confirming the transfer set, regenerating smaller candidates, the iterate-to-minimal loop, the output report.
+- **`skill-forge` owns behavioural testing**: it gains one thin new capability - **A/B equivalence** - that runs a runner over the same transfer set for two document versions and judges, per case, whether the candidate's behaviour is equivalent to the original's.
+
+### The distill loop (iterative-to-minimal)
+
+1. **Define the transfer set.** Derive behavioural test cases from the document across the `skill-forge` taxonomy (happy / edge / adversarial / composition). The user confirms or augments them before the baseline run - the transfer set *is* the operational definition of the essence, so the user signs off on it. The skill flags thin coverage.
+2. **Capture the teacher.** Run the **original** document through `skill-forge`'s runner on each case; record the behaviour it induces (the disciplines enforced, the outputs produced). This baseline is the equivalence target.
+3. **Compress = regenerate, not edit.** Produce a smaller candidate against the behavioural spec: the local core->pointer move, plus de-duplication and dropping behaviourally-inert prose. Regeneration (rewrite to function), not trimming, is what lets it get genuinely smaller.
+4. **A/B validate.** Run the **candidate** through the runner on the same transfer set; the equivalence judge compares candidate-vs-teacher behaviour per case under **strict no-regression**.
+5. **On any regression, the divergence names what was load-bearing.** Add back the minimum that restores the lost behaviour; re-validate.
+6. **Converge** on the smallest candidate that still passes; stop at diminishing returns (a round that can only shrink further by regressing) or a budget ceiling.
+7. **Output** the minimal equivalent document plus an **A/B report**.
+
+### Strict no-regression gate
+
+The candidate **passes** iff, on every transfer-set case, it induces every behaviour/discipline the original induced. Any dropped behaviour is a **fail** (essence lost) and triggers add-back. Incidental improvements (the candidate behaves *better* on a case) are acceptable but never required and never the goal - the goal is faithful, smaller reproduction. The gate is behavioural equivalence, not textual similarity.
+
+### Distribution-shift guard
+
+A distillation is only valid over the transfer set it was tested against - the same overfitting risk model distillation has outside its transfer distribution. The skill states this honestly and mitigates it two ways: push for diverse/adversarial coverage (breadth of the transfer set bounds the safety of the compression), and stay **conservative** - keep anything not *proven* behaviourally inert by the A/B. Silence about untested behaviour is forbidden; the report names the coverage.
+
+## The `skill-forge` addition: A/B equivalence
+
+A thin new capability, distinct from the existing absolute-quality panel:
+
+- **Input:** two document versions (original = teacher, candidate = student) and a transfer set.
+- **Mechanism:** for each case, run the existing runner (the pure-wrapper runner prompt) once per version, producing two transcripts. An **equivalence judge** compares the two transcripts and returns one of `equivalent | candidate-regressed | candidate-diverged`, citing the specific behaviour gained or lost.
+- **Output:** a per-case equivalence verdict; pass = zero `candidate-regressed`. `candidate-diverged` (different but not worse) is documented for the user's judgement.
+- **Transform-agnostic + efficiency signal.** The capability judges *behavioural equivalence between two versions* - it does not know or care which transform produced the candidate, so it serves every optimizer transform, not just compression. Alongside the equivalence verdict it records an **efficiency signal** per case (how directly the runner acted vs how much it had to unpack/reinterpret the instruction). Some transforms claim *behaviour-preserving-but-lighter* (the next one, directive-clarity) and can only be validated if the harness measures the lightness, not just the sameness: compression's gate is strict no-regression, while a lightness-claiming transform's gate is no-regression **and** a measured efficiency gain.
+- **Reuse:** the runner and runner-prompt are unchanged. The equivalence judge is a new, focused judge (compare-two-transcripts), separate from the five quality lenses. It is a library capability `semantic-compress` invokes; it does not change `skill-forge`'s own gate hierarchy.
+
+## Modes (when each fires)
+
+- **Local mode** (v1, retained): a quick span-level core->pointer pass, no A/B - for trivially compressing a short prompt where behavioural risk is negligible.
+- **Distill mode** (new, default for whole documents): the full A/B-validated loop above. Fires when compressing a skill/system-prompt/instruction document where preserving behaviour matters.
+
+The skill selects deterministically: a whole document / skill / system prompt -> distill mode; a short snippet with an obvious local swap and no behavioural surface -> local mode is permitted, but distill is the safe default.
+
+## Artifacts
+
+- The **minimal equivalent document**.
+- An **A/B distillation report**: original vs final size delta; the transfer set and its coverage; per-case equivalence verdicts; what was dropped (proven behaviourally inert); what proved load-bearing and was kept or added back; rounds run; the distribution-shift caveat (behaviour outside the transfer set is not guaranteed).
+
+## File changes (for the plan)
+
+- `skills/semantic-compress/SKILL.md` - reframe to two modes; add the distill loop, the hard behavioural-evidence rule, the distribution-shift guard, mode selection.
+- `skills/semantic-compress/references/` - distill-loop detail, transfer-set design guide (reuse taxonomy), the A/B distillation report template.
+- `skills/skill-forge/` - add the A/B-equivalence capability (a reference doc + the equivalence-judge prompt + a one-line mode entry in `SKILL.md`); `semantic-compress` invokes it.
+- `scripts/standalone_skill_config.py` + `scripts/tests/test_integration.py` - update the semantic-compress standalone entry/tests if references change; A/B/runner infra is `chat-skip` (team/subagent infra) for the standalone build, mirroring how skill-forge handles it.
+- `skills/README.md`, `docs/index.md`, `.claude-plugin/plugin.json` (description + MINOR version bump), `CLAUDE.md` scope if wording changes.
+
+## Validation
+
+This expansion is itself a `skill-forge` candidate. Once built, forge the expanded `semantic-compress`; and as a real-world acceptance test, run the new distill mode on a genuinely bloated document (a gstack giant such as `office-hours`, ~16k words) and confirm it produces a meaningfully smaller version that passes strict no-regression A/B - the case v1 could not touch.
+
+## The optimizer: a family of behaviour-preserving transforms
+
+Compression is the **first** of a family of behaviour-preserving instruction transforms this skill will host - each one making an LLM-directed document *lighter* (cheaper to read, faster to act on) without changing what it does, every one gated by the same A/B harness. The family is sourced from a cognitive-ergonomics view of instruction quality (negation cost, cognitive load, goal clarity, consistency - the way a document either fits or fights how the model processes it).
+
+- **Transform #1 - compress** (this spec): point at core, drop behaviourally-inert prose. Gate = strict no-regression.
+- **Transform #2 - directive-clarity** (follow-up spec: `2026-06-03-instruction-optimizer-directive-clarity-design.md`): rewrite instructions that force the model to *unpack* an action (bare negations, facts-not-actions, vague pointers, ordering rules) into concrete directives that name the action. Gate = no-regression **and** measured efficiency gain. An A/B preview established the lever is *directive clarity*, not positive polarity - so this is a tested hypothesis, not an assumed rule.
+
+Each future transform is a **hypothesis, A/B-validated before it ships** - the harness keeps the family honest. The umbrella stays distinct from `skill-forge`: the optimizer **refactors** (behaviour preserved, form lighter); `skill-forge` **improves** (behaviour changed for quality). The moment a transform changes behaviour, it belongs in the forge, not here.
+
+## Open questions for the plan
+
+- The equivalence-judge prompt: exact comparison rubric (how it decides regressed vs diverged from two transcripts) and its structured output schema.
+- Runner cost: the loop runs the runner twice per case per round (teacher captured once, candidate each round). Define a budget ceiling and whether the teacher baseline is cached across rounds (it should be - the original does not change).
+- Whether the distill report persists as a sidecar corpus (like skill-forge's example report) or is returned inline.
+- Standalone behaviour: distill mode needs subagents/forge; in pure chat (no subagents) the skill must degrade honestly - likely "local mode only; distill mode requires the runner harness" - confirm the degrade message.

--- a/docs/superpowers/specs/2026-06-03-skill-forge-hardening-and-ab-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-03-skill-forge-hardening-and-ab-extraction-design.md
@@ -1,0 +1,107 @@
+# Design: skill-forge hardening + A/B-equivalence extraction
+
+Date: 2026-06-03
+Status: Approved for implementation planning
+Context: post-ship review of skill-forge (v1.28.4) against Anthropic's skill-eval guidance
+
+## Problem
+
+A fresh review of the shipped `skill-forge` (against Anthropic's "evals + test across Haiku/Sonnet/Opus" guidance) surfaced one architectural refactor and a set of hardening gaps. Verified against the shipped code, the genuinely-open items are below; items the review raised that are already handled (per-lens fixture calibration - the fixture plants one defect per lens; the batching threshold - already labelled provisional; corpus location - already in `test-taxonomy.md`) are out of scope.
+
+This spec has two parts: **A) extract A/B-equivalence into its own library skill**, and **B) five hardening changes to skill-forge**.
+
+## Part A: extract A/B-equivalence into its own library skill
+
+A/B-equivalence currently lives inside `skill-forge` (`references/ab-equivalence.md` + `references/equivalence-judge-prompt.md`, ~216 lines), added when `semantic-compress` v2 needed it. The review's point stands: skill-forge answers *"is this one skill good?"* (quality panel -> promotion gate); A/B-equivalence answers *"do these two versions behave the same?"* - a different, more general question, with consumers beyond skill-forge (semantic-compress today; directive-clarity and prompt-regression next). Hosting it in skill-forge couples a general primitive to one skill's gate.
+
+### Goal
+
+A new library skill **`ab-equivalence`**: given two versions of a document and a transfer set, run each through a runner and judge per-case behavioural equivalence (`equivalent | candidate-regressed | candidate-diverged`) plus the efficiency signal. It is composed by `semantic-compress` (distill validation) and, later, `directive-clarity`.
+
+### Runner layering (recommended)
+
+The genuinely shared primitive is the **runner** ("apply a document to an input, return a transcript") - more general than the forge. So:
+
+- **`ab-equivalence` owns** `runner-prompt.md` (moved from skill-forge) + the equivalence judge + the A/B orchestration.
+- **`skill-forge` composes** `ab-equivalence`'s runner, and keeps its own 5-lens panel + 3-tier gate. Dependency flows by generality (skill-forge -> ab-equivalence), the same way `marathon` composes `pr-review-merge`.
+- **`semantic-compress`** composes `ab-equivalence` for distill-mode validation (replacing its current dependency on skill-forge's A/B capability).
+
+**Lighter fallback if the rewire is too much churn:** leave `runner-prompt.md` in skill-forge and have `ab-equivalence` reference it. This still removes the A/B orchestration + equivalence judge from skill-forge (the review's core ask) but leaves a mild `ab-equivalence -> skill-forge` dependency. The plan picks one after sizing the rewire; the recommended layering is preferred.
+
+### Behaviour-preserving
+
+This is a **refactor**: forge behaviour and distill behaviour must be identical before and after. The extraction is verified by re-running both (a behaviour-preserving move is exactly the optimizer's own domain - the meta-check is to A/B the forge against itself pre/post-extraction).
+
+### Knock-on
+
+`scripts/standalone_skill_config.py` + `scripts/tests/test_integration.py` gain an `ab-equivalence` entry/class; `skills/README.md`, `docs/index.md`, `.claude-plugin/plugin.json` updated; team/subagent infra `chat-skip`-wrapped as usual.
+
+## Part B: skill-forge hardening (the open review items)
+
+### B1 - Multi-model runner testing (highest value)
+
+skill-forge fixes the runner model implicitly. A skill that passes Fidelity on Opus runners can fail on Haiku, and Anthropic's guidance is to test across tiers. Add:
+
+- A **runner-model knob** (which model(s) the runner uses).
+- A rule: **forge against the weakest tier the skill will ship to** (Haiku is where skills break); optionally sweep tiers for skills that ship broadly.
+- The forge report records which model(s) the skill was forged against - a skill forged only on Opus is not certified for Haiku.
+
+### B2 - Scale investment by skill scope (not by lens count)
+
+The 5-lens default over-invests on a 50-line reference card. But the cost driver is **runners = test cases x rounds**, not lens count (the five lenses judge the *same* transcripts cheaply; Trigger is a static read). So:
+
+- Scale the **test-suite size and round budget** by skill scope (lines / surface). A tiny skill gets a minimal suite (1-2 cases) and a tight round budget; a large skill gets the full taxonomy.
+- **Keep all five lenses regardless of size** - dropping lenses by size would re-open the exact hole the self-forge closed (a 3-lens default silently drops Compression and Trigger). Lens count stays driven by explicit quick-check request, not by size.
+
+### B3 - STOP -> next-steps workflow
+
+On STOP (gate unmet at budget), skill-forge produces a best-so-far artifact + a report naming the unmet gate, but the *continuation* is implicit. Spell it out:
+
+- **Gate 1 (Fidelity) unmet** -> the skill cannot reliably do its job: revise the skill substantively (or the intent, if a clause was wrong) and re-forge.
+- **Gate 2 (HIGH dissent) unmet** -> a real quality risk remains: address the named HIGH finding and re-forge, or accept best-so-far with the dissent documented as a known limitation.
+- **Budget hit mid-progress** -> raise the budget and continue, or accept best-so-far.
+- Make the recommended next move explicit in the report, not left for the user to infer.
+
+### B4 - Promote semantics (context-dependent)
+
+"Promote" is currently vague about what writing the artifacts means across contexts. Make it explicit:
+
+- **Plugin repo** (skill lives in a repo): write the hardened files in place on a branch and **offer a PR**, as `assess-pr` does.
+- **Personal skill** (`~/.claude/skills/<name>/`): update the files **in place** (no PR), and say so.
+- The forge report always lists exactly what was written and where.
+
+### B5 - Borderline-severity calibration cases
+
+The flawed fixture proves each lens *can* catch its planted defect, but not that the behavioural lenses are well-calibrated on *severity* (a systematic leniency bias would pass the gate while under-rating real findings). Extend the fixture with a few **near-miss / borderline cases** (a defect a lens should rate LOW/MED, and a clean case a lens should pass) so the calibration check stresses severity judgement, not just detection. This addresses the real residual behind the review's (mistaken) "only Trigger is calibrated" point.
+
+## Non-goals
+
+- No change to the gate hierarchy, the five lenses' definitions, or the behavioural/static rule.
+- The 5-lens default stays; only suite size and round budget scale by scope.
+- The A/B extraction changes no forge or distill *behaviour* - it is a pure refactor.
+
+## Validation
+
+- **Re-forge skill-forge** after both parts: it must still self-promote (the self-forge is its acceptance test).
+- **Behaviour-preserving check on the extraction**: A/B the forge and the distill loop pre/post-extraction - same behaviour, by construction.
+- Contract + standalone suites green; standalone ZIPs build.
+
+## Housekeeping (fold in)
+
+The v2 distillation design spec (`2026-06-03-semantic-compress-distillation-design.md`) and the directive-clarity follow-up spec (`2026-06-03-instruction-optimizer-directive-clarity-design.md`) currently live only on the `semantic-compress-v2` branch, not on `main` - the implementation marathon shipped the code without merging the design history. Restore both to `main`'s `docs/superpowers/specs/` (and the index) as part of this work so the design record is complete and the directive-clarity tag's tasks reference a spec that exists on main.
+
+## File changes (for the plan)
+
+- New: `skills/ab-equivalence/SKILL.md` + references (moved `runner-prompt.md`, `ab-equivalence.md`, `equivalence-judge-prompt.md`).
+- `skills/skill-forge/SKILL.md` + references: remove the A/B-equivalence host content; compose `ab-equivalence`'s runner; add B1 multi-model, B2 scope-scaling (in `judge-lenses.md` / a runner section), B3 STOP next-steps, B4 promote semantics; extend the flawed fixture for B5.
+- `skills/semantic-compress/SKILL.md` + `references/distill-loop.md`: compose `ab-equivalence` instead of skill-forge's A/B capability.
+- `scripts/standalone_skill_config.py`, `scripts/tests/test_integration.py`: add `ab-equivalence`; update skill-forge/semantic-compress entries.
+- `skills/README.md`, `docs/index.md`, `.claude-plugin/plugin.json` (MINOR bump), `CLAUDE.md` scope.
+- Restore the two orphaned design specs to `main` + index.
+
+## Open questions for the plan
+
+- Runner layering: confirm the recommended (`ab-equivalence` owns the runner) vs the lighter fallback after sizing the skill-forge rewire.
+- The multi-model knob: is it a forge-time argument, a Marathon-config value, or both? How does the standalone (solo, no model choice) path degrade?
+- B2 scope thresholds: what line/surface counts map to minimal vs full suites - and is this a hard rule or lead judgement?
+- Does extracting the runner break the standalone build for skill-forge (which `chat-skip`s its team infra)? Confirm the markers move correctly with the runner.


### PR DESCRIPTION
## Summary

- Three design specs that shipped their code on other branches (`semantic-compress-v2`, `skill-forge-hardening`) never had their spec docs merged to `main`.
- This PR restores them to their canonical location in `docs/superpowers/specs/` and adds them to the chronological index in `docs/superpowers/README.md`.

## Changes

- `docs/superpowers/specs/2026-06-03-semantic-compress-distillation-design.md` - restored from `semantic-compress-v2` branch (documents the v2 holistic distillation mode)
- `docs/superpowers/specs/2026-06-03-instruction-optimizer-directive-clarity-design.md` - restored from `semantic-compress-v2` branch (documents the directive-clarity transform shipped inside semantic-compress)
- `docs/superpowers/specs/2026-06-03-skill-forge-hardening-and-ab-extraction-design.md` - restored from `skill-forge-hardening` branch commit a0c6c67 (documents this marathon's A/B-equivalence extraction + B1-B5 hardening)
- `docs/superpowers/README.md` - three chronological index entries added to the Specs table
- `.claude-plugin/plugin.json` - version bumped to 1.29.6

## Testing

Docs-only change. No logic changed. Contract test (`plugin contract pytest`) validates that relative markdown links resolve to real files - all three spec links point to real files added in this PR.

## Risk

Low. Strictly additive: three new files, three new README rows, version bump.