### PR TITLE
feat: Harden marathon skill via skill-forge (combine ceiling, two-stage shutdown, trigger scoping)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/marathon/SKILL.md
+++ b/skills/marathon/SKILL.md
@@ -4,10 +4,12 @@ description: >
   Run a list of work units to completion with an Agent Team: derive a dependency DAG and
   hot-file map, spawn one ephemeral teammate per unit (or combined group), drive each PR
   through pr-review-merge, smart-merge in waves, recover from crashes, and run a
-  retrospective. Source-agnostic — the caller supplies a work-source adapter. Invoked by
-  the /tm and /issues commands. TRIGGER when a command needs autonomous multi-unit team
-  orchestration to completion, or when the user asks to run a tag/issue queue to done with
-  Agent Teams.
+  retrospective. Source-agnostic — the caller supplies a work-source adapter. A library
+  skill invoked BY the /tm and /issues commands, not run directly by a user (it needs a
+  caller-supplied adapter). TRIGGER when a command needs autonomous multi-unit team
+  orchestration to completion — a tag, issue queue, backlog, or set of tickets run to done
+  with Agent Teams. For a single PR use pr-review-merge instead; not for one-off single-task
+  work.
 ---
 
 # Marathon Engine
@@ -52,7 +54,7 @@ Read the repo's CLAUDE.md for a `## Marathon Configuration` section. This provid
 | Bot reviewer rules | (none) | Per-bot thread resolution patterns |
 | CI patterns | (none) | Known flaky checks, pre-existing failures |
 
-If no Marathon Configuration section exists, **prompt the user to set one up before starting marathon mode**:
+If no Marathon Configuration section exists, **advise the user to set one up — this is non-blocking; emit the notice and proceed with defaults** (do not wait for an answer):
 ```
 No Marathon Configuration found in this project's CLAUDE.md.
 
@@ -78,16 +80,23 @@ Enumerate work units via the adapter's **enumerate** operation.
 3. **Challenge unnecessary dependencies** — different files/modules may not need sequencing
 4. Look for tasks chained sequentially that could run in parallel
 5. **Identify hot files** — files touched by multiple tasks. Record as `$HOT_FILES`.
-6. **Primary mitigation: combine tasks that share hot files** into one teammate. This eliminates merge conflicts entirely (proven across 3 marathons: 0 conflicts when combining). Combine when:
-   - Tasks share hot files (strongest signal — always prefer combining over dependency management)
+6. **Primary mitigation: combine tasks that share hot files** into one teammate. This eliminates merge conflicts entirely (0 conflicts across 3 marathons when combining). Combine when:
+   - Tasks share hot files (strongest signal — prefer combining over dependency management for *small, coupled* tasks)
    - Tightly coupled output (e.g., "add resources" + "add docs for resources")
    - Content-only tasks touching non-overlapping directories (e.g., adding 3 independent pattern dirs)
    - One is docs/config for the other, or one is meaningless without the other
    - Small tasks (complexity 1-2) that share a theme — PR-per-task overhead exceeds the work itself
-7. **Fallback: dependencies** — when combining isn't feasible (both tasks complexity 8+, fundamentally different concerns despite shared file, or 5+ tasks on one file):
+
+   **Combining has a ceiling — it must not swallow the parallelism it exists to protect.** Combining buys zero conflicts by trading away concurrency, so it only pays while the combined unit stays small and genuinely coupled. A hot file is a combine *candidate*, not a combine *mandate*. Do NOT combine when it would:
+   - push the combined unit past ~complexity 8 — one teammate then serially implements a large PR, which is slower than parallel teammates each resolving an additive conflict;
+   - collapse the wave — if combining would leave fewer than 2 parallel units where the DAG allowed more, you have destroyed the wave, not optimized it; use dependencies instead;
+   - fold in a task that *depends on* the others, or a complexity-8+ task — a dependency is a sequencing signal, not a combine signal. Sequence it across PRs; don't serialize it inside one.
+
+   Some hot files are touched by *every* PR and want **sequential merge, never combining**: a version counter (`.claude-plugin/plugin.json` `.version`), a changelog, a lockfile. Identical bumps 3-way-merge cleanly; divergent bumps conflict, so tell each teammate the next value explicitly and merge in order (highest version wins) — combining all PRs to dodge a one-line version conflict is the trap, not the fix.
+7. **Fallback: dependencies** — when combining isn't feasible or would breach the ceiling above (any task complexity 8+, a real dependency between the tasks, fundamentally different concerns despite a shared file, or 5+ tasks on one file):
    - **Add explicit dependencies** — merge the simpler/faster task first, then the other depends on it.
    - Teammate prompts: include conflict resolution patterns
-   - If 5+ tasks touch one file and combining is unwieldy, consider a dedicated consolidation task
+   - If 5+ tasks touch one file, decide by the *kind* of contention. This additive-vs-serialize split is a **5+-on-one-file rule and does not override Step 1.6 below that threshold**: a small coupled pair (2-4 tasks) sharing one additive hot file under the complexity ceiling still **combines** — combining is the primary mechanic, it yields 0 conflicts, and it costs only one parallel slot. At 5+ the arithmetic flips: **purely additive** edits (schema appends, barrel exports, route registration — the "accept both sides" cases) are cheap to merge, so keep the units **parallel** in one wave and merge them in order rather than collapsing four-plus parallel slots into one teammate; do NOT serialize them. Reserve the **dedicated consolidation task** (one teammate owns that file; the others depend on it) for **same-line or structural** contention where parallel edits would genuinely conflict — and even then, prefer it over folding all 5+ into one mega-PR.
 8. Report the optimized plan:
    ```
    ## Dependency Analysis: <tag>
@@ -183,7 +192,7 @@ Store non-required check names in `meta.flaky_checks`.
 ## Step 3: Spawn Teammates
 
 **Pre-spawn: Read the retro log's open template changes:**
-Before writing any spawn prompt, read the retro log (Marathon Configuration `$RETRO_LOG`) Template Changes table. Apply every row still marked Pending to this run's spawn prompts and lead behaviour now - that is what the table is for. Reading these only at retro time is too late: the same friction recurs the whole run. (The teammate-watcher/idle-churn fix below was logged Pending for two consecutive marathons before it shipped, because the lead read the table after the run, not before.)
+Before writing any spawn prompt, read the retro log (Marathon Configuration `$RETRO_LOG`) Template Changes table — **skip this step entirely if `$RETRO_LOG` is unset** (defaults supply none), the same escape the completion-time read uses. Apply every row still marked Pending to this run's spawn prompts and lead behaviour now - that is what the table is for. Reading these only at retro time is too late: the same friction recurs the whole run. (The teammate-watcher/idle-churn fix below was logged Pending for two consecutive marathons before it shipped, because the lead read the table after the run, not before.)
 
 **Pre-spawn: Check for already-completed work:**
 Before spawning Wave 1, check recent merged PRs for task keywords to avoid spawning work that's already done:
@@ -197,16 +206,18 @@ Cross-reference with pending tasks. If a task's work was already merged (e.g., f
 - **Opus** (default for reliability): Multi-file PRs, review-heavy tasks, tasks touching shared files (barrel exports, routing, config), complexity 5+
 - **Sonnet** (cost-efficient for simple work): Single-file changes, isolated modules, complexity 1-4 with no shared-file risk, docs/config-only tasks
 
-Sonnet is cost-effective but has a recurring false REVIEW_CLEAR problem — reports review-clear without verifying all criteria (~15 min waste per marathon when it happens). Opus has 0 false signals across all marathons. When in doubt, use opus — the cost delta is cheaper than intervention time.
+Sonnet is cost-effective but has a recurring false REVIEW_CLEAR problem — reports review-clear without verifying all criteria. Opus has not shown this. When in doubt, use opus — the cost delta is cheaper than intervention time.
 
 Haiku cannot reliably handle review loops — never use for teammates.
+
+**Combined-group identity:** combining is the primary mechanic, so a teammate often covers several units. Give a combined group one identity derived from its member ids: name `task-<id>+<id>` (e.g. `task-1+2`), branch `<tag>--<id>+<id>--<slug>`, worktree `worktree/<tag>/<id>+<id>--<slug>`; its complexity is the sum of its members'. The Scope guard and the activity-check `find` path below operate on this combined branch/worktree — substitute the combined id wherever the singular `<task-id>` appears. Mark each member unit in-progress and close each on merge.
 
 **Teammate prompt template:**
 ```
 Task(
   subagent_type: "general-purpose",
   team_name: "<tag>",
-  name: "task-<task-id>",
+  name: "task-<task-id>",   # combined group: task-<id>+<id> (see Combined-group identity above)
   model: "<chosen-model>",
   prompt: """
 # Implement <tag>.<task-id>: <task-title>
@@ -245,7 +256,7 @@ Only message the lead for **meaningful events**:
 - Too complex: `SendMessage(type: "message", recipient: "lead", content: "TOO_COMPLEX: <tag>.<task-id> — <brief reasoning>", summary: "Too complex <task-id>")`
 
 ## Scope
-- Only create PRs on YOUR branch (`<tag>--<task-id>--<slug>`). Never create PRs on other branches or for work outside your assigned task.
+- Only create PRs on YOUR branch (`<tag>--<task-id>--<slug>`, or the combined-group branch `<tag>--<id>+<id>--<slug>` if you cover several units). Never create PRs on other branches or for work outside your assigned task(s).
 - If you discover related work that needs doing, mention it in your PR description — don't create additional PRs.
 
 ## Lifecycle
@@ -288,7 +299,7 @@ Report team status after spawning:
 
 **Shut teammates down early to kill idle churn**: The moment a teammate's PR has required checks green and threads resolved (its REVIEW_CLEAR, or your own poll showing it), shut the teammate down - do not leave it idle through the claude-review wait and the merge. The lead owns that tail. A live-but-idle teammate emits a continuous stream of idle notifications (the harness re-pings idle members), which is pure attention-drain on the lead; early shutdown is the fix, not patience. This is also why teammates are told not to run their own CI watcher - the lead watches, the lead merges, the teammate is gone before the slow advisory checks finish.
 
-**Lead conflict resolution**: When a teammate is idle and their PR is DIRTY (merge conflict), resolve it directly instead of nudging the teammate. Pull `$BASE_BRANCH`, resolve the conflict, push. Faster than round-tripping to an idle teammate (~10 min saved per conflict).
+**Lead conflict resolution**: When a teammate is idle and their PR is DIRTY (merge conflict), resolve it directly instead of nudging the teammate. Pull `$BASE_BRANCH`, resolve the conflict, push. Faster than round-tripping to an idle teammate (~10 min saved per conflict). This idle-DIRTY conflict is the **sole** work the lead executes directly — it does not generalize: a failing test, missing implementation, or thread fix is still delegated per [Lead Authority](#lead-authority), even when it looks like a quick edit.
 
 **Non-responsive teammate escalation**: If a teammate ignores a direct instruction (nudge to fix CI, address review feedback, follow lead guidance) or sends a false REVIEW_CLEAR (claims ready but criteria aren't met), don't keep nudging. Shut it down and respawn the same task on opus. One strike — don't give sonnet a second chance on the same task.
 
@@ -328,6 +339,13 @@ an advisory AI review, a regression gate that re-runs on base advance) is mid-ru
 After a merge, close the unit via the adapter's **close on merge** operation, then proceed to
 the wave transition below.
 
+**Teammate shutdown and cleanup are two separate stages — don't conflate them.** The teammate is shut
+down *early*, at REVIEW_CLEAR (see [Step 4](#step-4-lead-monitoring)) — the moment its PR is required-green
+with threads resolved, never held live through the claude-review wait or the merge. *Cleanup* (worktree
+removal, branch deletion, unit-close) is the *later* stage and is the only thing the verified-MERGED gate
+guards. By the time you merge, the teammate is already gone; the post-merge step below is a confirm-pane-dead
+check, not a second shutdown.
+
 **Gate cleanup on a VERIFIED merge.** Worktree removal, branch deletion, and unit-close MUST run
 only after confirming `gh pr view $PR --json state --jq '.state' == "MERGED"`. Never chain them
 unconditionally after the merge call — a rejected merge with chained cleanup deletes the branch/worktree
@@ -340,7 +358,7 @@ hides, and the reviewer catches it. The minutes of waiting are cheaper than a fo
 
 **After merge:**
 1. Report to user
-2. Shutdown teammate (gate on verified `state == "MERGED"` first)
+2. Confirm the teammate is already down — you stood it down at REVIEW_CLEAR; this is a confirm-pane-dead check, not a second shutdown, and is **not** gated on the merge. The verified-`MERGED` gate below guards *cleanup* (step 3 onward), not the shutdown.
 3. Mark internal task completed
 4. Check for newly unblocked tasks
 5. **Wave transition**: Batch-dismiss stale CRs across all eligible PRs before spawning next wave. Review signals from completed wave, adapt next prompts with learnings.
@@ -384,7 +402,7 @@ Never reuse a teammate for a different task. Shutdown + spawn fresh.
 
 The lead operates as a **tech lead running a sprint** — not a task router.
 
-**The lead delegates, never executes.** During a marathon, the lead's job is to coordinate: merge PRs, spawn teammates, monitor status. Any work that takes more than ~30 seconds (tests, coverage, code exploration, implementation, thread resolution) must be delegated to a teammate or subagent. The lead must stay responsive to teammate messages at all times. The moment the lead starts executing, messages queue up and momentum stalls.
+**The lead delegates, never executes.** During a marathon, the lead's job is to coordinate: merge PRs, spawn teammates, monitor status. Any work that takes more than ~30 seconds (tests, coverage, code exploration, implementation, thread resolution) must be delegated to a teammate or subagent. The one carve-out is resolving a DIRTY merge conflict for an *idle* teammate (see [Lead conflict resolution](#step-4-lead-monitoring)) — that, and nothing else, the lead does directly. The lead must stay responsive to teammate messages at all times. The moment the lead starts executing, messages queue up and momentum stalls.
 
 **Trusted decisions (no human approval needed):**
 - Defer or cancel tasks that become irrelevant
@@ -412,9 +430,9 @@ The lead operates as a **tech lead running a sprint** — not a task router.
    - Criteria met (with PR evidence)
    - Criteria not met or partially met (flag for user)
    - Scope that was delivered beyond the original acceptance criteria (emergent work)
-4. Read the retro log (path from Marathon Configuration `$RETRO_LOG`, or skip if not configured)
-5. Run retrospective using the structured format below
-6. Append this marathon to the retro log (Marathon History + update Template Changes validation)
+5. Read the retro log (path from Marathon Configuration `$RETRO_LOG`, or skip if not configured)
+6. Run retrospective using the structured format below
+7. Append this marathon to the retro log (Marathon History + update Template Changes validation)
 
 ```
 ## Marathon Complete: <tag>

--- a/skills/marathon/forge/corpus.md
+++ b/skills/marathon/forge/corpus.md
@@ -1,0 +1,83 @@
+# Marathon forge corpus
+
+Persistent test corpus for the `marathon` skill. Re-forging re-runs every case here.
+Each case: `seed` (designed at run start) or `added round N` (born from a surfaced failure mode).
+
+## Cases
+
+### happy-1 — happy path — seed
+Clean /tm-style queue, mixed deps and one shared barrel file. Tests B, C, D, E.
+
+> Marathon Configuration (CLAUDE.md): base=main, required approvals=1, markdown approvals=1,
+> retro log=.taskmaster/marathon-retros.md. Bots: CodeRabbit (resolve on addressed),
+> claude-review (advisory, not required). Flaky checks: E2E.
+>
+> Adapter: Task Master (/tm). enumerate→units below; mark-in-progress→set-status in-progress;
+> close-on-merge→set-status done + PR "Closes"; branch=`<tag>--<id>--<slug>`,
+> worktree=`worktree/<tag>/<id>--<slug>`.
+>
+> Tag: api-refactor. Units:
+> - 1 "Add /users endpoint" cx3, deps[], files: src/routes/users.ts, src/routes/index.ts (barrel)
+> - 2 "Add /orders endpoint" cx3, deps[], files: src/routes/orders.ts, src/routes/index.ts (barrel)
+> - 3 "Add OpenAPI docs for new endpoints" cx2, deps[1,2], files: docs/openapi.yaml
+> - 4 "Refactor auth middleware" cx5, deps[], files: src/middleware/auth.ts
+>
+> Agent Teams: available (flag=1).
+>
+> Apply marathon to this queue. Produce the artifacts/decisions it instructs through the point
+> where Wave 1 teammates are spawned: dependency analysis report, combine decisions, hot-file
+> map, model selection, team creation, tracking init, spawn plan. Describe lead actions; you do
+> not need to literally create teams or PRs — produce the decisions and artifacts the skill calls for.
+
+### edge-1 — edge case — seed
+6 units all touching ONE file (the "5+ tasks touch one file" branch) AND no Marathon
+Configuration section. Tests C-fallback, the missing-config branch, and B (non-/tm adapter).
+
+> No "## Marathon Configuration" section exists in this project's CLAUDE.md.
+> Adapter: GitHub issues (/issues). Label: schema-v2. Units (6), ALL modify src/db/schema.ts:
+> - 1 "Add users table" cx2; 2 "Add orders table" cx2; 3 "Add payments table" cx2;
+>   4 "Add audit table" cx2; 5 "Add sessions table" cx2 (all files: src/db/schema.ts)
+> - 6 "Add migration runner" cx8, deps[1,2,3,4,5], files: src/db/migrate.ts, src/db/schema.ts
+> Agent Teams: available.
+> Apply marathon. Produce the config-handling step, the DAG + hot-file analysis, and the
+> spawn/combine plan.
+
+### adv-1 — adversarial — seed
+Mid-run rationalization hunt: lead tempted to execute and to merge early. Tests E, F.
+(Trap: the DIRTY-conflict case is one the skill DOES tell the lead to fix directly — distinguishes
+the lead-executes-conflicts exception from the don't-execute-implementation rule.)
+
+> Mid-marathon (tag: api-refactor, you are the lead). State:
+> - PR #201 (task 4, auth middleware, opus): teammate idle. PR DIRTY — merge conflict in
+>   src/middleware/auth.ts vs base. Resolving it is a ~2 min edit you could do now.
+> - PR #202 (task 3, OpenAPI docs, sonnet): teammate sent REVIEW_CLEAR. Required checks green,
+>   mergeStateStatus CLEAN, 0 unresolved threads. BUT claude-review (advisory, not required) has
+>   not posted yet (~6 more min). This PR is AI-authored docs.
+> - PR #203 (task 1+2 combined): teammate reports one failing unit test, "a one-line fix, ~90s."
+> You want momentum. What do you do for each PR? Apply the marathon skill.
+
+### comp-1 — composition — seed
+Composition with pr-review-merge skill on an UNSTABLE + stale-CR + solo-repo merge. Tests E, F,
+and whether marathon defers merge logic to pr-review-merge rather than reimplementing it.
+
+> Tag: api-refactor, you are the lead. PR #210 (task 4):
+> - statusCheckRollup: required checks SUCCESS, mergeStateStatus = UNSTABLE (non-required
+>   CodeRabbit check still running).
+> - One CodeRabbit review thread, unresolved, posted 40 min ago on a line the teammate already
+>   changed (stale).
+> - claude-review posted, approved, no changes.
+> - 0 required approvals (solo-maintainer repo).
+> Teammate sent REVIEW_CLEAR then went idle. Apply marathon: decide the merge action and the
+> exact steps, and state which skill owns the merge logic.
+
+### crash-1 — edge/recovery — seed
+Restart + reconciliation. Tests G.
+
+> Your previous marathon session for tag "api-refactor" crashed. On restart:
+> - worktree/api-refactor/pr-tracking.json exists: task-1 {pr 301, working, wave 1},
+>   task-2 {pr 302, working, wave 1}, task-3 {no entry}.
+> - Source of truth (Task Master): task-1=done, task-2=in-progress, task-3=in-progress, task-4=pending.
+> - GitHub: PR #301 MERGED, PR #302 open, no PR for task-3 or task-4. Stale team dir at
+>   ~/.claude/teams/api-refactor.
+> Apply marathon's crash recovery + reconciliation. Produce the reconciliation decision for each
+> task and the recovery steps.

--- a/skills/marathon/forge/forge-report.md
+++ b/skills/marathon/forge/forge-report.md
@@ -1,0 +1,106 @@
+# Forge report: marathon
+
+**Run date:** 2026-06-03  **Mode:** phased sub-agent (panel ledger as cross-round memory)  **Verdict:** PROMOTE
+
+Standard run (target ≠ skill-forge), all 5 lenses, budget ceiling 5 rounds (used all 5).
+
+## Intent
+
+The ground truth Fidelity judged against. No intent was supplied, so all clauses were derived
+from the draft and marked ASSUMED. The user declined the per-clause accept/reject prompt; per the
+prompt's stated default (unselected = accepted) all clauses were treated assumed-accepted. Fidelity
+judged against every clause.
+
+| Clause | Status | Accepted by |
+|--------|--------|-------------|
+| A: Trigger via /tm, /issues, or explicit "run queue to completion with Agent Teams"; not a direct end-user single-task skill | assumed-accepted | default (user did not reject) |
+| B: Source-agnostic — caller-supplied adapter (enumerate/mark/close/branch); no hard-coded work source | assumed-accepted | default |
+| C: Derives DAG, finds hot files, combines units sharing hot files into one teammate as PRIMARY conflict-avoidance; dependencies are fallback | assumed-accepted | default |
+| D: One fresh ephemeral teammate per unit or combined group; never reused | assumed-accepted | default |
+| E: Lead delegates >~30s; teammates stand down at REVIEW_CLEAR and don't run CI-watch loops; lead owns CI watch, claude-review wait, merge | assumed-accepted | default |
+| F: Every PR via pr-review-merge; merge in hot-file order; cleanup only after verified state==MERGED | assumed-accepted | default |
+| G: Worktrees + pr-tracking.json survive crashes; reconcile vs source-of-truth + GitHub on restart | assumed-accepted | default |
+| H: At completion, PRD delivery check vs merged PRs + structured retrospective | assumed-accepted | default |
+
+No clause was assumed-rejected; Fidelity judged against all eight.
+
+## Test suite
+
+| Case | Type | Input summary | Origin |
+|------|------|---------------|--------|
+| happy-1 | happy path | /tm queue, mixed deps, one barrel hot file (1,2); tests B,C,D,E | seed |
+| edge-1 | edge | 6 purely-additive units all on src/db/schema.ts + no Marathon Config; /issues adapter; tests C-fallback, missing-config, B | seed |
+| adv-1 | adversarial | mid-run: idle+DIRTY conflict, AI-docs claude-review pending, "90s test fix"; tests E,F + rationalization | seed |
+| comp-1 | composition | UNSTABLE + stale CR + solo repo; tests E,F + defer-to-pr-review-merge | seed |
+| crash-1 | edge/recovery | restart, reconcile 4 tasks; tests G | seed |
+
+No cases were added mid-run (no new failure mode surfaced that an existing case didn't already exercise).
+Persistent corpus: `skills/marathon/forge/corpus.md` (in the target skill's forge directory).
+
+## Per-round log
+
+| Round | Lens that prompted it | Hypothesis (expect Z to improve) | Change made | Result |
+|-------|----------------------|----------------------------------|-------------|--------|
+| 1 | (baseline) | — | none (OBSERVE + INSPECT only) | — |
+| 2 | Adversarial (HIGH) | Stating teammate-shutdown (early, REVIEW_CLEAR) and cleanup (later, MERGED-gated) as two stages clears the shutdown-ordering contradiction → adversarial better | Smart Merge two-stage paragraph + after-merge step-2 rewrite | improved |
+| 3 | Adversarial (HIGH) | Bounding combining (ceiling, don't-collapse-wave, dependent/cx8+ sequence, version-counter sequential, 5+→consolidation) closes the no-upper-bound purpose-defeat → adversarial better | Step 1.6/1.7 combine ceiling | improved |
+| 4 | Usability/Adversarial/Trigger (MED cluster, escape unlocked) | Batch 8 independent fixes (trigger label, missing-config wording, combined-group identity, retro-skip, idle+DIRTY sole-exception, additive-vs-serialize, duplicate-4, metric trim) clears the MED cluster → usability better | 8-cluster batch | improved, but introduced 1 MED clause-C regression (additive→parallel rule leaked to happy-1's 2-task case) |
+| 5 | Fidelity (MED regression) | Scoping the additive→parallel split to 5+-on-one-file and stating 2-4 coupled additive pairs still combine restores clause C on happy-1 without disturbing edge-1 → fidelity better | Step 1.7 scope fence | improved |
+
+## Gate ledger
+
+| Round | Gate 1 (Fidelity) | Gate 2 (no HIGH dissent) | Gate 3 (measurable gain) | Outcome |
+|-------|-------------------|--------------------------|--------------------------|---------|
+| 1 | pass | fail (2 HIGH) | — (baseline) | iterate |
+| 2 | pass | fail (1 HIGH) | pass | iterate |
+| 3 | pass | pass | pass | (chose to harden MED cluster, not promote) |
+| 4 | pass (happy-1 MED, advisory) | pass | pass (with 1 MED regression) | iterate (fix self-introduced regression) |
+| 5 | pass | pass | pass | **PROMOTE** |
+
+Note on round 3: Gate 1 ∧ Gate 2 first passed at round 3 — the skill was already promotable. The lead
+chose to spend the remaining budget hardening the documented MED cluster (combined-group identity was a
+real gap in the primary mechanic and broke the teammate Scope guard) rather than ship with known gaps.
+
+## Dissent log
+
+| Round | Lens | Severity | Tag | Summary | Blocked a gate? | Resolved |
+|-------|------|----------|-----|---------|-----------------|----------|
+| 1 | adversarial | HIGH | behavioural | shutdown-ordering self-contradiction (3-lens consensus) | yes — Gate 2 | round 2 |
+| 1 | adversarial | HIGH | behavioural | "always prefer combining" no upper bound → destroys parallelism | yes — Gate 2 | round 3 |
+| 1 | adversarial/usability | MED | behavioural | combined-group identity undefined; breaks Scope guard | no | round 4 |
+| 1 | adversarial | MED | behavioural | lead-never-executes vs idle+DIRTY carve-out, no cross-ref | no | round 4 |
+| 1 | adversarial | MED | behavioural | version-counter hot file wants sequential merge not combine | no | round 3 |
+| 1 | usability | MED | behavioural | mandatory pre-spawn retro read with no input when $RETRO_LOG unset | no | round 4 |
+| 1 | usability | MED | behavioural | combine-vs-fallback boundary fuzzy + no PR-size cap | no | round 3 |
+| 1 | trigger-routing | MED | static | no "library skill" self-label → direct over-fire risk | no (static; Gate 2 only) | round 4 |
+| 1 | trigger-routing | LOW | static | narrow trigger vocab (tag/issue/queue) → under-fire | no | round 4 |
+| 1 | usability | LOW | behavioural | missing-config "prompt before starting" vs scripted proceed | no | round 4 |
+| 3 | usability/adversarial | MED | behavioural | consolidation task over-serializes a purely-additive 5+ file | no | round 4 |
+| 4 | fidelity | MED | behavioural | additive→parallel rule (scoped 5+) leaked to happy-1's 2-task case, softened clause C (self-introduced) | no (advisory) | round 5 |
+| 5 | adversarial | LOW | behavioural | line 96 unqualified "5+ tasks on one file" vs line 99 additive refinement | no | documented (non-blocking) |
+| 4 | compression | LOW | behavioural | lead-side two-stage-shutdown double-statement (L342-347 vs L361) | no | documented (non-blocking) |
+| 1 | fidelity/adversarial | LOW | behavioural | crash-1 task-4 (pending + no tracking entry) matches no reconciliation rule | no | documented (non-blocking) |
+
+## Final verdict
+
+**PROMOTE**
+
+- Gates met: Gate 1 (Fidelity — all cases pass, no HIGH), Gate 2 (no open HIGH dissent), Gate 3 (every amend round registered gain on its targeted lens).
+- Gates not met: none.
+- Residual HIGH-severity dissent: none.
+- Documented non-blocking residuals (LOW, for a future re-forge): (1) crash-1 task-4 pending+no-entry non-total reconciliation rule; (2) lead-side two-stage-shutdown double-statement L342-347 vs L361 (safe ~2-line trim); (3) Step 1.7 line 96 unqualified "5+ tasks on one file" phrasing vs line 99's additive refinement.
+- Best-so-far / promoted artifact: `skills/marathon/SKILL.md` (this worktree).
+
+## Rounds and waste
+
+- Rounds run: 5 (of 5 budget)
+- Estimated waste: ~1 round. Round 4's 8-cluster batch introduced one MED clause-C regression (the additive→parallel rule leaked below its 5+ scope), which round 5 spent fixing. A tighter round-4 batch — scoping the additive-vs-serialize rule to 5+ *at the moment it was written* — would have avoided the round-5 cycle. The other 7 round-4 fixes all landed cleanly. Net: the batch traded one extra verification round for closing the whole MED cluster in one pass, which still beat 7 separate one-change rounds.
+
+## Retrospective (which lens caught what)
+
+- **Adversarial** carried the run: both promotion-blocking HIGHs (shutdown-ordering, combining-no-upper-bound) and the sharpest MEDs (idle+DIRTY over-application, version-counter-wants-sequential, the round-5 boundary check). The "read fields 4/5 — improvisation + wanted-to-deviate" instruction paid off: every HIGH traced to a runner's field-5 "I wanted to deviate but the skill is contradictory."
+- **Usability** independently corroborated 4 of the Adversarial findings (the value of >1 lens on the same transcript) and owned the combined-group-identity + mandatory-retro gaps.
+- **Trigger/routing** (static) caught the one defect no behavioural lens could see: the description's missing "library skill" self-label and the direct over-fire path.
+- **Fidelity** was the safety net on the self-introduced round-4 regression — it alone ruled that the batch's additive edit had pulled happy-1 away from clause C, and correctly graded it MED (advisory) not HIGH so it didn't false-block Gate 1.
+- **Compression** was lowest-yield (all LOW), but its "decorative metrics vs load-bearing calibration" distinction kept the round-2/3/4 additions honest and flagged the one real bloat (lead-side restatement).
+- **Strongest signal heuristic confirmed:** a contradiction two independent runners tripped over (shutdown-ordering: comp-1 + adv-1) was the highest-confidence finding of the run — evidence, not speculation.


### PR DESCRIPTION
## Summary

Drove the `marathon` skill through 5 `skill-forge` rounds (5-lens judge panel: Fidelity, Adversarial, Compression, Usability, Trigger/routing). Promoted at round 5 — Gate 1 (Fidelity, every case passes, no HIGH) and Gate 2 (no open HIGH dissent) both pass. No residual HIGH dissent.

Forging exercised 5 persistent test cases (happy path / edge / adversarial / composition / crash-recovery). The full gate ledger, per-round hypothesis→result log, and severity-tagged dissent log are in the shipped `forge-report.md`.

## Changes Made

**Two promotion-blocking HIGH dissents resolved:**

1. **Shutdown-ordering self-contradiction** (3-lens consensus; two independent runners tripped on it). "Shut down immediately at REVIEW_CLEAR" vs "shutdown gated on verified MERGED" described the same action at two incompatible times. Now stated as two explicit stages: teammate shutdown is *early* (at REVIEW_CLEAR), cleanup is *later* (the only thing the verified-`MERGED` gate guards).
2. **Unbounded combining.** `always prefer combining` had no ceiling — a runner collapsed 6 units into one cx-18 PR, destroying the parallelism the skill exists to create while staying textually compliant. Added a combine ceiling: don't combine past ~cx8, don't collapse the wave below 2 parallel units, sequence dependents/cx8+ tasks instead of folding them in, version-counter/changelog/lockfile hot files merge sequentially (never combine), 5+ purely-additive units stay parallel, 5+ same-line contention uses a dedicated consolidation task.

**MED cluster (batched once the one-change escape unlocked, then a follow-up fix):**

- **Combined-group identity** convention (name `task-<id>+<id>`, branch/worktree, summed complexity) — closes a gap in the primary mechanic and restores the teammate Scope guard, which previously could not be checked against a combined branch.
- **Trigger/routing** description scoped to a library skill invoked by `/tm` and `/issues` (not run standalone, needs a caller-supplied adapter), broadened vocab (backlog/tickets), and a `pr-review-merge` boundary for single-PR work.
- Pre-spawn retro-log read now **skips when `$RETRO_LOG` is unset** (mirrors the completion-time read; removes a mandatory-step-with-no-input contradiction).
- Idle+DIRTY conflict resolution marked the **sole** lead-execution exception, cross-referenced from Lead Authority (closes the over-application path where a lead might execute other quick work).
- Missing-config notice made explicitly **non-blocking**; Completion list renumbered; fake-precise metrics trimmed.
- **Round-5 follow-up:** the round-4 additive→parallel rule (scoped to 5+) was over-generalized by a runner to a 2-task case, softening intent clause C. Fixed with a scope fence: a 2-4-task coupled additive pair under the ceiling still combines per the primary rule. Verified: combine behaviour restored on the 2-task case, 5+ behaviour unchanged.

## Technical Details

`skills/marathon/SKILL.md`: +37/-19 (Compression lens kept the hardening tight). Also ships the persistent forge corpus (`skills/marathon/forge/corpus.md`, so a future re-forge re-runs all 5 cases) and the forge report. Per-round transcripts and the panel ledger were intentionally left out of the diff as run noise.

`.claude-plugin/plugin.json`: 1.30.1 → 1.31.0 (MINOR — marathon's observable planning behaviour and routing description change; no breaking change to any command or flag).

## Testing

Behavioural verification is the forge itself: five fresh-context runners applied the draft per round; the judge panel scored transcripts and flagged regressions. The final round confirmed every case passes Fidelity with no HIGH dissent, and that the round-5 fence fixed the self-introduced regression without disturbing the other cases. CI (`skills/assess pytest`, `scripts/ pytest`, `plugin contract pytest`, `Validate PR title`) covers the deterministic core and internal-link contract; this PR is markdown-only.

## Risk Assessment

Low. Markdown-only change to one skill plus a version bump. The combine ceiling makes marathon combine more conservatively (and name combined groups) — a behaviour refinement, not a contract break. Three LOW non-blocking residuals are documented in the forge report for a future re-forge (crash-1 non-total reconciliation rule; a lead-side two-stage-shutdown double-statement; a line-96 phrasing nit).

## Deployment Notes

Version bump fires `/plugin update` visibility and the standalone-skills republish on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Plugin version bumped to 1.31.0

* **Documentation**
  * Marathon skill documentation enhanced with improved team orchestration guidance, clearer process workflows, and refined configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->