### PR TITLE
fix: cap finding confidence when git churn history is degenerate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -659,6 +659,17 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     ctx["doc_graph"] = doc_graph
     ctx["doc_staleness"] = doc_staleness
     ctx["stale_hubs"] = _build_stale_hubs(doc_graph, doc_staleness)
+    # Churn-measurement reliability, surfaced to the report layer so the score
+    # line can carry a "snapshot / no usable history" caveat. True when the git
+    # history is degenerate - every file ~1 commit (shallow clone, fresh import,
+    # squashed/extracted tree) - in which case churn-derived findings are
+    # discounted (confidence capped, lying_map / hidden_coupling not counted) and
+    # the treemap saturation axis is inactive. Single source of truth: the
+    # doc-staleness block (lib.git_churn.churn_is_degenerate).
+    ctx["churn_degenerate"] = bool(
+        doc_staleness.get("churn_degenerate", False)
+        if isinstance(doc_staleness, dict) else False
+    )
     # Instruction-surface integrity (Layer 0): files present on disk but not
     # committed, and advertised-but-broken instruction references (dangling
     # symlinks + entry docs linking a missing instruction file). A broken

--- a/skills/assess/scripts/assess_report.py
+++ b/skills/assess/scripts/assess_report.py
@@ -198,10 +198,19 @@ def _render_commit_note(ctx: dict) -> str:
 
 
 def _render_churn_window(ctx: dict) -> str:
-    """Surface the churn-window label the treemap/doc-staleness pass settled on."""
+    """Surface the churn-window label the treemap/doc-staleness pass settled on.
+
+    When the history is degenerate (every file ~1 commit - a snapshot with no
+    usable history), the label carries a caveat so the churn axis, the saturation
+    treemap channel, and any churn-derived finding are read as inactive rather
+    than as a live signal (issue #172).
+    """
     doc_staleness = ctx.get("doc_staleness") or {}
     window = doc_staleness.get("churn_window")
-    return window if window else "unavailable"
+    label = window if window else "unavailable"
+    if ctx.get("churn_degenerate"):
+        return f"{label} - snapshot / no usable history, churn signal flat"
+    return label
 
 
 def render_report(ctx: dict, repo_name: str) -> str:

--- a/skills/assess/scripts/complexity-treemap.py
+++ b/skills/assess/scripts/complexity-treemap.py
@@ -76,7 +76,11 @@ import numpy as np
 # implementation. Only the colour mapping differs per heatmap and stays local.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from lib.assess_config import load_excludes  # noqa: E402
-from lib.git_churn import git_churn_scores, pick_churn_window  # noqa: E402
+from lib.git_churn import (  # noqa: E402
+    churn_is_degenerate,
+    git_churn_scores,
+    pick_churn_window,
+)
 from lib.treemap_render import (  # noqa: E402
     adaptive_cap,
     blend_to_grey,
@@ -414,13 +418,22 @@ def render(files: list[tuple[Path, int, float, str]],
            aux_data: dict[Path, int] | None = None,
            aux_label: str | None = None,
            survivor_density: dict[Path, float] | None = None,
-           tokens_by_path: dict[Path, int] | None = None) -> None:
+           tokens_by_path: dict[Path, int] | None = None,
+           churn_degenerate: bool = False) -> None:
     metric_label = "commits" if by == "churn" else "ccn"
     metrics = [f[2] for f in files]
     cap, cap_kind = adaptive_cap(metrics)
     # OrRd (ColorBrewer): colour-blind-safe sequential ramp, pale = simple ->
     # dark red = complex. Avoids the red-green of RdYlGn (the most common CVD).
     cmap = plt.get_cmap("OrRd")
+
+    # Degenerate churn = a flat saturation axis (every file ~1 commit), which
+    # would render as uniform full-saturation and read as a live signal. Drop it:
+    # the blocks render fully vivid (pure complexity), matching the no-git path,
+    # and the one-line summary below states the axis is inactive rather than
+    # legending a meaningless gradient.
+    if churn_degenerate:
+        aux_data = None
 
     aux_cap = 1.0
     aux_cap_kind = ""
@@ -461,7 +474,10 @@ def render(files: list[tuple[Path, int, float, str]],
     mx = float(max(metrics)) if metrics else 0.0
     print(f"hue: {metric_label}; range 0-{mx:.0f}; "
           f"cap {cap:.0f} ({cap_kind})")
-    if aux_data is not None:
+    if churn_degenerate:
+        print("saturation: churn signal flat (degenerate history - every file "
+              "~1 commit); axis inactive, rendering pure complexity.")
+    elif aux_data is not None:
         aux_max = max((float(aux_data.get(f[0], 0)) for f in files),
                        default=0.0)
         print(f"saturation: {aux_label}; range 0-{aux_max:.0f}; "
@@ -615,7 +631,8 @@ def write_stats(files: list[tuple[Path, int, float, str]],
                 aux_label: str | None,
                 root: Path, out_path: Path,
                 fn_ccn_by_path: dict[Path, list[float]] | None = None,
-                tokens_by_path: dict[Path, int] | None = None) -> None:
+                tokens_by_path: dict[Path, int] | None = None,
+                churn_degenerate: bool = False) -> None:
     """Write a JSON stats sidecar summarising the treemap data.
 
     Consumed by the /assess skill: percentiles drive Layer 3 (linter) scoring,
@@ -718,6 +735,12 @@ def write_stats(files: list[tuple[Path, int, float, str]],
             "scc": sum(1 for f in files if f[3] == "scc"),
         },
         "churn_window": aux_label,
+        # Churn-measurement reliability (lib.git_churn.churn_is_degenerate). True
+        # when the history is degenerate - every file ~1 commit - so the
+        # saturation axis carries no signal and the hotspot composite's churn
+        # term (sqrt(1 + commits)) is near-constant. A reader (and the report)
+        # treats the `commits` column and saturation axis as inactive here.
+        "churn_degenerate": bool(churn_degenerate),
         "loc": {
             "p50": pct(locs, 50),
             "p95": pct(locs, 95),
@@ -893,6 +916,14 @@ def main() -> int:
         return 1
 
     _warn_if_dominated_by_one_file(files)
+    # Is the churn axis trustworthy? A degenerate history (shallow clone, fresh
+    # import, squashed/extracted tree) shows ~1 commit per file, so the
+    # saturation axis is a flat non-signal. Detected via the single source of
+    # truth in lib.git_churn and threaded to render (drop the axis) and
+    # write_stats (record the flag). Computed only in hotspot mode (aux_data set).
+    churn_degenerate = aux_data is not None and churn_is_degenerate(
+        aux_data.values()
+    )
     # Estimate tokens once, post-artifact-filter, and share the map between the
     # treemap (block area) and the stats sidecar (size unit + keyhole budget) so
     # both views agree and no file is read twice.
@@ -906,10 +937,12 @@ def main() -> int:
     render(files, root, out, f"Hotspot: {root.name}",
            show_labels=args.labels, by=effective_by,
            aux_data=aux_data, aux_label=aux_label,
-           survivor_density=survivor_density, tokens_by_path=tokens)
+           survivor_density=survivor_density, tokens_by_path=tokens,
+           churn_degenerate=churn_degenerate)
     if args.stats:
         write_stats(files, aux_data, aux_label, root, args.stats,
-                    fn_ccn_by_path=fn_ccn_by_path, tokens_by_path=tokens)
+                    fn_ccn_by_path=fn_ccn_by_path, tokens_by_path=tokens,
+                    churn_degenerate=churn_degenerate)
     return 0
 
 

--- a/skills/assess/scripts/lib/doc_complexity_join.py
+++ b/skills/assess/scripts/lib/doc_complexity_join.py
@@ -209,6 +209,16 @@ def analyze_doc_complexity_join(
         if doc_staleness.get("available", False)
         else []
     )
+    # Churn-measurement reliability (set once in lib.git_churn, carried on the
+    # doc-staleness block). When the history is degenerate - every file ~1 commit
+    # (shallow clone, fresh import, squashed/extracted tree) - the `ratio` that
+    # drives `freshness` is built on a churn count that means nothing, even
+    # though the doc->code association may be perfectly precise. `confidence`
+    # encodes association precision, not measurement reliability, so a precise
+    # map over a meaningless churn signal would otherwise stamp a high-confidence
+    # lying_map. Cap every doc's confidence to "low" so the existing
+    # low-confidence guard below suppresses the lying_map classification.
+    churn_degenerate = bool(doc_staleness.get("churn_degenerate", False))
     doc_paths = [d["path"] for d in docs_in]
     assignment = _assign_code_to_docs(list(file_ccn), doc_paths)
     covered_code = {c for codes in assignment.values() for c in codes}
@@ -227,6 +237,10 @@ def analyze_doc_complexity_join(
         )
         freshness = _signed_freshness(doc)
         doc_value = round(complexity_summarised * freshness, 3)
+        # Degenerate churn caps measurement confidence to "low" regardless of how
+        # precise the association is (see churn_degenerate above). The reported
+        # confidence reflects the cap so a downstream reader sees the discount.
+        confidence = "low" if churn_degenerate else doc.get("confidence")
 
         finding: str | None = None
         # Trivial code never produces a finding: complexity_summarised below the
@@ -239,7 +253,7 @@ def analyze_doc_complexity_join(
             # "stale" purely because the repo is busy elsewhere. That is too
             # coarse to call a lying map - the same confidence guard the Layer 0
             # stale-hub reporting applies. Leave such a doc unclassified.
-            low_confidence = doc.get("confidence") == "low"
+            low_confidence = confidence == "low"
             if freshness < 0 and not low_confidence:
                 finding = "lying_map"
             elif freshness > 0:
@@ -251,7 +265,7 @@ def analyze_doc_complexity_join(
             "freshness": freshness,
             "doc_value": doc_value,
             "finding": finding,
-            "confidence": doc.get("confidence"),
+            "confidence": confidence,
             "subject_code_count": len(subject),
             "recommendation": _RECOMMENDATIONS.get(finding) if finding else None,
         }

--- a/skills/assess/scripts/lib/doc_staleness.py
+++ b/skills/assess/scripts/lib/doc_staleness.py
@@ -32,6 +32,7 @@ from lib.doc_graph import (
     is_repo_file,
 )
 from lib.git_churn import (
+    churn_is_degenerate,
     file_last_commit_days,
     pick_churn_window,
     tracked_files,
@@ -237,6 +238,17 @@ def analyze_doc_staleness(
         churn_map = {}
         churn_label = None
 
+    # Is the churn measurement itself trustworthy? A degenerate history (shallow
+    # clone, fresh import, squashed/extracted tree) shows ~1 commit per file, so
+    # `code_churn_in_window` swells to the file count and inflates every ratio
+    # below. We measure degeneracy over the *code* distribution (the subject the
+    # ratio's numerator sums) and surface it as the single source of truth other
+    # consumers read - the doc->complexity join caps confidence, the keyhole
+    # summary drops churn-derived findings, the report carries a snapshot caveat.
+    churn_degenerate = churn_is_degenerate(
+        churn_map.get(c, 0) for c in code_files
+    )
+
     base_doc_dirs = _build_base_doc_dirs(repo_root, docs)
     code_dirs = {c.parent for c in code_files}
 
@@ -337,6 +349,11 @@ def analyze_doc_staleness(
     return {
         "available": True,
         "churn_window": churn_label,
+        # Churn-measurement reliability, independent of doc->code association
+        # precision. True = the window has no usable churn signal (every file ~1
+        # commit), so any finding built on `code_churn_in_window` / `ratio` must
+        # be discounted - see `lib.git_churn.churn_is_degenerate`.
+        "churn_degenerate": churn_degenerate,
         "docs": [r.as_dict() for r in sorted(results, key=lambda r: -r.ratio)],
         "association": {
             "code_file_count": len(code_files),

--- a/skills/assess/scripts/lib/git_churn.py
+++ b/skills/assess/scripts/lib/git_churn.py
@@ -12,8 +12,10 @@ scripts (which also pull in lizard/matplotlib/squarify).
 """
 from __future__ import annotations
 
+import math
 import subprocess
 import sys
+from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
 
@@ -259,3 +261,62 @@ def pick_churn_window(
         return ({p: data.get(p, 0) for p in file_paths},
                 f"commits ({label})")
     return None, None
+
+
+# A churn window is "degenerate" when its commits-per-file distribution is
+# effectively flat: almost every file that moved in the window shows a single
+# commit. That is the fingerprint of a history with no usable churn signal -
+# a shallow clone, a fresh import, or a squashed/extracted source tree where
+# every file was created in one bulk commit. A count of "1 commit" there is an
+# extraction artifact, not a measure of how much the file actually churns.
+#
+# The danger is that downstream signals read the count as if it meant activity:
+# `code_churn_in_window` swells to ~= the file count, the doc-staleness ratio
+# inflates, and a *precise* doc->code association (high `subject_method`
+# confidence) then stamps a high-confidence `lying_map` onto pure noise. The two
+# properties are independent - association precision says *which* code a doc maps
+# to; measurement reliability says whether the churn count *means* anything - and
+# only this flag carries the second. Consumers that read it degrade: cap finding
+# confidence, drop churn-derived findings from the summary, flatten the treemap
+# saturation axis. This is the single source of truth; consumers thread the
+# boolean rather than recomputing the distribution.
+DEGENERATE_CHURN_P95 = 1
+# Below this many files with any activity the distribution is too small to judge.
+# A three-file utility repo where each file shows one commit is not the
+# shallow-clone / squashed-history artifact this guards against, so we never call
+# degeneracy on a handful of files - we'd risk flattening a genuinely tiny repo.
+MIN_ACTIVE_FILES_FOR_DEGENERACY = 5
+
+
+def churn_is_degenerate(
+    commit_counts: Iterable[int],
+    min_active_files: int = MIN_ACTIVE_FILES_FOR_DEGENERACY,
+    p95_threshold: int = DEGENERATE_CHURN_P95,
+) -> bool:
+    """True when a per-file commit-count distribution carries no churn signal.
+
+    `commit_counts` is any iterable of per-file commit counts - the values of a
+    churn map (``pick_churn_window`` / ``git_churn_scores`` output). Files with
+    zero commits in the window are ignored: degeneracy is a property of the
+    *shape* of the activity among files that actually moved, not of how many sat
+    idle. Among those active files we take the 95th percentile (nearest-rank, so
+    a couple of genuinely-churned files can't mask an otherwise-flat import) and
+    call the window degenerate when it is at or below ``p95_threshold`` (1 by
+    default - "almost every touched file shows a single commit"). p95 rather than
+    max so the detector reports on the bulk of the distribution, equivalent to
+    "near-zero variance across files".
+
+    Returns False when fewer than ``min_active_files`` files have any activity:
+    too few data points to distinguish a degenerate history from a legitimately
+    small or quiet repo, where flattening the churn signal would be the wrong
+    call. Pure and side-effect-free so every consumer (doc-staleness join,
+    keyhole summary, treemap) can read the same verdict off the same data.
+    """
+    active = sorted(c for c in commit_counts if c and c > 0)
+    if len(active) < min_active_files:
+        return False
+    # Nearest-rank p95: index of the ceil(0.95 * n)-th value (1-based), so for an
+    # all-ones distribution p95 == 1 and a single outlier among thousands of
+    # ones still leaves p95 == 1.
+    idx = max(0, math.ceil(0.95 * len(active)) - 1)
+    return active[idx] <= p95_threshold

--- a/skills/assess/scripts/lib/keyhole_signals.py
+++ b/skills/assess/scripts/lib/keyhole_signals.py
@@ -801,9 +801,30 @@ def integrate(
     except Exception:  # noqa: BLE001 - degrade, never crash
         self_ref_paths = []
 
+    # Churn-measurement reliability (single source of truth: lib.git_churn, set
+    # on the doc-staleness block). When the history is degenerate - every file ~1
+    # commit (shallow clone, fresh import, squashed/extracted tree) - the churn
+    # signal carries no information, so the two findings derived from it must not
+    # be counted: `lying_map` (built on the doc-staleness ratio) and
+    # `hidden_coupling` (built on co-commit change coupling, which a single bulk
+    # import maximally inflates). lying_map is already suppressed upstream by the
+    # confidence cap in the join; hidden_coupling is dropped here. Both blocks
+    # keep their raw data (honest); only the *counted findings* degrade.
+    churn_degenerate = bool(doc_staleness.get("churn_degenerate", False))
+    churn_derived_findings = {"lying_map", "hidden_coupling"}
+
+    def _churn_paths(name: str, paths: list[str]) -> list[str]:
+        return [] if (churn_degenerate and name in churn_derived_findings) else paths
+
     findings = assemble_findings({
-        "hidden_coupling": [h["path"] for h in behaviour.get("hidden_coupling_findings", [])],
-        "lying_map": [d["path"] for d in documentation.get("stale_doc_on_complexity", [])],
+        "hidden_coupling": _churn_paths(
+            "hidden_coupling",
+            [h["path"] for h in behaviour.get("hidden_coupling_findings", [])],
+        ),
+        "lying_map": _churn_paths(
+            "lying_map",
+            [d["path"] for d in documentation.get("stale_doc_on_complexity", [])],
+        ),
         "unexplained_complexity": [
             d["path"] for d in documentation.get("unexplained_complexity", [])
         ],

--- a/skills/assess/tests/test_assess_report.py
+++ b/skills/assess/tests/test_assess_report.py
@@ -135,6 +135,21 @@ def test_full_render_metrics_values() -> None:
     assert "**Churn window:** commits (last 12mo)" in report
 
 
+def test_churn_window_carries_degenerate_caveat() -> None:
+    """Issue #172: when the run-context flags a degenerate churn history, the
+    churn-window line carries a 'snapshot / no usable history' caveat so the
+    score line isn't read as backed by a live churn signal."""
+    ctx = _full_ctx()
+    ctx["churn_degenerate"] = True
+    report = render_report(ctx, "demo")
+    assert "snapshot / no usable history, churn signal flat" in report
+
+    # Default (no flag) leaves the line clean - no regression for real histories.
+    clean = render_report(_full_ctx(), "demo")
+    assert "**Churn window:** commits (last 12mo)" in clean
+    assert "snapshot / no usable history" not in clean
+
+
 def test_full_render_substitute_is_strict() -> None:
     # render_report must not raise on a fully populated context.
     render_report(_full_ctx(), "demo")

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -117,6 +117,22 @@ def test_write_stats_uses_commits_field_and_balanced_rank(treemap, tmp_path):
     assert by_path["frozen.go"]["commits"] == 1
 
 
+def test_write_stats_records_churn_degenerate_flag(treemap, tmp_path):
+    """Issue #172: the stats sidecar carries ``churn_degenerate`` so the report
+    and a reader know the saturation axis / commits column is inactive. Default
+    is False; passing the flag records True."""
+    root = tmp_path
+    f = root / "a.go"
+    out = root / "stats.json"
+    treemap.write_stats([(f, 100, 5.0, "lizard")], {f: 1}, "commits (all-time)",
+                        root, out)
+    assert json.loads(out.read_text())["churn_degenerate"] is False
+
+    treemap.write_stats([(f, 100, 5.0, "lizard")], {f: 1}, "commits (all-time)",
+                        root, out, churn_degenerate=True)
+    assert json.loads(out.read_text())["churn_degenerate"] is True
+
+
 def test_write_stats_commits_none_without_git(treemap, tmp_path):
     """No churn data (no git) -> commits is None, distinct from a real 0."""
     root = tmp_path

--- a/skills/assess/tests/test_doc_complexity_join.py
+++ b/skills/assess/tests/test_doc_complexity_join.py
@@ -90,6 +90,42 @@ def test_complex_plus_stale_is_lying_map_negative_value() -> None:
     assert "do not auto-generate" in rec
 
 
+def test_degenerate_churn_caps_confidence_and_suppresses_lying_map() -> None:
+    """Issue #172: a precise (nearest-ancestor, high-confidence) association over
+    a DEGENERATE churn history must not stamp a lying_map. The churn count means
+    nothing - confidence encodes association precision, not measurement
+    reliability - so the join caps confidence to 'low' (the existing guard then
+    suppresses the finding). Same stale ratio and high confidence as the
+    lying_map case; only ``churn_degenerate`` differs."""
+    staleness = _staleness([_doc("pkg/engine/README.md", ratio=6.0)])
+    staleness["churn_degenerate"] = True
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/engine/README.md"]
+    # The ratio still computes negative freshness from the inflated churn...
+    assert doc["freshness"] == -1.0
+    # ...but the measurement is unreliable: confidence is capped and no lie called.
+    assert doc["confidence"] == "low"
+    assert doc["finding"] is None
+    assert result["findings"]["lying_maps"] == []
+
+
+def test_non_degenerate_churn_preserves_high_confidence_lying_map() -> None:
+    """Regression guard: with genuine churn variance (churn_degenerate False, the
+    default) the same precise association still produces a high-confidence
+    lying_map - the fix must not blunt real findings."""
+    staleness = _staleness([_doc("pkg/engine/README.md", ratio=6.0)])
+    staleness["churn_degenerate"] = False
+    result = analyze_doc_complexity_join(COMPLEXITY_STATS, staleness, Path("/repo"))
+
+    doc = _by_path(result)["pkg/engine/README.md"]
+    assert doc["confidence"] == "high"
+    assert doc["finding"] == "lying_map"
+    assert [u["path"] for u in result["findings"]["lying_maps"]] == [
+        "pkg/engine/README.md"
+    ]
+
+
 def test_low_confidence_stale_doc_is_not_a_lying_map() -> None:
     """A stale-by-ratio doc whose staleness is low-confidence (subject_method ==
     'repo-baseline') must NOT be classified a lying_map: the ratio is measured

--- a/skills/assess/tests/test_doc_staleness.py
+++ b/skills/assess/tests/test_doc_staleness.py
@@ -126,6 +126,40 @@ def test_stale_doc_beside_churny_code_has_high_ratio(git_repo) -> None:
     assert readme["ratio"] >= 5  # frozen map of a churning module
 
 
+def test_churn_degenerate_flag_on_single_commit_per_file_repo(git_repo) -> None:
+    """Issue #172: a history where every file shows one commit (a bulk import /
+    shallow clone / squashed tree) is degenerate - the churn count is an
+    extraction artifact, not activity. The doc-staleness block surfaces that as
+    ``churn_degenerate: True`` so downstream consumers discount churn findings."""
+    repo, commit = git_repo
+    (repo / "README.md").write_text("module map", encoding="utf-8")
+    for i in range(6):
+        (repo / f"mod{i}.py").write_text(f"x = {i}", encoding="utf-8")
+    commit("bulk import - one commit touches every file", days_ago=10)
+
+    r = analyze_doc_staleness(repo)
+    assert r["churn_degenerate"] is True
+
+
+def test_churn_not_degenerate_with_genuine_variance(git_repo) -> None:
+    """Regression guard: a repo with a real spread of commits-per-file is NOT
+    degenerate, so its high-confidence churn findings are untouched."""
+    repo, commit = git_repo
+    (repo / "README.md").write_text("module map", encoding="utf-8")
+    for i in range(6):
+        (repo / f"mod{i}.py").write_text("start", encoding="utf-8")
+    commit("init", days_ago=30)
+    # mod0 churns repeatedly; mod1 once more; mod2..5 stay frozen -> a spread.
+    for j in range(8):
+        (repo / "mod0.py").write_text(f"v = {j}", encoding="utf-8")
+        commit(f"churn {j}", days_ago=20 - j)
+    (repo / "mod1.py").write_text("v = 99", encoding="utf-8")
+    commit("touch mod1", days_ago=5)
+
+    r = analyze_doc_staleness(repo)
+    assert r["churn_degenerate"] is False
+
+
 def test_fresh_doc_beside_fresh_code_has_low_ratio(git_repo) -> None:
     repo, commit = git_repo
     (repo / "README.md").write_text("module map", encoding="utf-8")

--- a/skills/assess/tests/test_git_churn.py
+++ b/skills/assess/tests/test_git_churn.py
@@ -1,0 +1,67 @@
+"""Contract tests for the churn-degeneracy detector (issue #172).
+
+`churn_is_degenerate` is the single source of truth that lets every downstream
+consumer (doc->complexity join, keyhole summary, treemap) tell a meaningless
+churn signal from a real one. A degenerate window - every file ~1 commit, the
+fingerprint of a shallow clone / fresh import / squashed or extracted history -
+must be flagged so a precise doc->code association can no longer stamp a
+high-confidence finding onto pure extraction artifact.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from lib.git_churn import churn_is_degenerate  # noqa: E402
+
+
+def test_all_ones_is_degenerate() -> None:
+    """The canonical artifact: every file shows exactly one commit."""
+    assert churn_is_degenerate([1] * 1979) is True
+
+
+def test_single_outlier_among_ones_still_degenerate() -> None:
+    """One genuinely-churned file among thousands of single-commit files does
+    not rescue the signal - p95 (not max) reports on the flat bulk."""
+    counts = [1] * 1978 + [50]
+    assert churn_is_degenerate(counts) is True
+
+
+def test_zero_commit_files_are_ignored() -> None:
+    """Idle files (0 commits in the window) don't count toward the distribution:
+    degeneracy is the shape of the activity among files that actually moved."""
+    counts = [0] * 500 + [1] * 10
+    assert churn_is_degenerate(counts) is True
+
+
+def test_genuine_variance_is_not_degenerate() -> None:
+    """A real history with a spread of commits-per-file carries signal."""
+    counts = list(range(1, 60))  # 1..59, p95 well above 1
+    assert churn_is_degenerate(counts) is False
+
+
+def test_uniform_high_count_is_not_degenerate() -> None:
+    """Flat-but-active (every file committed several times) still has p95 > 1, so
+    it is not the single-commit artifact this guards against."""
+    assert churn_is_degenerate([5] * 100) is False
+
+
+def test_too_few_active_files_is_not_called() -> None:
+    """Below the minimum active-file count the distribution is too small to judge
+    - a tiny utility repo where each file shows one commit is not the
+    shallow-clone artifact, so we don't flatten its churn signal."""
+    assert churn_is_degenerate([1, 1, 1]) is False
+    assert churn_is_degenerate([]) is False
+
+
+def test_at_minimum_active_files_all_ones_is_degenerate() -> None:
+    """Exactly at the threshold, an all-ones distribution is degenerate."""
+    assert churn_is_degenerate([1, 1, 1, 1, 1]) is True
+
+
+def test_accepts_any_iterable() -> None:
+    """Consumers pass a generator of churn-map values; the detector consumes it
+    once without requiring a materialised list."""
+    assert churn_is_degenerate(c for c in [1, 1, 1, 1, 1, 1]) is True

--- a/skills/assess/tests/test_keyhole_signals.py
+++ b/skills/assess/tests/test_keyhole_signals.py
@@ -343,6 +343,89 @@ def test_render_findings_markdown_attention_section_caps_at_five() -> None:
     assert len(rows) == ks.MAX_ATTENTION_ROWS_RENDERED
 
 
+# --- Issue #172: degenerate churn drops churn-derived findings ----------------
+
+# A bleeding-but-statically-modular dir -> hidden_coupling; reused below.
+_BLEEDING_COMMIT_SETS = [
+    {Path("looksmodular/x.py"), Path("core/util.py")},
+    {Path("looksmodular/y.py"), Path("core/util.py")},
+    {Path("looksmodular/x.py"), Path("core/other.py")},
+    {Path("looksmodular/z.py"), Path("core/util.py")},
+    {Path("looksmodular/x.py"), Path("shared/s.py")},
+]
+_MODULAR_STRUCTURE = {
+    "available": True, "modularity_q": 0.6, "front_door_ratio": 0.95,
+}
+# A complex code file under a doc dir, so a stale high-confidence doc -> lying_map.
+_COMPLEXITY_STATS = {
+    "ccn": {"p50": 3.0, "p95": 8.0, "max": 30.0},
+    "files_scored": 1,
+    "top_complex": [{"path": "pkg/core.py", "loc": 400, "ccn": 30.0}],
+    "top_hotspots": [],
+    "top_large": [],
+}
+
+
+def _stale_doc_staleness(*, churn_degenerate: bool) -> dict:
+    """A high-confidence stale doc over pkg/core.py - a lying_map when the churn
+    history is real, suppressed when it is degenerate."""
+    return {
+        "available": True,
+        "churn_window": "commits (last 12mo)",
+        "churn_degenerate": churn_degenerate,
+        "docs": [{
+            "path": "pkg/README.md",
+            "ratio": 6.0,
+            "last_commit_days": 10,
+            "doc_churn_in_window": 1,
+            "code_churn_in_window": 6,
+            "subject_code_count": 1,
+            "subject_method": "nearest-ancestor",
+            "confidence": "high",
+        }],
+    }
+
+
+def _integrate(*, churn_degenerate: bool) -> dict:
+    return ks.integrate(
+        repo_root=Path("/nonexistent"),
+        complexity_stats=_COMPLEXITY_STATS,
+        doc_staleness=_stale_doc_staleness(churn_degenerate=churn_degenerate),
+        dead_code={"available": False, "candidate_count": 0,
+                   "candidates": [], "tools": []},
+        observability={"rung": None, "reachable": {"present": False}},
+        structure=_MODULAR_STRUCTURE,
+        commit_sets=_BLEEDING_COMMIT_SETS,
+    )
+
+
+def _finding_paths(result: dict, name: str) -> list[str]:
+    return next(f["paths"] for f in result["derived_findings"] if f["name"] == name)
+
+
+def test_real_churn_produces_churn_derived_findings() -> None:
+    """Baseline: with real churn (not degenerate), the lying_map and
+    hidden_coupling findings fire and are counted in the keyhole summary."""
+    result = _integrate(churn_degenerate=False)
+    assert _finding_paths(result, "lying_map") == ["pkg/README.md"]
+    assert _finding_paths(result, "hidden_coupling") == ["looksmodular"]
+    counted = {c["name"] for c in result["keyhole_summary"]["concerns"]}
+    assert {"lying_map", "hidden_coupling"} <= counted
+
+
+def test_degenerate_churn_drops_churn_derived_findings_from_summary() -> None:
+    """Issue #172: on a degenerate churn history the same inputs yield zero
+    churn-derived findings - lying_map (confidence capped in the join) and
+    hidden_coupling (dropped here) are absent from derived_findings AND the
+    keyhole_summary, so a reader sees 0 lying maps from a meaningless signal."""
+    result = _integrate(churn_degenerate=True)
+    assert _finding_paths(result, "lying_map") == []
+    assert _finding_paths(result, "hidden_coupling") == []
+    counted = {c["name"] for c in result["keyhole_summary"]["concerns"]}
+    assert "lying_map" not in counted
+    assert "hidden_coupling" not in counted
+
+
 # --- Task 3: build_keyhole_summary -------------------------------------------
 
 def test_build_keyhole_summary_counts_concerns_and_safe_zones() -> None:


### PR DESCRIPTION
## Summary

Degenerate git history (every file shows ~1 commit in the churn window - shallow clone, fresh import, squashed/extracted tree) produced **high-confidence** churn-derived findings built on a meaningless signal. The root cause: `confidence` encoded doc->code **association precision** (`subject_method`), not churn **measurement reliability**. A precise association over a flat churn distribution still scored `confidence: high`, so `README.md` was reported as a high-confidence `lying_map` from a pure extraction artifact, and the treemap saturation axis was rendered as a live signal while carrying no information.

Closes #172

## Changes Made

A single degeneracy detector in `lib/git_churn.py` (`churn_is_degenerate`) is the source of truth; consumers read the produced boolean rather than recomputing the distribution.

- **`lib/git_churn.py`** - `churn_is_degenerate(commit_counts)`: nearest-rank p95 over the files that actually moved; degenerate when p95 <= 1 (with a minimum-active-files guard so a tiny/quiet repo isn't flattened).
- **`lib/doc_staleness.py`** - computes degeneracy over the code-churn distribution and exposes `churn_degenerate` on its output block (the single source of truth in `run-context.json`).
- **`lib/doc_complexity_join.py`** - when churn is degenerate, caps `confidence` to `low`; the existing low-confidence guard then suppresses `lying_map`. The reported `confidence` reflects the cap.
- **`lib/keyhole_signals.py`** - drops churn-derived findings (`lying_map`, `hidden_coupling`) from `derived_findings`/`keyhole_summary` when degenerate (raw blocks keep their data; only counted findings degrade).
- **`complexity-treemap.py`** - detects degeneracy on the churn map, drops the saturation axis (renders pure complexity), states "churn signal flat" in the one-line summary, and records `churn_degenerate` in the stats sidecar.
- **`assess_core.py`** - surfaces `churn_degenerate` into `run-context.json`.
- **`assess_report.py`** - the churn-window line carries a "snapshot / no usable history, churn signal flat" caveat.
- **Version bump** `1.38.1` -> `1.38.2`.

## Technical Details

`confidence` conflated two independent properties: association precision (which code a doc maps to) and churn measurement reliability (whether the count means anything). Only the new flag carries the second. p95 (not max) so a handful of genuinely-churned files among thousands of single-commit files can't mask the degeneracy.

## Testing

- New `test_git_churn.py`: degeneracy-detector unit tests (all-ones, single outlier, zero-commit files ignored, genuine variance, uniform-high, too-few-files guard, iterable input).
- `test_doc_complexity_join.py`: degenerate churn caps confidence and suppresses `lying_map`; **regression** - genuine variance preserves the high-confidence `lying_map`.
- `test_keyhole_signals.py`: `integrate`-level - real churn produces and counts `lying_map`+`hidden_coupling`; degenerate churn drops both from `derived_findings` and `keyhole_summary`.
- `test_doc_staleness.py`: single-commit-per-file repo flags `churn_degenerate: True`; genuine-variance repo stays `False`.
- `test_complexity_treemap.py`: stats sidecar records the flag.
- `test_assess_report.py`: degenerate caveat on the churn-window line; clean line otherwise.

Suites green: `skills/assess` (578 passed, 1 skipped), `scripts/` (105), plugin contract (183), plus ruff + mypy gates clean.

## Risk Assessment

Low. Degeneracy is detected purely from distribution shape, so a repo with genuine churn variance has p95 > 1 and is unaffected (covered by explicit regression tests). The flag defaults to `False` and absent keys degrade to not-degenerate, so existing callers and run-context consumers are backward compatible.
