### PR TITLE
refactor: Compress /understand to validated behavioural equivalent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/commands/understand.md
+++ b/commands/understand.md
@@ -1,93 +1,28 @@
-Deep Understanding Mode (根回し - Nemawashi Phase)
+Deep Understanding Mode
 
-Purpose:
-- Create space (間, ma) for understanding to emerge
-- Lay careful groundwork for all that follows
-- Achieve complete understanding (grokking) of the true need
-- Unpack complexity (desenrascar) without rushing to solutions
-- Define specific issues, gaps, or questions requiring investigation
-- Consider what might be unnecessary or removable (danshari 断捨離)
-- Separate people from problems (Norwegian 'saklig' - factual, objective)
-- Identify interests behind positions (Arabic 'maqasid' - underlying purpose)
+Lay groundwork before any solution. Create space for the true need to emerge; understand it fully, unpack complexity without rushing to solve. Reach an intuitive grasp of the core issue.
 
-Expected Behaviors:
-- Show determination (sisu) in questioning assumptions
-- Practice careful attention to context (taarof)
-- Hold space for ambiguity until clarity emerges
-- Work to achieve intuitive grasp (aperçu) of core issues
-- Maintain strict focus on problem definition without solution exploration
-- Question if the problem itself needs to exist
-- Look beyond stated positions to underlying interests
-- Distinguish between what people say they want and why they want it
+Disciplines:
+- Strict focus on problem definition - no solution exploration. Reject solution discussions; request reframing when solutions appear in the problem statement.
+- Question assumptions and vague terms with determination; challenge the framing, the scope, and whether the problem needs solving at all.
+- Hold space for ambiguity until clarity emerges; attend to context.
+- Consider what is unnecessary or removable - elimination and simplification are valid.
+- Separate people from problems; look past stated positions to underlying interests; distinguish what people want from why. Reframe positions as shared interests; challenge either/or thinking; suggest objective criteria.
 
-Core Questions:
+Core questions:
 - What do we mean by [key terms]?
 - What explicit and implicit needs exist?
-- Who are the stakeholders?
-- What defines success?
-- What constraints exist?
-- What cultural/contextual factors matter?
+- Who are the stakeholders, and what interests sit behind their positions?
+- What defines success? What objective criteria would all stakeholders accept?
+- What constraints and cultural/contextual factors matter?
 - What is the gap between current and ideal state?
-- What specific knowledge gaps need addressing?
-- Could elimination rather than solution better serve the need?
-- What happens if we do nothing?
-- What parts of the current approach could be removed entirely?
-- What are the underlying interests behind stated positions?
-- What objective criteria might all stakeholders accept?
-- What common ground exists between different stakeholders?
-- How might we reframe positions as shared interests?
+- What knowledge gaps need investigation?
+- Could elimination serve better than a solution? What happens if we do nothing? What could be removed entirely?
 
-Understanding is Complete When:
-- Core terms are clearly defined
-- Explicit and implicit needs are surfaced
-- Scope is well-bounded
-- Success criteria are clear
-- Stakeholders are identified
-- Achieve aperçu - intuitive grasp of essence
-- Problem statement is clear, concise, and solution-independent
-- All assumptions are documented and validated
-- Current vs. ideal state is explicitly articulated
-- All stakeholders align on problem definition
-- Underlying interests are identified beyond positions
-- Common ground between stakeholders is established
-- Objective success criteria are agreed upon
-- Problem is framed in terms of interests, not positions
+Understanding is complete when: core terms are defined; explicit and implicit needs surfaced; scope bounded; success criteria and objective evaluation criteria agreed; stakeholders identified and aligned; assumptions documented and validated; current vs ideal state articulated; underlying interests surfaced and common ground established; and the problem statement is specific, measurable, and solution-independent, with no embedded solution.
 
-Return to Understanding When:
-- New assumptions surface
-- Implicit needs emerge
-- Context shifts
-- Understanding feels incomplete
-- Solutions are being proposed prematurely
-- Problem statement contains embedded solutions
-- Stakeholders show misaligned understanding
-- Assumptions remain untested
+Produce a provisional, solution-independent restatement of the problem - explicitly marked to-be-validated, not yet agreed.
 
-Explicit Permissions:
-- Push back on vague terms
-- Question assumptions
-- Request clarification
-- Challenge problem framing
-- Take time for proper nemawashi
-- Reject any solution discussions
-- Request reframing when solutions appear in problem statements
-- Pause to examine implicit assumptions
-- Challenge scope creep
-- Challenge whether the problem needs solving at all
-- Suggest elimination or simplification as valid approaches
-- Question the underlying purpose or need itself
-- Reframe positional statements as interest questions
-- Separate relationship issues from substantive problems
-- Challenge either/or thinking
-- Suggest objective criteria for evaluation
-
-Phase Exit Criteria:
-- Problem statement is specific, measurable, and solution-independent
-- Knowledge gaps are explicitly identified
-- All assumptions are documented and validated
-- Problem scope is clearly bounded
-- No hidden solutions exist in problem framing
-- Problem contextualizes the topic and its significance
-- Stakeholders agree on problem definition
+Return to understanding when new assumptions or implicit needs surface, context shifts, understanding feels incomplete, solutions are proposed prematurely, the problem statement embeds a solution, or stakeholders are misaligned.
 
 Apply to following statement:


### PR DESCRIPTION
## Summary

Distills the `/understand` command from 94 to 29 lines (3782 -> 2245 chars, **41% smaller**) while preserving behaviour. The compression was validated with `semantic-compress` A/B distill mode, not by inspection: each change was gated on behavioural equivalence against the original over a 6-case transfer set.

`/understand` stays a **command** (not converted to a skill) - a deliberate stop-and-think gate, matching its `CLAUDE.md` classification as a portable framework command.

## Changes Made

- Merge four overlapping checklists (Purpose / Expected-Behaviors / Explicit-Permissions, and Complete-When / Phase-Exit-Criteria) into `Disciplines` + one completion sentence.
- Strip the English glosses on the pointer terms (proven inert by the gloss-drop arm).
- Strip all ten foreign-language pointer words (`nemawashi, ma, desenrascar, aperçu, sisu, taarof, danshari, saklig, maqasid, grok`). An ablation arm stripping the bare words to their plain directives showed them to be **decoration on this transfer set** - the directives carry the behaviour. The single `saklig`/T2 regression did **not** reproduce under 3x replication (N=1 sampling noise).
- Add an explicit "produce a provisional, solution-independent restatement" instruction - the one *reproduced* regression, restored via add-back.

## Testing / validation

- 6-case transfer set: 1 happy / 2 edge / 2 adversarial / 1 composition; 7/7 behaviour-inducing sections covered.
- Teacher baseline captured once and reused; candidate arms judged per-case for equivalence under a strict no-regression gate.
- **Honest caveat:** the shipped version passes on a **replication-adjusted** gate - one T2 regression was shown to be noise via 3x replication, not a clean first-pass 6/6. Equivalence is proven only over this transfer set (distribution-shift caveat applies), and the pointer ablation proves the words aren't needed to *produce* the behaviour, not that they don't *stabilise* its run-to-run variance (unmeasured).
- Full evidence (both candidate arms, per-round log, replication, runner budget) is in the A/B distillation report kept out of the shipped tree per the repo's "result docs don't ship" convention.

## Risk

Low. Behavioural equivalence validated; no code paths affected (markdown command). Version bumped 1.33.1 -> 1.33.2 (PATCH - behaviourally equivalent refactor; the textual diff is large but the A/B shows no behaviour change).

## Follow-up (separate PR, not in this one)

The exercise exposed a gap in `semantic-compress` itself: the `core->pointer` step certifies kept pointers as "activators" without an ablation arm to test it. A follow-up should make pointer-ablation the default (or force an honest "load-bearing untested" label) and add replication before a single regression locks an add-back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured "Deep Understanding Mode" documentation with a streamlined framework featuring condensed disciplines, refined core questions, and an improved completion checklist for enhanced clarity.

* **Chores**
  * Updated plugin version to 1.33.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->