### PR TITLE
feat: Add ab-equivalence to standalone build pipeline

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on /skill-forge's A/B equivalence harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.29.7",
+  "version": "1.29.10",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -222,6 +222,32 @@ SKILLS: dict[str, dict] = {
         "exclude_dirs": set(),
         "replacements": {},
     },
+    "ab-equivalence": {
+        "standalone_name": "ab-equivalence",
+        "standalone_description": (
+            "Compare two versions of an LLM-directed document - an original (teacher) and a "
+            "candidate (student) - across a transfer set and return a per-case "
+            "behavioural-equivalence verdict plus an efficiency signal. A transform-agnostic "
+            "library capability other skills compose to gate a transform on behavioural sameness. "
+            "TRIGGER when asked to A/B test two versions of a prompt, instruction, or skill, to "
+            "check whether a rewritten or compressed document still behaves the same as the "
+            "original, to validate behavioural equivalence between two document versions, or to "
+            "gate a transform on no-regression. This standalone build runs solo mode only; "
+            "phased sub-agent and team modes require the Claude Code CLI."
+            + VERSION_SUFFIX
+        ),
+        "source_dir": "skills/ab-equivalence",
+        "exclude_dirs": {"tests", "__pycache__", ".pytest_cache", ".venv"},
+        "replacements": {
+            "execution-mode-rule": (
+                "This standalone build runs solo mode only: a single agent works each case "
+                "sequentially - applying the original and candidate via the runner wrapper, "
+                "then judging the two transcripts with the equivalence-judge prompt to record "
+                "the per-case verdict and efficiency signal. Phased sub-agent and team modes "
+                "require the Claude Code CLI and are not available here."
+            ),
+        },
+    },
     "semantic-compress": {
         "standalone_name": "semantic-compress",
         "standalone_description": (

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -234,6 +234,55 @@ class TestDeslopBuild:
         assert Path(zf1.filename).read_bytes() == Path(zf2.filename).read_bytes()
 
 
+# ── ab-equivalence ───────────────────────────────────────────────────────────
+
+class TestAbEquivalenceBuild:
+    @pytest.fixture(scope="class")
+    def ab_zip(self, tmp_path_factory):
+        return _build("ab-equivalence", tmp_path_factory.mktemp("ab-equivalence"))
+
+    def test_skill_md_present(self, ab_zip):
+        assert "ab-equivalence/SKILL.md" in ab_zip.namelist()
+
+    def test_references_present(self, ab_zip):
+        names = ab_zip.namelist()
+        for ref in (
+            "ab-equivalence/references/runner-prompt.md",
+            "ab-equivalence/references/ab-equivalence.md",
+            "ab-equivalence/references/equivalence-judge-prompt.md",
+        ):
+            assert ref in names, f"{ref} missing from ZIP"
+
+    def test_no_team_infrastructure_leaked(self, ab_zip):
+        for name, content in _md_contents(ab_zip).items():
+            for tool in ("TeamCreate", "SendMessage", "TeamDelete"):
+                assert tool not in content, f"{name}: {tool} leaked"
+
+    def test_no_agent_teams_env_var(self, ab_zip):
+        for name, content in _md_contents(ab_zip).items():
+            assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in content, (
+                f"{name}: capability flag env var leaked"
+            )
+
+    def test_frontmatter_name_correct(self, ab_zip):
+        skill_md = ab_zip.read("ab-equivalence/SKILL.md").decode("utf-8")
+        assert "name: ab-equivalence" in skill_md
+
+    def test_standalone_description_applied(self, ab_zip):
+        skill_md = ab_zip.read("ab-equivalence/SKILL.md").decode("utf-8")
+        assert "Standalone build v" in skill_md
+
+    def test_no_orphan_markers(self, ab_zip):
+        for name, content in _md_contents(ab_zip).items():
+            assert "chat-skip" not in content, f"{name}: chat-skip marker leaked"
+            assert "chat-replace" not in content, f"{name}: chat-replace marker leaked"
+
+    def test_zip_is_deterministic(self, tmp_path):
+        zf1 = _build("ab-equivalence", tmp_path / "run1")
+        zf2 = _build("ab-equivalence", tmp_path / "run2")
+        assert Path(zf1.filename).read_bytes() == Path(zf2.filename).read_bytes()
+
+
 # ── semantic-compress ─────────────────────────────────────────────────────────
 class TestSemanticCompressBuild:
     @pytest.fixture(scope="class")

--- a/skills/ab-equivalence/SKILL.md
+++ b/skills/ab-equivalence/SKILL.md
@@ -100,6 +100,7 @@ Why it exists: compression's gate is **strict no-regression** (sameness alone). 
 
 ## Execution modes
 
+<!-- chat-replace:execution-mode-rule -->
 The capability runs the same mechanism in every mode; modes differ only in how the runner pair per case and the equivalence judge are spawned. The caller's harness selects the mode; A/B equivalence runs inside whatever mode it is handed.
 
 **Solo mode** (chat / standalone ZIP, no subagents) is the default: a single agent works each case sequentially - it applies the `original` via the runner wrapper, then the `candidate` on the identical input, then judges the two transcripts with the equivalence-judge prompt, recording the verdict and efficiency signal before moving to the next case. The cached teacher transcript is the only state carried between rounds.


### PR DESCRIPTION
## Summary

- Registers `ab-equivalence` in `scripts/standalone_skill_config.py` with a `standalone_description` (solo-mode note + VERSION_SUFFIX), `execution-mode-rule` replacement, and `exclude_dirs` matching the skill-forge pattern
- Adds `<!-- chat-replace:execution-mode-rule -->` marker to `skills/ab-equivalence/SKILL.md` so the multi-mode intro swaps to a standalone-only sentence in the ZIP
- Adds `TestAbEquivalenceBuild` to `scripts/tests/test_integration.py` covering the 8 required assertions: SKILL.md present, three references present (runner-prompt, ab-equivalence, equivalence-judge-prompt), no team infrastructure (TeamCreate/SendMessage/TeamDelete), no capability env var, correct frontmatter name, standalone description applied, no orphan markers, deterministic ZIP
- Bumps plugin version to `1.29.10`

## Test plan

- [ ] `cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -v` - all 108 tests pass
- [ ] `TestAbEquivalenceBuild` - all 8 new tests pass
- [ ] ZIP structure confirmed: `ab-equivalence/SKILL.md` + three references under `references/`, no `tests/`, no team infra strings