### PR TITLE
feat: Self-contained standalone skill ZIPs + clearer download path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.github/workflows/build-standalone-skills.yml
+++ b/.github/workflows/build-standalone-skills.yml
@@ -68,6 +68,6 @@ jobs:
 
           gh release create "$TAG" \
             --title "Standalone skill ZIPs — v${VERSION}" \
-            --notes "Standalone skill ZIPs for Claude Desktop and claude.ai, built from plugin v${VERSION}. Install via Settings → Customize → Skills → Upload Skill. A new release is published on every plugin version bump; find the newest at https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills" \
+            --notes "Standalone skill ZIPs for claude.ai, Claude Desktop, Cowork, and any other Agent-Skills assistant, built from plugin v${VERSION}. Each ZIP is self-contained - download only the skill(s) you want. Install via Settings → Customize → Skills → Upload Skill. The newest bundle is always linked from the latest plugin release: https://github.com/bjcoombs/ai-native-toolkit/releases/latest" \
             --latest=false \
             dist/standalone-skills/*.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,19 @@ As the **final** step, once all of a marathon's PRs are merged and the retrospec
 ```bash
 VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
 gh release create "v$VERSION" --generate-notes --title "v$VERSION"
+
+# Prepend a pointer to the standalone ZIP bundle so the README's stable
+# releases/latest link can hand off to that version's downloadable ZIPs.
+# (build-standalone-skills.yml publishes standalone-skills-v$VERSION on the
+# version-bump push, so it exists by the time you cut this release.)
+ZIP_URL="https://github.com/bjcoombs/ai-native-toolkit/releases/tag/standalone-skills-v${VERSION}"
+BODY=$(gh release view "v$VERSION" --json body -q .body)
+gh release edit "v$VERSION" --notes "📦 **Standalone skill ZIPs** (claude.ai, Claude Desktop, Cowork, any Agent-Skills assistant): ${ZIP_URL}
+
+${BODY}"
 ```
 
-`.github/release.yml` maps the PR labels (`feat`/`fix`/`docs`/`chore`/`refactor`) to release-note categories, and `build-standalone-skills.yml` republishes the standalone ZIPs on the version bump. One release per marathon, not one per PR.
+`.github/release.yml` maps the PR labels (`feat`/`fix`/`docs`/`chore`/`refactor`) to release-note categories, and `build-standalone-skills.yml` republishes the standalone ZIPs on the version bump. The plugin release is marked Latest, so `releases/latest` always resolves to it and its notes link straight to the ZIP bundle. One release per marathon, not one per PR.
 
 ## Testing a branch before merging
 
@@ -129,7 +139,9 @@ gh release create "v$VERSION" --generate-notes --title "v$VERSION"
 
 ## Standalone skill pipeline
 
-`assess` and `huddle` are also distributed as standalone ZIPs for Claude Desktop chat and Cowork via `Settings → Customize → Skills → Upload Skill`.
+`assess`, `huddle`, `deslop`, `skill-forge`, and `semantic-compress` are also distributed as standalone ZIPs for claude.ai, Claude Desktop, Cowork, and any other Agent-Skills assistant via `Settings → Customize → Skills → Upload Skill`. The set is whatever `SKILLS` in `scripts/standalone_skill_config.py` lists.
+
+**Each ZIP must be self-contained.** A standalone ZIP ships one skill with no siblings, so a plugin-time cross-skill link (`../<other-skill>/...` or `skills/<other-skill>/...`) cannot resolve. Two mechanisms keep ZIPs whole: `bundle_files` vendors a needed file from another skill into the ZIP (e.g. skill-forge vendors `ab-equivalence`'s `runner-prompt.md`, the wrapper its solo mode fills), and the build's link localizer (`transform_skill.localize_cross_skill_links`) rewrites every cross-skill reference - to the local copy if vendored, otherwise degraded to a bare mention. `ab-equivalence` is a **library skill** (composed by skill-forge and semantic-compress, never invoked directly), so it ships **no** standalone ZIP of its own; its files are vendored into the consumer that uses them. `scripts/tests/test_integration.py::test_no_dangling_cross_skill_references` fails the build if any shipped `.md` still carries a `../<skill>`/`skills/<skill>` path - the guardrail that was missing when the ab-equivalence extraction left skill-forge's runner reference dangling.
 
 **Build locally:**
 ```bash
@@ -145,7 +157,7 @@ bash scripts/build-standalone-skills.sh --dest ~/Desktop  # custom output dir
 - `scripts/tests/test_integration.py` - full-build ZIP content validation (forbidden strings, expected files)
 - Run: `cd scripts && uv run --with pytest pytest -v`
 
-**CI:** `.github/workflows/build-standalone-skills.yml` triggers on `plugin.json` version bumps and publishes a per-version immutable release tagged `standalone-skills-v<version>` (one create call, no delete - GitHub immutable releases permanently reserve a tag once it has backed a release, so the old rolling `standalone-skills-latest` delete-and-recreate pattern can never succeed again). The newest is always at `releases?q=standalone-skills`. `.github/workflows/tests.yml` now runs both the `skills/assess/` suite and the `scripts/` suite on every PR and push.
+**CI:** `.github/workflows/build-standalone-skills.yml` triggers on `plugin.json` version bumps and publishes a per-version immutable release tagged `standalone-skills-v<version>` (one create call, no delete - GitHub immutable releases permanently reserve a tag once it has backed a release, so the old rolling `standalone-skills-latest` delete-and-recreate pattern can never succeed again). Users don't browse these directly: the per-marathon plugin release (`v<version>`, marked Latest) carries a link to that version's `standalone-skills-v<version>` bundle in its notes, so the README points at `releases/latest` and the release page hands off to the ZIP tag (see "Release after a marathon"). `.github/workflows/tests.yml` now runs both the `skills/assess/` suite and the `scripts/` suite on every PR and push.
 
 **Marker rules:**
 - `<!-- chat-skip:start/end -->` - wraps content to remove entirely (plugin path resolution, `$ARGUMENTS`, agent-orchestration infrastructure, namespaced slash commands)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AI Native Toolkit
 
-A Claude Code plugin: skills, agents, and commands for AI-native development. Runs locally in your Claude Code session, against your own codebase, using whichever model you're already paying for - nothing leaves your machine beyond what Claude Code itself sends.
+A Claude Code plugin - and a set of standalone skills for **any AI assistant**: skills, agents, and commands for AI-native development. In Claude Code it runs locally against your own codebase using whichever model you already pay for. Several of the skills also ship as standalone [Agent Skills](https://www.anthropic.com/news/skills) ZIPs you can upload to claude.ai, Claude Desktop, Cowork, or any assistant that supports the skills format - no Claude Code required.
+
+> **Want the skills without Claude Code?** Download the ZIPs from the **[latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest)** - the release notes link straight to that version's standalone skill bundle - and upload them in your assistant's Skills UI. Full walkthrough: [Standalone skill ZIPs](#standalone-skill-zips-any-ai-assistant). Currently standalone: `/assess`, `/huddle`, `/deslop`, `/skill-forge`, `/semantic-compress`.
 
 > **New here?** The [Map of Content](docs/index.md) is the navigation index - one trail to every skill, command, agent, and design doc in this repo. The [`CLAUDE.md`](CLAUDE.md) contract holds the rules for editing it.
 
@@ -12,12 +14,13 @@ The aim is not an AI that comprehends complexity humans no longer can, trusted b
 
 There's a second half, and it's the same ethic pointed the other way. When a contributor makes a mistake, the question is never "who do we blame" but "what made that mistake possible, and what would make it impossible next time?" A bank doesn't give a new engineer production access and hope - it builds role-based access, staged environments, and CI that catches the error before it ships. Those guardrails aren't distrust; they're how you protect people from costly mistakes by design, and an AI contributor needs the same protection a human does. `/assess` scores exactly these: linters, architecture tests, CI gates, coverage, review automation. Framed positively: **have we set the codebase up so that doing the wrong thing is hard, and the right thing is the path of least resistance?** Give the contributor the map *and* the guardrails - that is what `/assess` measures the distance to.
 
-The headline pieces are four **skills**:
+The headline pieces are five **skills**:
 
 - **`/assess`** - score any codebase's readiness for AI agent contributors against an 8-layer contract model (navigability, runtime liveness, code design, linters, architecture tests, CI, coverage, review bots, AI project management), with a Codecov-style complexity hotspot SVG and a doc-navigability graph SVG (both colour-blind-safe). Generates a report + the two SVGs and opens a PR in the target repo.
 - **`/huddle`** - structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing (solo -> debate -> huddle -> panel -> board).
 - **`/deslop`** - detect and remove the telltale signs of AI writing (puffery, the rule of three, "not X but Y", filler diction, chatbot leakage, fabricated citations). Runs as a silent quality gate while writing, or as an explicit audit/edit pass. Derived from Wikipedia's "Signs of AI writing".
 - **`/skill-forge`** - harden a skill (draft or existing) through judge-panel refinement rounds until it clears a strict 3-tier promotion gate. A prove-and-promote quality gate that runs after authoring, built on the same team-lead pattern as `/huddle` - and proven by forging itself.
+- **`/semantic-compress`** - shrink an LLM-directed document (a prompt, instruction set, or skill) while preserving what it does: point at core knowledge the model already holds, keep project-specific detail verbatim, and - in Claude Code - gate whole-document distillation on an A/B behavioural-equivalence check so every cut is proven, not guessed. Includes a directive-clarity pass that rewrites latent-action instructions into ones that name the action.
 
 ## What `/assess` produces
 
@@ -119,7 +122,7 @@ A single `main.dart.js` or thousands of lines of `.pb.go` shouldn't dominate the
 
 The skill runs locally - lizard, optional scc, and git log do the analysis in your Claude Code session. No data leaves the machine.
 
-> **Portability split.** The framework pieces (`/assess`, `/huddle`, `/deslop`, `/skill-forge`, `/6hats`, `/understand` and their agents) are portable and work in any Claude Code session. The workflow commands (`/tm`, `/fix-pr`, `/fix-develop`) bake in one author's daily setup: a `<repo>-main/` + `worktree/` layout, GitHub + `gh` CLI, Task Master, CodeRabbit/claude[bot] review threads, and the Agent Teams capability flag. See [Adapting](#adapting-for-your-workflow) before relying on them in a different setup.
+> **Portability split.** The framework pieces (`/assess`, `/huddle`, `/deslop`, `/skill-forge`, `/semantic-compress`, `/6hats`, `/understand` and their agents) are portable and work in any Claude Code session. The workflow commands (`/tm`, `/fix-pr`, `/fix-develop`) bake in one author's daily setup: a `<repo>-main/` + `worktree/` layout, GitHub + `gh` CLI, Task Master, CodeRabbit/claude[bot] review threads, and the Agent Teams capability flag. See [Adapting](#adapting-for-your-workflow) before relying on them in a different setup.
 
 ## Install
 
@@ -132,16 +135,16 @@ From inside a Claude Code session (not a shell - `/plugin` is a Claude Code comm
 
 Skills appear namespaced: `/ai-native-toolkit:assess`, `/ai-native-toolkit:huddle`, `/ai-native-toolkit:deslop`. Update with `/plugin update ai-native-toolkit`. Remove with `/plugin remove ai-native-toolkit`. The plugin doesn't touch your existing `~/.claude/` files.
 
-## Also available in Claude Desktop and claude.ai web
+## Standalone skill ZIPs (any AI assistant)
 
-`/assess`, `/huddle`, `/deslop`, and `/skill-forge` are installable as standalone skill ZIPs - no Claude Code required. Verified working in claude.ai web and Claude Desktop.
+`/assess`, `/huddle`, `/deslop`, `/skill-forge`, and `/semantic-compress` ship as standalone [Agent Skills](https://www.anthropic.com/news/skills) ZIPs - **no Claude Code required**. They are plain skill folders (a `SKILL.md` plus reference files), so they work in any assistant that supports the skills format. Verified in claude.ai web, Claude Desktop, and Cowork; usable anywhere the format is accepted. Each ZIP is fully self-contained - download just the skill you want.
 
-### Two install paths - pick by where you use Claude
+### Two install paths - pick by where you work
 
 | You use... | Install via | Updates |
 |---|---|---|
 | Claude Code | `/plugin install` (see [Install](#install) above) | Automatic on `/plugin update`. Use this when available - it's the maintained path. |
-| claude.ai web or Claude Desktop only | Manual ZIP upload (below) | Manual: re-download from the rolling release and use the Skills UI's **Replace** option. See [Upgrading the standalone install](#upgrading-the-standalone-install) and [Staying notified of new versions](#staying-notified-of-new-versions) below. |
+| claude.ai, Claude Desktop, Cowork, or any other AI assistant | Manual ZIP upload (below) | Manual: re-download from the latest release and use the Skills UI's **Replace** option. See [Upgrading the standalone install](#upgrading-the-standalone-install) and [Staying notified of new versions](#staying-notified-of-new-versions) below. |
 
 The ZIPs are rebuilt automatically from the same source on every plugin version bump, so feature parity is maintained - only the update mechanism differs.
 
@@ -149,24 +152,24 @@ The ZIPs are rebuilt automatically from the same source on every plugin version 
 
 - A paid plan (Pro, Max, Team, or Enterprise) - Skills upload is not on the Free tier.
 - For `/assess`: **Settings → Capabilities → Code execution and file creation** must be on (required for the Python scripts). Enable **Allow network egress** too if your repo's `pyproject.toml` pulls dependencies.
-- `/huddle` and `/deslop` need neither - they're pure reasoning.
+- `/huddle`, `/deslop`, `/skill-forge`, and `/semantic-compress` need neither - they're pure reasoning.
 
 ### Install (claude.ai web - verified path)
 
-1. Download `assess.zip`, `huddle.zip`, and `deslop.zip` from the [newest standalone-skills release](https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills&expanded=true) (a fresh `standalone-skills-vX.Y.Z` release is published on every plugin version bump; pick the one at the top).
+1. Open the **[latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest)**. Its release notes link to that version's **standalone skill ZIPs** bundle (a fresh bundle is published on every plugin version bump). From there, download the skill(s) you want - `assess.zip`, `huddle.zip`, `deslop.zip`, `skill-forge.zip`, `semantic-compress.zip`. Each ZIP is self-contained, so grab only the ones you need.
 2. Open https://claude.ai/customize/skills (or sidebar → Customize → Skills).
 3. Click the **+** at the top right of the Skills column.
 4. Hover **Create skill →** then click **Upload a skill**.
 5. Select the `.zip` (don't unzip).
 6. Confirm the skill appears under **Personal skills** with toggle on and **Trigger: Slash command + auto**.
 
-Claude Desktop has the same Skills uploader under Settings; the flow is analogous.
+Claude Desktop, Cowork, and other assistants expose the same Skills uploader (usually under Settings); the flow is analogous.
 
 ### Upgrading the standalone install
 
 The Skills UI has a built-in **Replace** option - use it instead of uninstalling and re-uploading (Replace preserves any in-progress chats that reference the skill).
 
-1. Download the new `assess.zip` / `huddle.zip` / `deslop.zip` from the [newest standalone-skills release](https://github.com/bjcoombs/ai-native-toolkit/releases?q=standalone-skills&expanded=true) (the top `standalone-skills-vX.Y.Z` entry).
+1. Download the new ZIP for the skill you're upgrading from the [latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest) (follow the standalone skill ZIPs link in its notes).
 2. In Customize → Skills, click the skill you want to upgrade.
 3. Open the three-dot menu (⋮) in the top right of the detail pane.
 4. Click **Replace** and select the new `.zip`.
@@ -190,6 +193,8 @@ In a fresh chat, try:
 - **assess**: "How AI-ready is this codebase?" / "Give me a complexity heatmap"
 - **huddle**: "Run a huddle on [decision]" / "Give me red-team/blue-team analysis of [question]"
 - **deslop**: "Make this sound less like AI" / "De-slop this draft" / "Does this read as AI-written?"
+- **skill-forge**: "Harden this skill" / "Is this skill ready to ship?"
+- **semantic-compress**: "Compress this prompt without losing meaning" / "Tighten this instruction set"
 
 If a skill only fires on `/skill-name` and not on natural language, the frontmatter description is missing trigger phrasing - edit `standalone_description` in `scripts/standalone_skill_config.py` and rebuild.
 

--- a/scripts/standalone_skill_config.py
+++ b/scripts/standalone_skill_config.py
@@ -201,6 +201,17 @@ SKILLS: dict[str, dict] = {
                 "until the gate promotes or the budget ceiling stops it."
             ),
         },
+        # skill-forge composes ab-equivalence's runner: solo mode fills the
+        # pure-wrapper template verbatim per runner per test case. In the plugin
+        # that template lives in the sibling ab-equivalence skill; a standalone
+        # ZIP has no siblings, so vendor the one file skill-forge actually uses.
+        # The build's link localizer rewrites `../ab-equivalence/.../runner-prompt.md`
+        # references to this local copy; the other ab-equivalence files (the
+        # contract and the equivalence judge) are not used by the forge loop, so
+        # they are not vendored.
+        "bundle_files": {
+            "references/runner-prompt.md": "skills/ab-equivalence/references/runner-prompt.md",
+        },
     },
     "deslop": {
         "standalone_name": "deslop",
@@ -222,32 +233,14 @@ SKILLS: dict[str, dict] = {
         "exclude_dirs": set(),
         "replacements": {},
     },
-    "ab-equivalence": {
-        "standalone_name": "ab-equivalence",
-        "standalone_description": (
-            "Compare two versions of an LLM-directed document - an original (teacher) and a "
-            "candidate (student) - across a transfer set and return a per-case "
-            "behavioural-equivalence verdict plus an efficiency signal. A transform-agnostic "
-            "library capability other skills compose to gate a transform on behavioural sameness. "
-            "TRIGGER when asked to A/B test two versions of a prompt, instruction, or skill, to "
-            "check whether a rewritten or compressed document still behaves the same as the "
-            "original, to validate behavioural equivalence between two document versions, or to "
-            "gate a transform on no-regression. This standalone build runs solo mode only; "
-            "phased sub-agent and team modes require the Claude Code CLI."
-            + VERSION_SUFFIX
-        ),
-        "source_dir": "skills/ab-equivalence",
-        "exclude_dirs": {"tests", "__pycache__", ".pytest_cache", ".venv"},
-        "replacements": {
-            "execution-mode-rule": (
-                "This standalone build runs solo mode only: a single agent works each case "
-                "sequentially - applying the original and candidate via the runner wrapper, "
-                "then judging the two transcripts with the equivalence-judge prompt to record "
-                "the per-case verdict and efficiency signal. Phased sub-agent and team modes "
-                "require the Claude Code CLI and are not available here."
-            ),
-        },
-    },
+    # ab-equivalence is a library skill: it is composed by skill-forge and
+    # semantic-compress, never invoked directly by a user, so it ships no
+    # standalone ZIP of its own. The one file a standalone consumer actually uses
+    # (the runner-prompt wrapper, by skill-forge solo mode) is vendored into that
+    # consumer's ZIP via bundle_files above. semantic-compress's standalone build
+    # disables Distill mode (the only other ab-equivalence consumer), so it needs
+    # nothing vendored; the build's link localizer degrades its ab-equivalence
+    # references to bare mentions.
     "semantic-compress": {
         "standalone_name": "semantic-compress",
         "standalone_description": (

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -4,6 +4,7 @@ Integration tests: run the full standalone skill build and validate ZIP contents
 Catches the class of bug where plugin-internal content leaks into bundled
 reference files that weren't processed by the transformer.
 """
+import re
 import zipfile
 from pathlib import Path
 
@@ -18,6 +19,9 @@ def _build(skill_name: str, tmp_path: Path) -> zipfile.ZipFile:
 
     cfg = SKILLS[skill_name]
     out_zip = tmp_path / f"{cfg['standalone_name']}.zip"
+    bundle_files = {
+        dest: REPO_ROOT / src for dest, src in cfg.get("bundle_files", {}).items()
+    } or None
     issues = build_standalone_skill_zip(
         skill_source_dir=REPO_ROOT / cfg["source_dir"],
         out_zip=out_zip,
@@ -25,6 +29,7 @@ def _build(skill_name: str, tmp_path: Path) -> zipfile.ZipFile:
         standalone_description=cfg["standalone_description"],
         replacements=cfg["replacements"],
         exclude_dirs=frozenset(cfg["exclude_dirs"]),
+        bundle_files=bundle_files,
     )
     assert not issues, "Build produced issues:\n" + "\n".join(issues)
     assert out_zip.exists(), "ZIP not created despite no issues reported"
@@ -234,53 +239,64 @@ class TestDeslopBuild:
         assert Path(zf1.filename).read_bytes() == Path(zf2.filename).read_bytes()
 
 
-# ── ab-equivalence ───────────────────────────────────────────────────────────
+# ── ab-equivalence (vendored, no standalone ZIP of its own) ───────────────────
+# ab-equivalence is a library skill composed by skill-forge and semantic-compress,
+# never invoked directly, so it ships no standalone ZIP. The one file skill-forge's
+# solo mode uses (the runner-prompt wrapper) is vendored into skill-forge's ZIP;
+# the build's link localizer rewrites the `../ab-equivalence/.../runner-prompt.md`
+# references to that local copy. These tests pin that vendoring.
 
-class TestAbEquivalenceBuild:
+
+class TestSkillForgeVendorsRunner:
     @pytest.fixture(scope="class")
-    def ab_zip(self, tmp_path_factory):
-        return _build("ab-equivalence", tmp_path_factory.mktemp("ab-equivalence"))
+    def forge_zip(self, tmp_path_factory):
+        return _build("skill-forge", tmp_path_factory.mktemp("forge-vendor"))
 
-    def test_skill_md_present(self, ab_zip):
-        assert "ab-equivalence/SKILL.md" in ab_zip.namelist()
+    def test_runner_prompt_vendored(self, forge_zip):
+        assert "skill-forge/references/runner-prompt.md" in forge_zip.namelist(), (
+            "skill-forge composes ab-equivalence's runner; the wrapper must be "
+            "vendored into the standalone ZIP so solo mode can fill it"
+        )
 
-    def test_references_present(self, ab_zip):
-        names = ab_zip.namelist()
-        for ref in (
-            "ab-equivalence/references/runner-prompt.md",
-            "ab-equivalence/references/ab-equivalence.md",
-            "ab-equivalence/references/equivalence-judge-prompt.md",
-        ):
-            assert ref in names, f"{ref} missing from ZIP"
+    def test_runner_link_resolves_locally(self, forge_zip):
+        skill_md = forge_zip.read("skill-forge/SKILL.md").decode("utf-8")
+        assert "(references/runner-prompt.md)" in skill_md, (
+            "the runner link must be rewritten to the vendored local copy"
+        )
 
-    def test_no_team_infrastructure_leaked(self, ab_zip):
-        for name, content in _md_contents(ab_zip).items():
-            for tool in ("TeamCreate", "SendMessage", "TeamDelete"):
-                assert tool not in content, f"{name}: {tool} leaked"
+    def test_ab_equivalence_skill_link_degraded(self, forge_zip):
+        # The capability mention `[ab-equivalence](../ab-equivalence/SKILL.md)`
+        # has no local target, so it degrades to plain text, never a dead link.
+        skill_md = forge_zip.read("skill-forge/SKILL.md").decode("utf-8")
+        assert "](../ab-equivalence/SKILL.md)" not in skill_md
 
-    def test_no_agent_teams_env_var(self, ab_zip):
-        for name, content in _md_contents(ab_zip).items():
-            assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in content, (
-                f"{name}: capability flag env var leaked"
-            )
 
-    def test_frontmatter_name_correct(self, ab_zip):
-        skill_md = ab_zip.read("ab-equivalence/SKILL.md").decode("utf-8")
-        assert "name: ab-equivalence" in skill_md
+def _all_standalone_skill_names() -> list[str]:
+    from standalone_skill_config import SKILLS
 
-    def test_standalone_description_applied(self, ab_zip):
-        skill_md = ab_zip.read("ab-equivalence/SKILL.md").decode("utf-8")
-        assert "Standalone build v" in skill_md
+    return list(SKILLS)
 
-    def test_no_orphan_markers(self, ab_zip):
-        for name, content in _md_contents(ab_zip).items():
-            assert "chat-skip" not in content, f"{name}: chat-skip marker leaked"
-            assert "chat-replace" not in content, f"{name}: chat-replace marker leaked"
 
-    def test_zip_is_deterministic(self, tmp_path):
-        zf1 = _build("ab-equivalence", tmp_path / "run1")
-        zf2 = _build("ab-equivalence", tmp_path / "run2")
-        assert Path(zf1.filename).read_bytes() == Path(zf2.filename).read_bytes()
+# Plugin-time cross-skill references (`../<skill>/...`, possibly several `../`
+# deep, or `skills/<skill>/...`) cannot resolve in a standalone ZIP, which ships
+# one skill with no siblings. The build's localizer must rewrite or degrade every
+# one. This guardrail is exactly the check that was missing when the ab-equivalence
+# extraction left skill-forge's runner reference dangling.
+_CROSS_SKILL_RE = re.compile(r"(?:\.\./|skills/)[a-z][a-z0-9-]+/[A-Za-z0-9._/-]*\.md")
+
+
+@pytest.mark.parametrize("skill_name", _all_standalone_skill_names())
+def test_no_dangling_cross_skill_references(skill_name, tmp_path):
+    zf = _build(skill_name, tmp_path)
+    offenders: list[str] = []
+    for name, content in _md_contents(zf).items():
+        for hit in _CROSS_SKILL_RE.findall(content):
+            offenders.append(f"{name}: {hit}")
+    assert not offenders, (
+        f"{skill_name} ships dangling cross-skill references (each standalone ZIP "
+        "must be self-contained; vendor the file or let the localizer degrade it):\n"
+        + "\n".join(offenders)
+    )
 
 
 # ── semantic-compress ─────────────────────────────────────────────────────────

--- a/scripts/transform_skill.py
+++ b/scripts/transform_skill.py
@@ -1,6 +1,7 @@
 """Transform a Claude Code plugin skill into a standalone ZIP for Chat / Cowork."""
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import zipfile
@@ -89,6 +90,68 @@ def _transform_md(text: str, replacements: dict[str, str]) -> str:
     text = strip_chat_skip(text)
     text = apply_chat_replace(text, replacements)
     return text
+
+
+# A cross-skill reference: a markdown path that points OUT of this skill, either
+# `../<other-skill>/...` (sibling in the plugin tree, possibly several `../`
+# segments deep) or `skills/<other-skill>/...` (repo-root style). In the plugin
+# these resolve because every skill is a sibling; in a standalone ZIP each skill
+# ships alone, so they dangle. The localizer below rewrites them: to a path
+# relative to the referencing file if the target was vendored into the ZIP,
+# otherwise to a bare mention (drops the path/link, keeps the name).
+_CROSS_SKILL_LINK = re.compile(
+    r"\[([^\]]+)\]\(((?:(?:\.\./)+|skills/)[A-Za-z0-9][A-Za-z0-9./-]*?\.md)\)"
+)
+_CROSS_SKILL_PATH = re.compile(
+    r"(?:(?:\.\./)+|skills/)[A-Za-z0-9][A-Za-z0-9./-]*?/([A-Za-z0-9._-]+\.md)"
+)
+
+
+def localize_cross_skill_links(target_root: Path) -> None:
+    """Rewrite cross-skill markdown references in the staged ZIP tree in place.
+
+    A standalone ZIP ships one skill with no siblings, so a plugin-time link like
+    ``../ab-equivalence/references/runner-prompt.md`` cannot resolve. For each
+    ``.md`` in *target_root*:
+
+    - if the referenced basename was vendored into this ZIP (present somewhere
+      under the skill root), the path is rewritten relative to the referencing
+      file so the link resolves (a ``references/`` file pointing at a vendored
+      sibling becomes a bare ``runner-prompt.md``, not ``references/...``);
+    - otherwise the reference degrades to a bare mention - a markdown link
+      ``[label](path)`` becomes ``label``, and an inline path token keeps only
+      its basename - so no dangling ``../<skill>``/``skills/<skill>`` path ships.
+
+    The top-level ``SKILL.md`` is excluded as a link *target*: a cross-skill
+    ``[x](../x/SKILL.md)`` is a capability mention, not navigation to *this*
+    skill's own manifest, so it degrades to plain text rather than self-linking.
+    """
+    present: dict[str, Path] = {}
+    for f in target_root.rglob("*"):
+        if f.is_file() and f.name != "SKILL.md":
+            present.setdefault(f.name, f)
+
+    for md in target_root.rglob("*.md"):
+        def _rel(basename: str) -> str | None:
+            target = present.get(basename)
+            if target is None:
+                return None
+            return Path(os.path.relpath(target, md.parent)).as_posix()
+
+        def _link(m: re.Match[str]) -> str:
+            label, path = m.group(1), m.group(2)
+            rel = _rel(path.rsplit("/", 1)[-1])
+            return f"[{label}]({rel})" if rel is not None else label
+
+        def _path(m: re.Match[str]) -> str:
+            basename = m.group(1)
+            rel = _rel(basename)
+            return rel if rel is not None else basename
+
+        text = md.read_text("utf-8")
+        text = _CROSS_SKILL_LINK.sub(_link, text)
+        text = _CROSS_SKILL_PATH.sub(_path, text)
+        md.write_text(text, "utf-8")
 
 
 def strip_frontmatter(text: str) -> str:
@@ -184,6 +247,13 @@ def build_standalone_skill_zip(  # noqa: C901  # marker-transform + zip assembly
             ),
             "utf-8",
         )
+
+    # After the full tree is staged (source + vendored bundle_files), rewrite any
+    # cross-skill references so each ZIP is self-contained: vendored targets link
+    # locally, everything else degrades to a bare mention. Runs before the
+    # orphan-marker check and zip so the shipped .md never carries a dangling
+    # `../<skill>` / `skills/<skill>` path.
+    localize_cross_skill_links(target_root)
 
     issues: list[str] = []
     for md in sorted(target_root.rglob("*.md")):


### PR DESCRIPTION
## Summary

Extracting `ab-equivalence` into a library skill (last marathon) left the **standalone `skill-forge` ZIP broken**: its `SKILL.md` tells the agent to fill `../ab-equivalence/references/runner-prompt.md` verbatim, but that file moved to a sibling skill that isn't present when each skill is uploaded as its own ZIP. The most load-bearing prompt in the forge dangled, and nothing caught it - the build had no cross-skill link check. This makes every standalone ZIP self-contained again and adds the guardrail.

It also addresses three distribution/UX issues raised on the README: the ZIP download links pointed at a `?q=` search page (no download), the skills weren't framed as usable beyond Claude Code, and the headline list was stale.

## Changes Made

**Pipeline (the fix):**
- `skill-forge` vendors `ab-equivalence`'s `runner-prompt.md` into its ZIP via the existing `bundle_files` mechanism (the wrapper its solo mode actually fills).
- New presence-aware link localizer (`transform_skill.localize_cross_skill_links`): for every `.md` in a staged ZIP, a cross-skill reference (`../<skill>/...`, any depth, or `skills/<skill>/...`) is rewritten relative-to-file if the target was vendored, otherwise degraded to a bare mention (markdown link -> its label; inline path -> its basename). No dangling path ships.
- `ab-equivalence` no longer builds its own standalone ZIP - it is a library skill (composed by skill-forge and semantic-compress, never invoked directly). `semantic-compress` disables Distill mode (its only ab-equivalence consumer) standalone, so its references degrade to plain mentions; nothing is vendored there.

**Guardrail:**
- `test_no_dangling_cross_skill_references` (parametrized over every standalone skill) fails the build if any shipped `.md` still carries a `../<skill>`/`skills/<skill>` path. This is exactly the check that was missing. `_build` now exercises `bundle_files` so tests reflect the real build; `TestSkillForgeVendorsRunner` pins the runner vendoring + local link resolution.

**README:**
- Lead with a top-of-readme callout: the skills ship as standalone Agent Skills ZIPs for **any AI assistant**, not just Claude Code.
- Headline skills: four -> five (added `/semantic-compress`); added it to the advertised standalone set and the portability split.
- Downloads now point at the stable [`releases/latest`](https://github.com/bjcoombs/ai-native-toolkit/releases/latest), whose notes link to that version's ZIP bundle - replacing the broken `?q=standalone-skills` search links.

**Release process / docs:**
- `CLAUDE.md`: document the self-contained rule, the vendor + localizer mechanism, and ab-equivalence-as-library; the "Release after a marathon" snippet now prepends a standalone-ZIP-bundle link to the plugin release notes so `releases/latest` hands off to the download.
- `build-standalone-skills.yml` release notes point at `releases/latest` instead of the `?q=` search.

## Technical Details

The localizer emits paths relative to the *referencing* file, so a `references/` doc linking a vendored sibling becomes a bare `runner-prompt.md`, not `references/runner-prompt.md`. The top-level `SKILL.md` is excluded as a link *target* (a cross-skill `[x](../x/SKILL.md)` is a capability mention, not navigation to this skill's own manifest), so it degrades to plain text rather than self-linking.

## Testing

- `scripts/ pytest`: 105 pass (incl. new guardrail + vendoring tests).
- `plugin contract pytest`: 185 pass (link + leaked-tag scan over the edited README/CLAUDE.md).
- ruff `C901` (max-complexity 15) clean; mypy clean.
- Built all 5 ZIPs and confirmed zero dangling `../<skill>`/`skills/<skill>` references across every shipped `.md`; verified skill-forge's runner link resolves to the vendored copy.

## Risk Assessment

Low. Build-pipeline + docs change. The localizer only rewrites cross-skill path tokens (intra-skill `references/...` links are untouched); the guardrail test enforces the invariant going forward. Removes the standalone `ab-equivalence` ZIP, which shipped <48h ago and was a never-invoked library skill.

## Deployment Notes

`1.31.1 -> 1.32.0` (MINOR). On merge, the version bump publishes `standalone-skills-v1.32.0`; the plugin `v1.32.0` release (cut per the updated CLAUDE.md snippet) links to it, making `releases/latest` the stable download entry point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone skill ZIPs now available for any AI assistant, not just Claude.
  * Added `/semantic-compress` to headline skills.

* **Documentation**
  * Updated installation and upgrade instructions for standalone skills.
  * Clarified supported assistant contexts in release notes.
  * Enhanced skill compatibility and portability guidance.

* **Chores**
  * Version bump to 1.32.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->