### PR TITLE
fix: detect Obsidian vault nested below repo root in doc-graph

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.38.3",
+  "version": "1.39.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -99,7 +99,12 @@ Doc link-graph for Layer 0 navigability. Parses `[[wikilinks]]` and
 graph. Derives PageRank centrality, orphan rate, connectivity, MOC validation, and
 doc->code association edges. The doc->code edges are reused by `doc_staleness.py` and
 `understanding_analysis.py`, making this module a shared dependency for the document
-analysis layer.
+analysis layer. Obsidian-vault detection (`_vault_detected`) walks the repo subtree,
+pruning `EXCLUDE_DIRS`, to find a `.obsidian/` directory anywhere under `repo_root`,
+not just at the root - a vault kept as a subdirectory (`repo/notes/.obsidian/`) sits
+below the `git rev-parse --show-toplevel` scan target and was previously reported as no
+vault, silently disabling downstream vault accommodations (#179). Pruning `EXCLUDE_DIRS`
+keeps a vendored or build-artifact `.obsidian/` from tripping a false positive.
 
 **`doc_staleness.py`**
 Doc-staleness metric for Layer 0. Associates each doc with the code it describes via

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -28,6 +28,7 @@ required. If ``networkx`` is unavailable the module degrades to an
 """
 from __future__ import annotations
 
+import os
 import posixpath
 import re
 from dataclasses import dataclass, field
@@ -272,7 +273,32 @@ def _strip_anchor_and_alias(target: str) -> str:
 
 
 def _vault_detected(repo_root: Path) -> bool:
-    return (repo_root / ".obsidian").is_dir()
+    """True if the repo is, or contains, an Obsidian vault.
+
+    A vault is rooted at the directory holding `.obsidian/`, but that root is
+    not always the scan target: `/assess` scans from `git rev-parse
+    --show-toplevel`, so a vault kept as a subdirectory of a git repo
+    (`repo/notes/.obsidian/`) puts `.obsidian/` *below* repo_root. The old
+    `repo_root/.obsidian` check only saw a vault rooted exactly at the scan
+    target and reported `false` for the nested case - a false negative that
+    silently disabled every downstream vault accommodation (#179).
+
+    We therefore check repo_root and walk its subtree, pruning the same
+    non-navigational trees the doc scan skips (`EXCLUDE_DIRS` - `node_modules`,
+    `vendor`, ...) so a vendored or build-artifact `.obsidian/` can't trip a
+    false positive, while a real vault is found wherever it sits in the repo.
+    """
+    repo_root = repo_root.resolve()
+    if (repo_root / ".obsidian").is_dir():
+        return True
+    for _dirpath, dirnames, _filenames in os.walk(repo_root):
+        if ".obsidian" in dirnames:
+            return True
+        # Prune heavy / non-navigational subtrees from the descent. `.obsidian`
+        # is itself in EXCLUDE_DIRS, but we've already matched it above before
+        # pruning, so it never gets removed out from under the search.
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+    return False
 
 
 def _obsidiantools_available() -> bool:

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -91,6 +91,42 @@ def test_dangling_wikilink_counted(tmp_path: Path) -> None:
     assert r.dangling_links >= 1
 
 
+def test_vault_detected_at_repo_root(tmp_path: Path) -> None:
+    """`.obsidian/` at the scan target -> the repo is the vault root."""
+    (tmp_path / ".obsidian").mkdir()
+    _write(tmp_path, "note.md", "content")
+    r = build_doc_graph(tmp_path)
+    assert r.vault_detected is True
+
+
+def test_vault_detected_when_nested_below_repo_root(tmp_path: Path) -> None:
+    """A vault kept as a subdirectory of a git repo (`repo/notes/.obsidian/`)
+    puts `.obsidian/` below the scan target. The flag must still read true -
+    the false negative this guards against silently disabled every downstream
+    vault accommodation (#179)."""
+    (tmp_path / "notes" / ".obsidian").mkdir(parents=True)
+    _write(tmp_path, "notes/note.md", "content")
+    r = build_doc_graph(tmp_path)
+    assert r.vault_detected is True
+
+
+def test_vault_not_detected_on_plain_repo(tmp_path: Path) -> None:
+    """A repo with no `.obsidian/` anywhere reports false."""
+    _write(tmp_path, "README.md", "no vault here")
+    r = build_doc_graph(tmp_path)
+    assert r.vault_detected is False
+
+
+def test_vault_not_detected_for_obsidian_under_excluded_dir(tmp_path: Path) -> None:
+    """A `.obsidian/` vendored under a pruned tree (e.g. `node_modules/`) is a
+    build/dependency artifact, not this repo's vault - it must not trip the
+    flag."""
+    (tmp_path / "node_modules" / "pkg" / ".obsidian").mkdir(parents=True)
+    _write(tmp_path, "README.md", "real repo, not a vault")
+    r = build_doc_graph(tmp_path)
+    assert r.vault_detected is False
+
+
 def test_wikilink_inside_fenced_code_block_is_not_counted(tmp_path: Path) -> None:
     """A FORMAT spec or Obsidian-syntax tutorial that *shows* `[[foo]]` as a
     sample inside a fenced code block must not contribute a phantom edge or


### PR DESCRIPTION
## Summary

`vault_detected` is the gate every downstream Obsidian-vault accommodation hangs off, so a false negative silently disables them all. `_vault_detected(repo_root)` only checked `repo_root / .obsidian`, but `/assess` scans from `git rev-parse --show-toplevel`, which is not always the vault root. A vault kept as a subdirectory of a git repo (`repo/notes/.obsidian/`) puts `.obsidian/` *below* the scan target, so the check returned `false` on a repo that is unambiguously a vault.

Closes #179

## Changes Made

- `skills/assess/scripts/lib/doc_graph.py` — `_vault_detected` now checks `repo_root` and walks its subtree for a `.obsidian/` directory, pruning the same non-navigational trees the doc scan skips (`EXCLUDE_DIRS` — `node_modules`, `vendor`, ...) so a vendored or build-artifact `.obsidian/` can't trip a false positive. Added `import os`.
- `skills/assess/tests/test_doc_graph.py` — four cases: `.obsidian` at root → true, nested below root → true, plain repo → false, `.obsidian` under an excluded (`node_modules/`) tree → false.
- `.claude-plugin/plugin.json` — version bump to `1.39.0`.

## Technical Details

The walk is top-down and prunes excluded directories from descent, so cost is bounded by directory count on the navigable tree. `.obsidian` is itself in `EXCLUDE_DIRS`, but it is matched before pruning, so the search never removes its own target. Inward-only import contract preserved (`os` is stdlib).

## Testing

- `skills/assess` pytest: 582 passed, 1 skipped (4 new vault tests included).
- ruff + mypy clean on the changed module and test file.

## Risk Assessment

Low. Localized to the vault-flag plumbing; no change to edge/link-parsing logic (left for #176). Detection is now broader (matches the issue's "a repo containing an `.obsidian/` directory" contract) but bounded against false positives by reusing the doc-scan exclude set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vault detection now identifies nested vaults within project subdirectories, not just at the root level. Automatically excludes build and vendor directories to prevent false positive detections in complex project structures.

* **Chores**
  * Version bumped to 1.39.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->