### PR TITLE
feat: Enforce the assess core import boundary; widen mypy to assess_core

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ bash scripts/build-standalone-skills.sh --dest ~/Desktop  # custom output dir
 
 ## /assess architecture
 
-Deterministic core in `skills/assess/scripts/lib/` does all data work; the LLM only writes prose.
+Deterministic core in `skills/assess/scripts/lib/` does all data work; the LLM only writes prose. The layering is **inward-only**: a `lib/` module may import other `lib/` modules and third-party libraries, but never an orchestrator script (`assess_core.py`, `assess_finalize.py`, `assess_report.py`, `assess_gate.py`, ...). This keeps the core independently testable and reusable. It is no longer just a convention - `skills/assess/tests/test_self_architecture.py` enforces it as a contract: an `ast` scan fails the build if any `lib/` module imports an orchestrator (the forbidden set is derived from disk, so a new orchestrator is covered automatically).
 
 - `lib/agent_instructions_grader.py` - heuristic scoring of CLAUDE.md / AGENTS.md / GEMINI.md / .cursorrules / .github/copilot-instructions.md (regex + arithmetic, no AI)
 - `lib/stats_diff.py` - cross-run comparison (graduated/regressed/new/persistent hotspots)

--- a/skills/assess/pyproject.toml
+++ b/skills/assess/pyproject.toml
@@ -56,10 +56,11 @@ max-complexity = 15
 [tool.mypy]
 # Issue #79: type hints existed but were unenforced. This gate makes them a
 # contract. Scoped to the deterministic core (lib/) where the annotations are
-# densest and most load-bearing; the top-level orchestrator scripts
-# (assess_core.py, assess_finalize.py, complexity-treemap.py) and the build
-# pipeline are the next ratchet step.
-files = ["scripts/lib"]
+# densest and most load-bearing, plus the orchestrator assess_core.py (the
+# most-churned file, ratcheted in here). The remaining orchestrator scripts
+# (assess_finalize.py, complexity-treemap.py) and the build pipeline are the
+# next ratchet step.
+files = ["scripts/lib", "scripts/assess_core.py"]
 # lib/ is a package; treat scripts/ as the import base so lib.<mod> resolves and
 # the back-compat shims (scripts/stats_diff.py, lib/assess_core.py) don't collide
 # as duplicate top-level modules.

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -32,6 +32,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 # Make sibling lib package importable when run as a script
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -587,7 +588,11 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     )
     append_log_entry(assess_dir, log_entry)
 
-    ctx = {
+    # Heterogeneous run-context bus: values are dicts, lists, scalars, or the
+    # degrade-gracefully bool/str/None fallbacks. Typed as dict[str, Any] so the
+    # block accessors below (ctx["dead_code"] etc.) stay assignable to the
+    # signal functions that consume them.
+    ctx: dict[str, Any] = {
         "run_date": run_date,
         # The commit the scan measured. Absolute LOC/CCN figures are a snapshot
         # of this commit; the report pins the SHA and warns when HEAD is dirty

--- a/skills/assess/scripts/lib/wiki_writer.py
+++ b/skills/assess/scripts/lib/wiki_writer.py
@@ -38,7 +38,11 @@ class LogEntry:
     files_scored: int
     readiness_score: float
     maturity_label: str
-    instructions_grade: str
+    # Optional[str]: None means no instruction file was found at any known
+    # location (the schema convention in CLAUDE.md). The log template renders it
+    # via str.format, so a None prints as "None" - unchanged from prior runtime
+    # behaviour; only the annotation is corrected to match the data.
+    instructions_grade: str | None
     graduated_count: int
     regressed_count: int
     new_count: int

--- a/skills/assess/tests/test_self_architecture.py
+++ b/skills/assess/tests/test_self_architecture.py
@@ -1,0 +1,90 @@
+"""Executable architecture contract for the /assess deterministic core.
+
+`CLAUDE.md` states the layering: the deterministic core in
+`skills/assess/scripts/lib/` does all the data work, and the orchestrator
+scripts in `skills/assess/scripts/` (assess_core, assess_finalize, ...) call
+into it and assemble `run-context.json`. Dependencies point **inward**: a lib
+module may import other lib modules and third-party libraries, but it must never
+import an orchestrator. That keeps the core independently testable and reusable -
+the property the decomposition-parity test relies on.
+
+This was a convention enforced only by review (the L4 "Partial" the tool's own
+self-assessment flagged). This test makes it a contract: an `ast` scan over every
+module in `lib/` asserts none imports an orchestrator. The forbidden set is
+*derived* from disk - every `.py` directly under `scripts/` (not in `lib/`) - so
+a newly added orchestrator is forbidden automatically, with no edit here.
+
+Pure stdlib (`ast`, `pathlib`); no import side effects, so it is safe and fast.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# tests/ -> assess/ ; the deterministic core and its orchestrators live under scripts/.
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+
+def _orchestrator_modules() -> set[str]:
+    """Importable module names of the orchestrator layer: every ``*.py`` directly
+    under ``scripts/`` (excluding the ``lib/`` package). Hyphenated run-only
+    scripts (``complexity-treemap.py``) are kept for completeness - their stems
+    are not valid identifiers, so they can never appear as an import anyway."""
+    return {p.stem for p in SCRIPTS_DIR.glob("*.py")}
+
+
+def _lib_modules() -> list[Path]:
+    """Every Python module in the deterministic core, recursively (includes the
+    ``test_pressure/`` subpackage)."""
+    return sorted(LIB_DIR.rglob("*.py"))
+
+
+def _imported_names(tree: ast.AST) -> set[str]:
+    """Collect the dotted module path of every ``import`` / ``from ... import``
+    in a parsed module (absolute imports only; relative imports stay in-package
+    by construction and cannot reach an orchestrator)."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # level > 0 is a relative import (``from . import x``) - in-package,
+            # never an orchestrator. Only absolute imports can cross the boundary.
+            if node.level == 0 and node.module:
+                names.add(node.module)
+    return names
+
+
+def test_fixture_paths_resolve() -> None:
+    """Guard against a path bug making the boundary test vacuously pass."""
+    orchestrators = _orchestrator_modules()
+    libs = _lib_modules()
+    assert LIB_DIR.is_dir(), f"lib package not found at {LIB_DIR}"
+    assert "assess_core" in orchestrators, "expected assess_core.py among the orchestrators"
+    assert libs, "expected at least one module in the deterministic core"
+
+
+def test_core_does_not_import_orchestrators() -> None:
+    """No `lib/` module may import an orchestrator script - dependencies point
+    inward. A failure means the deterministic core grew an upward dependency."""
+    orchestrators = _orchestrator_modules()
+    violations: list[str] = []
+
+    for module in _lib_modules():
+        tree = ast.parse(module.read_text(encoding="utf-8"), filename=str(module))
+        for imported in _imported_names(tree):
+            # Match an orchestrator stem appearing as any dotted component, so
+            # both ``import assess_core`` and ``import scripts.assess_core`` are
+            # caught.
+            hit = next((o for o in orchestrators if o in imported.split(".")), None)
+            if hit:
+                rel = module.relative_to(LIB_DIR.parent)
+                violations.append(f"{rel} imports orchestrator '{hit}' (via '{imported}')")
+
+    assert not violations, (
+        "deterministic core must not import the orchestrator layer "
+        "(dependencies point inward - see CLAUDE.md /assess architecture):\n  "
+        + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary

PR2 of the planned pair addressing the v1.36.0 `/assess` self-assessment (spec: `docs/superpowers/specs/2026-06-04-assess-feedback-seams-and-archtest-design.md`). Closes the **L4** architecture gap and takes the **L2** mypy ratchet step. PR1 (#160, the seam map + lying_map fix) is already merged.

### L4 - make the stated layering executable

`CLAUDE.md` states the layering: the deterministic core (`scripts/lib`) does the data work, the orchestrators (`assess_core.py`, ...) call into it - dependencies point **inward**. That was enforced only by review (the tool scored L4 **Partial**). New `skills/assess/tests/test_self_architecture.py` makes it a contract: an `ast` scan over every `lib/` module fails if it imports an orchestrator.

- The forbidden set is **derived from disk** (every `*.py` directly under `scripts/`), so a newly added orchestrator is covered automatically - no edit to the test.
- Verified the detector catches both `import assess_core` and `from scripts.assess_gate import x`, and ignores stdlib. The boundary **holds today**, so it lands green and pins the good state.
- Runs inside the required `skills/assess pytest` check, so a future upward import fails merge.

### L2 - widen the type gate

Added `scripts/assess_core.py` (the most-churned file) to the mypy `files` list - the config comment already named it as the next ratchet. Fixed the 4 surfaced errors by **correcting annotations to match the data, no behaviour change**:
- `LogEntry.instructions_grade` is now `str | None` (the `Optional[str]` schema `CLAUDE.md` already documents; runtime already handled None).
- The run-context bus `ctx` is typed `dict[str, Any]`, so the block accessors (`ctx["dead_code"]` etc.) stay assignable to the signal functions that consume them.

Documented the inward-only boundary in `CLAUDE.md`'s `/assess architecture` section.

## Changes Made

- `skills/assess/tests/test_self_architecture.py` - new `ast` import-boundary contract (2 tests).
- `skills/assess/pyproject.toml` - mypy scope `+ scripts/assess_core.py`.
- `skills/assess/scripts/assess_core.py` - `ctx: dict[str, Any]` annotation + `Any` import.
- `skills/assess/scripts/lib/wiki_writer.py` - `LogEntry.instructions_grade: str | None`.
- `CLAUDE.md` - document the enforced boundary.
- `.claude-plugin/plugin.json` - bump 1.36.1 -> 1.36.2 (PATCH; internal enforcement + types, no `/assess` output change).

## Testing

- `skills/assess` pytest: 539 passed, 1 skipped (incl. the 2 new archtest cases).
- mypy (widened): clean, 25 source files.
- `ruff`: clean. `plugin contract` pytest: 182. `scripts/` build pytest: 105.
- No em dashes.

## Risk Assessment

Low. The archtest pins an already-true property; the mypy fixes are annotation-only with no runtime change (verified by the full suite, including the decomposition-parity and wiki_writer tests).