### PR TITLE
docs: Align the README with the Marketplace listing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ ${BODY}"
 
 `.github/release.yml` maps the PR labels (`feat`/`fix`/`docs`/`chore`/`refactor`) to release-note categories, and `build-standalone-skills.yml` republishes the standalone ZIPs on the version bump. The plugin release is marked Latest, so `releases/latest` always resolves to it and its notes link straight to the ZIP bundle. One release per marathon, not one per PR.
 
+**Marketplace listing (manual, web-only).** The repo also publishes the [AI-Readiness Assess Gate action](https://github.com/marketplace/actions/ai-readiness-assess-gate). The listing's "latest version" does **not** advance with `gh release create` - no API exists for the Marketplace flag. To refresh it: edit the release in the web UI, tick "Publish this Action to the GitHub Marketplace", update. Do this on marathon releases; consumers are unaffected either way (their `uses:` pins and Dependabot bumps read git tags, not the listing).
+
 ## Testing a branch before merging
 
 `/plugin install` only sees `main`. To test an unmerged branch's `SKILL.md` + scripts as a real plugin - or to run the scripts directly against a target repo - see [`docs/testing-a-branch-locally.md`](docs/testing-a-branch-locally.md). Key point: plugin skills resolve their bundled scripts via `$CLAUDE_PLUGIN_ROOT` (the version cache dir), not `~/.claude/skills/`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Claude Code plugin - and a set of standalone skills for **any AI assistant**: 
 
 > **New here?** The [Map of Content](docs/index.md) is the navigation index - one trail to every skill, command, agent, and design doc in this repo. The [`CLAUDE.md`](CLAUDE.md) contract holds the rules for editing it.
 
+> **Here from the GitHub Marketplace?** You found the **AI-Readiness Assess Gate** - the CI-gate half of this toolkit. It runs the same deterministic engine the `/assess` skill uses (complexity treemap, promissory-marker scan, doc-graph signals - zero AI tokens) on every pull request and gates on what your `.assess/config.toml` opts into. Jump straight to [Use as a GitHub Action](#use-as-a-github-action); the rest of this README covers the full plugin the action is carved from.
+
 ## Why this exists
 
 When you hand work to an AI, does it behave like a brand-new hire, or like an engineer who has been in the org eighteen months? The difference isn't capability - both can write correct code. It's *externalized context*: knowing where things live, which contracts are load-bearing, where the minefields are, and why the weird thing is weird. An AI contributor is structurally always the new hire - every session starts with an empty head, seeing the codebase through one narrow context window. So the whole question becomes: **how much of the tenured engineer's implicit map has the codebase made explicit and navigable?** The more it has, the more a fresh agent behaves like it has been here eighteen months.
@@ -124,14 +126,14 @@ The skill runs locally - lizard, optional scc, and git log do the analysis in yo
 
 ### Use as a GitHub Action
 
-The assess gate also ships as a composite GitHub Action, so any repo can run the deterministic core on every PR without installing the plugin:
+The assess gate ships as a composite GitHub Action ([Marketplace listing](https://github.com/marketplace/actions/ai-readiness-assess-gate)), so any repo can run the deterministic core on every PR without installing the plugin - no Claude, no API keys, no tokens spent:
 
 ```yaml
 steps:
   - uses: actions/checkout@v6
     with:
       fetch-depth: 0   # full history so the churn window is accurate
-  - uses: bjcoombs/ai-native-toolkit@v1.42.0
+  - uses: bjcoombs/ai-native-toolkit@v1.42.2
     with:
       config: .assess/config.toml   # optional; warn-only defaults without it
 ```


### PR DESCRIPTION
## Summary

The new [Marketplace listing](https://github.com/marketplace/actions/ai-readiness-assess-gate) renders the repo README, which leads with Claude Code plugin installation - the action a Marketplace visitor came for sat below the fold at the bottom of the /assess section.

## Changes Made

- Header callout (**Here from the GitHub Marketplace?**) alongside the existing two audience-routing callouts, linking straight to the action section and framing the action/plugin relationship in one sentence.
- Action section links back to the Marketplace listing and states the no-Claude/no-keys/no-tokens contract up front; example pin updated to current.
- CLAUDE.md release runbook records the manual Marketplace-tick step (web-only, no API) and when to bother - the runbook was a lying map about its own release process otherwise.

## Testing

Plugin contract suite green (183) - link checks cover the new internal anchors.

## Deployment Notes

PATCH bump to 1.42.2; docs only.