### PR TITLE
docs: Re-anchor assess lib/README and own the co-change seam map

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ Deterministic core in `skills/assess/scripts/lib/` does all data work; the LLM o
 
 Tests live in `skills/assess/tests/` and run via `uv run --with pytest pytest`. Add a test alongside any change to a deterministic module - that's the contract that lets us trust the output regardless of which LLM is driving.
 
+`skills/assess/scripts/lib/README.md` is the per-module reference and the home of the **co-change seam map**: it names the directories that move together by design (the core <-> lib seam, each lib module <-> its test, and the standalone build <-> the skills it packages) so the historical coupling `/assess` flags on this repo reads as owned cohesion, not entanglement. Update it alongside any change to a `lib/` module so it never becomes a lying map of its own.
+
 The `.assess/` directory in a target repo is a compounding wiki:
 
 - `assess-report.md` - latest prose-heavy summary (LLM-written)

--- a/docs/superpowers/specs/2026-06-04-assess-feedback-seams-and-archtest-design.md
+++ b/docs/superpowers/specs/2026-06-04-assess-feedback-seams-and-archtest-design.md
@@ -1,0 +1,109 @@
+# Design: Address /assess feedback - seam map, lying-map fix, executable architecture
+
+_2026-06-04. Source: the v1.36.0 `/assess` self-assessment (score 7.0 / 8, AI-Native)._
+
+## Context
+
+Running `/assess` against this repo (the tool assessing itself) surfaced a Top 3
+Actions list and four further opportunities. This design takes the **quick wins
+plus the L4 architecture test**, and **deliberately excludes** the coverage /
+mutation gate (Action 3): the repo's `CLAUDE.md` lists "No coverage gates" as an
+intentional non-goal, so the tool is flagging a conscious design decision, not a
+defect. Reversing that is out of scope for this round.
+
+The work splits into two sequential PRs - docs first (fast, zero-risk), then the
+enforcement changes (which carry small but real "might surface latent work"
+risk, now measured and bounded).
+
+## Goals
+
+1. Clear the one high-confidence `lying_map` the run flagged, by making the doc
+   it points at actually current.
+2. Make the assess subsystem's genuine co-change cohesion **owned and documented**
+   (the `hidden_coupling` attention list) - named as cohesion, not entanglement.
+3. Make the layering `CLAUDE.md` already *states* into an **executable, merge-gating
+   contract** (the L4 gap), and extend the L2 type gate onto the most-churned file.
+
+## Non-goals
+
+- No coverage gate, no mutation testing (honors the stated non-goal).
+- No L0 wayfinding polish (cross-reference wiring, orphan linking) - deferred.
+- No refactor of any hotspot file. The hidden_coupling is expected cohesion; the
+  response is documentation, not decomposition.
+
+## Measured premises (verified 2026-06-04)
+
+- **Import boundary already holds:** no `skills/assess/scripts/lib/*.py` module
+  imports an orchestrator. The archtest pins the current good state; it does not
+  force a fix. (Verified by grep for orchestrator imports in `lib/`.)
+- **mypy on `assess_core.py` = 4 errors:** one `Optional[str]` passed where `str`
+  is expected (line ~580), three dict-union args passed to functions expecting a
+  plain `dict` (lines ~768-771). Small, real, fixable by narrowing types.
+- **lying_map detail:** `skills/assess/scripts/lib/README.md`, confidence `high`,
+  `nearest-ancestor` association, subject churn 58 vs doc churn 1, last changed 2
+  days ago (so most subject churn predates it; ~2 `lib/` commits postdate it).
+
+## PR1 - `docs`: keep the assess seam map honest
+
+**Files:** `skills/assess/scripts/lib/README.md`, `CLAUDE.md`, the spec doc.
+
+1. **Re-anchor `lib/README.md` (Action 2, lying_map).** Walk the `lib/` commits
+   since the README was written (`git log 46c308e..HEAD -- skills/assess/scripts/lib/`),
+   reconcile each module's documented responsibility against the current code, and
+   update any drift. The point is content currency, not a no-op touch - the doc
+   should describe the modules as they are now.
+2. **Extend the co-change seam map (Action 1, hidden_coupling).** Add a short
+   "Co-change seams" section to `lib/README.md` naming the directories that evolve
+   together by design - the `lib/` modules and their `tests/`, and the
+   `scripts/` standalone-build ↔ `skills/` packaging seam - and stating plainly
+   that this is genuine subsystem cohesion (the scanners, their tests, and the
+   build that packages them move in lockstep), *not* accidental entanglement. Add a
+   one-line pointer from `CLAUDE.md`'s `/assess architecture` section to that
+   "Co-change seams" note so it is discoverable from the entry doc.
+
+**Version:** PATCH (1.36.1). No test or output change. **Validation:** the README
+content matches the current `lib/` modules; the markdown link contract stays green.
+
+## PR2 - `feat`: make the architecture executable + widen the type gate
+
+**Files:** new `skills/assess/tests/test_self_architecture.py`,
+`skills/assess/pyproject.toml`, `skills/assess/scripts/assess_core.py`, `CLAUDE.md`.
+
+1. **`test_self_architecture.py` - import-boundary contract.** An `ast`-based scan
+   over `skills/assess/scripts/lib/*.py` that parses each module's `import` /
+   `from ... import` statements and asserts none names an orchestrator module
+   (`assess_core`, `assess_finalize`, `assess_report`, `assess_gate`,
+   `complexity-treemap`, `doc-graph-svg`). Dependencies point inward: the
+   deterministic core stays independent of the scripts that orchestrate it. Pure
+   stdlib (`ast`, `pathlib`), no new dependency. It runs inside the required
+   `skills/assess pytest` check, so a future upward import fails merge. This makes
+   `CLAUDE.md`'s stated "core does data work, orchestrator coordinates" layering an
+   executable contract (L4 Partial -> contract).
+   - The test enumerates the orchestrator set explicitly (a small, named list) so
+     a new orchestrator script is a conscious one-line addition, and a `lib`
+     module importing one is a loud failure.
+2. **Widen the mypy gate (L2 ratchet).** Add `scripts/assess_core.py` to the
+   mypy `files` in `skills/assess/pyproject.toml`, and fix the 4 surfaced errors by
+   narrowing types (guard the `Optional[str]` before the `LogEntry` call; tighten
+   the dict-union types flowing into `integrate(...)`). No behaviour change.
+3. **Document the contract.** Add a short note to `CLAUDE.md`'s `/assess
+   architecture` section that the inward-only import boundary is now enforced by
+   `test_self_architecture.py`, so the layering is a contract, not a convention.
+
+**Version:** PATCH (1.36.2). Internal enforcement + types only; no `/assess` output
+change. **Validation:** the new test passes (boundary holds today); `ruff + mypy
+gates` job green with the widened scope; full `skills/assess` suite green.
+
+## Sequencing
+
+PR1 merges first (docs, zero-risk), then PR2 branches off the updated `main`.
+Both touch `CLAUDE.md`; doing them sequentially avoids a divergent-version /
+overlapping-edit conflict on that file. Each PR bumps `plugin.json` (hot file).
+
+## Testing strategy
+
+- PR1: no code; rely on the `plugin contract` link resolver staying green and a
+  read-through that the README matches the current `lib/` modules.
+- PR2: the new `test_self_architecture.py` is itself the test; plus the existing
+  `skills/assess` suite and the `ruff + mypy gates` job must stay green with the
+  widened mypy scope. Run locally with `GIT_CONFIG_GLOBAL=/dev/null`.

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -31,6 +31,30 @@ Seeing these two files in the same commit as `assess_core.py` is expected, not a
 defect. If the core is later decomposed, treat this seam as the natural boundary -
 `doc_graph` and `keyhole_signals` are where the cut-line already lives.
 
+## The wider co-change seams (cohesion, not entanglement)
+
+`/assess`'s own hotspot scan flags several directories as historically co-changing:
+`skills/assess/scripts`, `skills/assess/scripts/lib`, `skills/assess/tests`,
+`skills/assess/tests/fixtures`, and `scripts` (+ `scripts/tests`). That is the static
+import map saying "separate directories" while git says "they move together." Here the
+coupling is genuine subsystem cohesion, and naming it is the point - so a reader (or an
+agent) trusts the boundary deliberately rather than being surprised by the seam:
+
+- **`scripts/lib` modules <-> `skills/assess/tests`.** Each deterministic module is
+  pinned by a test in `skills/assess/tests/`, and the contract in `CLAUDE.md` is explicit
+  ("Add a test alongside any change to a deterministic module"). So a module and its test
+  are *meant* to move in the same commit - the test is the module's behavioural contract,
+  not a separable concern. A reviewer seeing `doc_graph.py` and `test_doc_graph.py` in one
+  diff is seeing the intended unit of change.
+- **`scripts/` (standalone build) <-> `skills/`.** The standalone-skill build under
+  `scripts/` vendors and transforms the very skills it packages, so a change to a skill's
+  shape and the build that ships it co-change by construction. That seam is documented in
+  `CLAUDE.md`'s "Standalone skill pipeline" section; it is cohesion between a packager and
+  the thing it packages, not a leak.
+
+None of these is a refactor task. They are recorded here so the seam is owned: if any is
+ever cut, this note is where the intended boundary is written down.
+
 ---
 
 ## Module reference
@@ -96,10 +120,13 @@ signal regardless of doc state.
 Integration barrier between the individual signal modules and `assess_core`. Derives
 the per-directory containment view from the commit-file sets the orchestrator parses
 once and passes in, then assembles all five run-context blocks from the upstream signal
-outputs. Emits the six named derived findings (hidden coupling, bleeding module,
-refactor boundary, orphaned understanding, lying map, etc.) as a structured array.
-Each block build is wrapped in a catch-all so one signal's failure degrades that block
-to `available: False` rather than crashing the run.
+outputs. Emits the eight named derived findings as a fixed-order structured array:
+`hidden_coupling`, `lying_map`, `unexplained_complexity`, `untrusted_hotspot`,
+`self_referential_tests`, `orphaned_understanding`, `candidate_dead_weight`, and
+`refactor_boundary` (the two trust-axis findings, `untrusted_hotspot` and
+`self_referential_tests`, were added after this module's first cut). Each block build
+is wrapped in a catch-all so one signal's failure degrades that block to
+`available: False` rather than crashing the run.
 
 **`coupling_analysis.py`**
 B3 static-vs-historical disagreement cross: compares the import-graph view
@@ -155,12 +182,28 @@ usefulness: positive directives, tradeoff phrases, path references, verifiable
 outcomes, and freshness. Pure regex + arithmetic, filename-agnostic.
 
 **`liveness_scan.py`**
-Layer 1 liveness inputs, two tiers:
+Layer 1 liveness inputs, three tiers:
 - Dead-code tier: runs a language-appropriate static dead-code tool (vulture, ts-prune,
   staticcheck, etc.) to flag candidate-dead exports within the repo boundary.
 - Observability tier: scores three rungs - instrumented (telemetry emitted), discoverable
   (runbook present), reachable (agent has an invokable path to runtime state). The
   reachability rung decides the Layer 1 score.
+- Capability-offer tier: delegates to `jvm_capabilities.py` to detect JVM/Maven build
+  systems and report, per analysis capability, whether a serving tool is already
+  configured, could be run/installed in-session, or honest-degrades with a named
+  candidate. Surfaced so a non-enumerated ecosystem proposes a tool rather than
+  silently reading "absent".
+
+**`jvm_capabilities.py`**
+JVM/Maven capability-driven analysis offers (issue #113, v1 bounded). Generalises
+`/assess`'s tool mapping from a hardcoded per-language allowlist (vulture for Python,
+ts-prune for TS, staticcheck for Go) to a *capability-driven detect-or-propose* model,
+proven on one capability (liveness) in one build system (Maven). Reports each capability
+in one of four states - `served`, `offer` (with a run-or-install `consent` shape),
+`credited` (a configured pom.xml plugin already serves it), or `honest_degrade` (nothing
+serves it yet; the report names the capability and a candidate tool). Imported by
+`liveness_scan.py`, never by the orchestrator - it is an inward dependency of the
+liveness tier.
 
 **`anomaly_detector.py`**
 Inspects a run-context dict for suspicious results (e.g. zero files scored, implausible


### PR DESCRIPTION
## Summary

Addresses **Actions 1 and 2** from the v1.36.0 `/assess` self-assessment (the first slice of the agreed plan in `docs/superpowers/specs/2026-06-04-assess-feedback-seams-and-archtest-design.md`). Both are about the `skills/assess/scripts/lib` subsystem; both are docs-only.

### Action 2 - clear the high-confidence `lying_map`

The run flagged `skills/assess/scripts/lib/README.md` as a `lying_map` (confidence high, nearest-ancestor). It was real drift: since the README was written (#117), the `lib/` it describes gained a **401-line module (`jvm_capabilities.py`, #121)** it never mentioned, `liveness_scan.py` grew a third tier, and `keyhole_signals.py` went from **six derived findings to eight**. Re-anchored to current code:
- `jvm_capabilities.py` documented (a liveness sub-module; the capability detect-or-propose model).
- `liveness_scan.py` description updated to its three tiers (dead-code, observability, capability-offer).
- The derived-findings list corrected to the eight fixed-order names.

### Action 1 - own the co-change seam map

The `hidden_coupling` attention list flags several assess directories as historically co-changing. A new **"wider co-change seams"** section in `lib/README.md` names them and states plainly this is **owned cohesion, not entanglement**: each `lib/` module moves with its test (the `CLAUDE.md` "add a test alongside any change" contract), and the `scripts/` standalone build moves with the `skills/` it packages. The intended cut-lines are written down so a future split has a recorded boundary. A pointer from `CLAUDE.md`'s `/assess architecture` section makes the seam map discoverable from the entry doc.

## Changes Made

- `skills/assess/scripts/lib/README.md` - re-anchored module reference + new co-change seam map.
- `CLAUDE.md` - one-line pointer to the seam map (inline code, not a clickable link, per the repo's link-contract convention).
- `docs/superpowers/specs/2026-06-04-assess-feedback-seams-and-archtest-design.md` - the design spec for this two-PR effort.
- `.claude-plugin/plugin.json` - bump 1.36.0 -> 1.36.1 (PATCH, docs-only).

## Testing

- `plugin contract` pytest: 181 passed (envelope-tag + link contracts green).
- `scripts/` standalone-build pytest: 105 passed (the README ships in the assess ZIP).
- No em dashes.

## Risk Assessment

Minimal. Documentation only - no Python, no skill output, no behaviour change. The deterministic core is untouched.

## Follow-up

PR2 (`feat`) lands the L4 import-boundary archtest + the wider mypy gate, off updated `main` (sequenced because both touch `CLAUDE.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Patched version to 1.36.1

* **Documentation**
  * Expanded module documentation to clarify co-change relationships and architectural ownership boundaries
  * Added specification for planned architectural improvements and enforcement testing strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->