### PR TITLE
fix: warn when assess-pr remote redirects to a different repo

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.38.1",
+  "version": "1.38.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess-pr/SKILL.md
+++ b/skills/assess-pr/SKILL.md
@@ -36,6 +36,24 @@ esac
 # If the command failed (no remote, no gh, not a GitHub repo, unauthenticated),
 # $PUSH_INFO is empty and $PERM stays empty - fall back to the local-branch
 # flow with the reason. Never silently assume push works.
+
+# Detect remote-to-gh redirect: GitHub follows transfers/renames, so gh may
+# resolve a different owner/repo than the configured remote implies.
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
+if [ -n "$REMOTE_URL" ]; then
+  # Strip trailing .git, then extract owner/repo from SSH and HTTPS forms.
+  # SSH:   git@github.com:owner/repo.git -> owner/repo
+  # HTTPS: https://github.com/owner/repo -> owner/repo
+  REMOTE_SLUG=$(echo "$REMOTE_URL" | sed -e 's/\.git$//' -e 's|.*github\.com[:/]\(.*\)|\1|')
+else
+  REMOTE_SLUG=""
+fi
+GH_SLUG=$(echo "$PUSH_INFO" | jq -r '.nameWithOwner // empty')
+if [ -n "$REMOTE_SLUG" ] && [ -n "$GH_SLUG" ] && [ "$REMOTE_SLUG" != "$GH_SLUG" ]; then
+  REDIRECT_NOTICE="Note: origin (\`$REMOTE_SLUG\`) redirects to \`$GH_SLUG\`; the offers below target the redirected repo."
+else
+  REDIRECT_NOTICE=""
+fi
 ```
 
 Interpret the result:
@@ -43,6 +61,8 @@ Interpret the result:
 - `CAN_PUSH=1` (viewerPermission is `WRITE` / `MAINTAIN` / `ADMIN`, or the remote is a push-eligible fork): offer the direct PR flow below.
 - `CAN_PUSH=0` and viewerPermission is `READ` / `TRIAGE`: name the constraint, then offer the fork-based PR flow ("fork `<owner>/<repo>` and open the PR from your fork?") as an alternative to "leave local". Do not offer the direct flow.
 - `gh` unavailable / not a GitHub remote / not authenticated (`$PUSH_INFO` empty): skip both PR offers entirely and surface only the "leave local" outcome, naming the reason ("no GitHub remote detected" / "`gh` not authenticated").
+
+If `$REDIRECT_NOTICE` is non-empty, output it verbatim on its own line before the offer below.
 
 Then surface the question - verbatim, picking the shape that matches the access tier.
 

--- a/skills/assess-pr/SKILL.md
+++ b/skills/assess-pr/SKILL.md
@@ -41,15 +41,23 @@ esac
 # resolve a different owner/repo than the configured remote implies.
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
 if [ -n "$REMOTE_URL" ]; then
-  # Strip trailing .git, then extract owner/repo from SSH and HTTPS forms.
-  # SSH:   git@github.com:owner/repo.git -> owner/repo
-  # HTTPS: https://github.com/owner/repo -> owner/repo
-  REMOTE_SLUG=$(echo "$REMOTE_URL" | sed -e 's/\.git$//' -e 's|.*github\.com[:/]\(.*\)|\1|')
+  # Normalise SSH and HTTPS forms (and GitHub Enterprise hosts) to owner/repo.
+  # SSH:   git@host:owner/repo.git   -> owner/repo
+  # HTTPS: https://host/owner/repo/  -> owner/repo
+  # Strip protocol, any user@, the host (not just github.com), a trailing .git,
+  # and a trailing slash - so a GHE host or a trailing slash can't masquerade as
+  # a redirect.
+  REMOTE_SLUG=$(echo "$REMOTE_URL" \
+    | sed -e 's|^[a-zA-Z]*://||' -e 's|^[^@/]*@||' -e 's|^[^/:]*[:/]||' -e 's|\.git$||' -e 's|/$||')
 else
   REMOTE_SLUG=""
 fi
 GH_SLUG=$(echo "$PUSH_INFO" | jq -r '.nameWithOwner // empty')
-if [ -n "$REMOTE_SLUG" ] && [ -n "$GH_SLUG" ] && [ "$REMOTE_SLUG" != "$GH_SLUG" ]; then
+# Compare case-insensitively: GitHub treats owner/repo as case-insensitive, so a
+# pure case difference is not a redirect and must not emit a spurious notice.
+REMOTE_SLUG_LC=$(echo "$REMOTE_SLUG" | tr '[:upper:]' '[:lower:]')
+GH_SLUG_LC=$(echo "$GH_SLUG" | tr '[:upper:]' '[:lower:]')
+if [ -n "$REMOTE_SLUG" ] && [ -n "$GH_SLUG" ] && [ "$REMOTE_SLUG_LC" != "$GH_SLUG_LC" ]; then
   REDIRECT_NOTICE="Note: origin (\`$REMOTE_SLUG\`) redirects to \`$GH_SLUG\`; the offers below target the redirected repo."
 else
   REDIRECT_NOTICE=""


### PR DESCRIPTION
## Summary

- Extends the Step 5 capability-detection bash block in `skills/assess-pr/SKILL.md` to parse `owner/repo` from `git remote get-url origin`
- Compares it against `gh repo view`'s `nameWithOwner` (which follows GitHub transfer/rename redirects)
- On mismatch, sets `REDIRECT_NOTICE` and adds an instruction to emit it verbatim before the Step 5 offer
- A non-redirected remote sets `REDIRECT_NOTICE=""` - no behaviour change for the common case

## Changes

- `skills/assess-pr/SKILL.md`: extended Step 5 bash block with redirect detection; added notice-emission instruction before the offer
- `.claude-plugin/plugin.json`: version bump 1.38.1 -> 1.38.3

## Test plan

- [ ] `scripts/` pytest: 103 pass, 2 pre-existing failures unrelated to this change (huddle config markers)
- [ ] `skills/assess/tests/`: 562 pass, 1 skipped

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.38.3

* **New Features**
  * PR assessment flow now detects when a configured remote redirects to a different GitHub repository and displays a notification clarifying the target repository for PR offers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->