### PR TITLE
fix: Close two marathon/pr-review-merge gaps from a live run

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/marathon/SKILL.md
+++ b/skills/marathon/SKILL.md
@@ -263,7 +263,7 @@ Only message the lead for **meaningful events**:
 1. Implement → push incrementally → create PR → message lead PR_CREATED
 2. Fix any failing **required** checks and any already-posted bot threads; push. Do NOT watch CI - the lead owns that.
 3. Message lead REVIEW_CLEAR (required checks green, threads resolved) and stand down. Do not sit through the slow `claude-review`/AI-review window - that wait is the lead's to hold.
-4. The lead owns the claude-review wait + merge, cleans up, and shuts you down at green. After REVIEW_CLEAR you are not re-woken - if more work surfaces the lead spawns a fresh teammate (one task, one teammate). Approve the shutdown request when received.
+4. The lead owns the claude-review wait + merge, cleans up, and shuts you down at green. After REVIEW_CLEAR you are not re-woken - if more work surfaces the lead spawns a fresh teammate (one task, one teammate). **Approve the lead's `shutdown_request` promptly when it arrives, and after REVIEW_CLEAR do NOT idle-ping or re-send merge-readiness nudges** — the lead owns the merge; re-nudging an already-cleared PR just churns the lead while it holds the claude-review wait.
 """
 )
 ```

--- a/skills/pr-review-merge/SKILL.md
+++ b/skills/pr-review-merge/SKILL.md
@@ -55,6 +55,16 @@ git fetch origin $BASE && git merge origin/$BASE --no-edit
 # If can't auto-resolve: report blocked with details
 ```
 
+**Resolving a `.claude-plugin/plugin.json` conflict (the common one in multi-PR waves).** The conflict is **not always confined to `.version`** — a sibling PR may also have reframed the marketplace `description` or another field. A version-only line edit (`sed`-ing just the version line, or a regex that targets only `.version`) silently keeps the stale side of *every other* field and can leave merge markers behind. Resolve the **whole file** deterministically: take the side carrying the siblings' already-merged field changes (usually base), then overwrite only the version with `jq`:
+
+```bash
+git checkout --theirs .claude-plugin/plugin.json   # base side, which has the merged siblings' description/other-field edits
+jq --arg v "<your-next-version>" '.version = $v' .claude-plugin/plugin.json > /tmp/pj && mv /tmp/pj .claude-plugin/plugin.json
+git add .claude-plugin/plugin.json
+```
+
+Always `git diff` the full `plugin.json` before resolving — never assume the only divergence is the version line.
+
 **Conflict resolution patterns:**
 - **Import/route files** (e.g., App.tsx, index.ts): Accept BOTH sides — additions are additive
 - **Barrel exports** (e.g., shared/index.ts): Accept both sides — each adds its own export


### PR DESCRIPTION
## Summary

Follow-up to #149, prompted by a live marathon lead's review of that hardening pass. #149 fixed the lead side of shutdown ordering and added the combine ceiling + trigger scoping; the reviewer correctly identified two gaps it left open. Both are runtime corrections (observed teammate behaviour and a conflict that bit a real run), so they are applied directly rather than re-forged.

## Changes Made

**1. marathon — teammate Lifecycle (`skills/marathon/SKILL.md`)**

#149's two-stage shutdown resolved the *lead*-side contradiction (shutdown early at REVIEW_CLEAR; cleanup later, MERGED-gated). But the *teammate* side was untouched: the template still only said "approve the shutdown request when received." In a live run, teammates kept idle-pinging and re-sending merge-readiness status instead of approving the pending `shutdown_request` — so even with early shutdown the lead still churned. Added an explicit instruction: approve the `shutdown_request` promptly, and after REVIEW_CLEAR do not idle-ping or re-send merge-readiness nudges (the lead owns the merge).

**2. pr-review-merge — Review Loop sync / Smart Merge (`skills/pr-review-merge/SKILL.md`)**

A `.claude-plugin/plugin.json` conflict in a multi-PR wave is not always confined to `.version` — a sibling PR may also have reframed the marketplace `description`. A version-only line-regex keeps the stale side of every other field and can leave merge markers behind (this bit a real run). Added the deterministic resolution to the conflict-resolution patterns (which Smart Merge's DIRTY handling already delegates to): take the side carrying the siblings' merged field edits, overwrite only `.version` with `jq`, and always `git diff` the full file first rather than assuming the version line is the only divergence.

## Technical Details

Two markdown-only edits plus a PATCH bump (`1.31.0 → 1.31.1`). The pr-review-merge note lives in the Review Loop Step 1 sync block — the single source of truth that Smart Merge's "DIRTY → resolve using the Review Loop conflict-resolution patterns" already points to — so both the teammate sync path and the lead's DIRTY-resolution path inherit it.

The "unbounded combining" HIGH from #149 needed no change: the reviewer agreed the ceiling is a sound guardrail and would have passed their defensible 6-task case (wave stayed above 2 parallel units).

## Testing

Markdown-only; CI (`skills/assess pytest`, `scripts/ pytest`, `plugin contract pytest`, `Validate PR title`) covers the deterministic core and internal-link contract. No links added.

## Risk Assessment

Low. Two additive instruction clarifications to existing skills + version bump. No contract change to any command or flag.