### PR TITLE
fix: Shorten action.yml description under the Marketplace 125-char limit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,12 @@
 # the pinned version - no separate clone step, no tag-must-exist race: if the
 # `uses:` ref resolved, the scripts are present.
 name: 'AI-Readiness Assess Gate'
+# Marketplace requires the description under 125 chars. The longer contract
+# (config.toml gating, checkout with fetch-depth: 0 first) lives in the
+# header comment above and the README's "Use as a GitHub Action" section.
 description: >-
-  Run the /assess deterministic core (complexity treemap, promissory-marker
-  scan, doc-graph signals) against the checked-out repository and gate on the
-  [gate] section of .assess/config.toml. Zero LLM tokens; warn-only until the
-  repository opts in. Requires actions/checkout with fetch-depth: 0 first.
+  Deterministic AI-readiness gate: complexity, churn and promissory-marker
+  signals on every PR. Zero AI tokens, warn-only.
 author: 'bjcoombs'
 branding:
   icon: 'shield'

--- a/skills/assess/tests/test_action_contract.py
+++ b/skills/assess/tests/test_action_contract.py
@@ -116,3 +116,10 @@ def test_action_yml_is_git_tracked():
         capture_output=True, text=True,
     )
     assert out.stdout.strip() == "action.yml"
+
+
+def test_action_description_fits_marketplace_limit():
+    """GitHub Marketplace rejects an action whose description is 125+ chars -
+    discovered live on the v1.42.0 release page. Pin publishability."""
+    desc = _action()["description"]
+    assert len(desc) < 125, f"{len(desc)} chars: {desc}"


### PR DESCRIPTION
## Summary

The GitHub Marketplace publish form rejects `action.yml` because its description is over the 125-character limit (it was a paragraph). Releases are immutable, so the fix rides a new patch release.

## Changes Made

- `action.yml` description shortened to 120 chars: _"Deterministic AI-readiness gate: complexity, churn and promissory-marker signals on every PR. Zero AI tokens, warn-only."_ The longer contract detail stays in the file's header comment and the README section.
- `test_action_description_fits_marketplace_limit` pins the limit so publishability can't silently regress.

## Testing

skills/assess suite green (648 passed) including the new contract test.

## Deployment Notes

PATCH bump to 1.42.1. After merge I'll cut the v1.42.1 release - tick the Marketplace checkbox on that release page.