### PR TITLE
fix: Install pinned ripgrep in the emitted assess-gate workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/templates/assess-gate.yml.template
+++ b/skills/assess/templates/assess-gate.yml.template
@@ -39,6 +39,18 @@ jobs:
         with:
           fetch-depth: 0  # full history so the churn window is accurate
           persist-credentials: false  # nothing here pushes; don't leave a token in .git
+
+      - name: Install ripgrep (promissory-marker scan)
+        # The marker scan (stale TODOs, suppressions, disabled tests) shells out
+        # to rg; ubuntu-latest does not ship it. Without rg the scan honestly
+        # degrades - but then the unactioned_intent finding can never fire in
+        # CI, so a config.toml gating on it would be silently toothless. Pinned
+        # .deb per the supply-chain invariant (a floating apt version could move
+        # the baseline with no change in this tree).
+        continue-on-error: true  # missing tool degrades coverage, not the check
+        run: |
+          curl -fsSLO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
+          sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
 $tool_steps
       - name: Install uv
         id: setup-uv

--- a/skills/assess/tests/test_ci_workflow.py
+++ b/skills/assess/tests/test_ci_workflow.py
@@ -126,8 +126,26 @@ def test_tool_install_failures_do_not_red_the_check():
     out = render_ci_workflow(plugin_version="1.23.0", discovered_tools=ALL_EXTERNAL_TOOLS)
     installs = out.count("go install") + out.count("npm install")
     assert installs == len(ALL_EXTERNAL_TOOLS)
-    # One continue-on-error per tool install, plus one on the uv setup step.
-    assert out.count("continue-on-error: true") == installs + 1
+    # One continue-on-error per tool install, plus one on the uv setup step,
+    # plus one on the always-present ripgrep step (the marker scan dependency).
+    assert out.count("continue-on-error: true") == installs + 2
+
+
+def test_render_always_installs_pinned_ripgrep():
+    """The promissory-marker scan needs rg, which ubuntu-latest does not ship.
+
+    The step is unconditional (the scan is core, not a discovered extra) and
+    version-pinned like every other install: without rg the scan honestly
+    degrades, which would make a config.toml gating on unactioned_intent
+    silently toothless in CI while local runs report debt.
+    """
+    out = render_ci_workflow(plugin_version="1.23.0")
+    assert "Install ripgrep" in out
+    rg_lines = [ln for ln in out.splitlines() if "ripgrep/releases/download" in ln]
+    assert rg_lines, "expected a pinned ripgrep download"
+    assert re.search(r"/download/\d+\.\d+\.\d+/", rg_lines[0]), (
+        f"unpinned ripgrep: {rg_lines[0].strip()}"
+    )
 
 
 def test_render_skips_python_dep_tools():


### PR DESCRIPTION
## Summary

Follow-up to #184. The freeze-into-CI offer emits a workflow that runs the deterministic core on every PR - but the new promissory-marker scan needs `rg`, which ubuntu-latest does not ship. The scan would degrade honestly (`rg not on PATH`), which in this context is the wrong kind of honest: the `unactioned_intent` finding could never fire in CI, so a repo opting `fail_on = ["unactioned_intent"]` would have a silently toothless gate while local runs report real debt. Same root cause as the tests.yml failure fixed inside #184, now closed in the product template.

## Changes Made

- `assess-gate.yml.template`: unconditional ripgrep install step - version-pinned `.deb` (14.1.1) per the supply-chain invariant, `continue-on-error: true` per the warn-only infra contract.
- Tests: `test_render_always_installs_pinned_ripgrep` (step present + pinned), and the continue-on-error count updated with the reason documented.

Existing emitted workflows are frozen contracts pinned to older toolkit tags and are unaffected until regenerated; the fix applies to every gate emitted from v1.41.1 on.

## Testing

All suites green: skills/assess 640, scripts 105, plugin contract 183; ruff + mypy clean.

## Deployment Notes

PATCH bump to 1.41.1.