### PR TITLE
feat: Live AI-readiness badge from the committed .assess wiki

### DIFF
--- a/.assess/badge.json
+++ b/.assess/badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "AI-readiness",
+  "message": "7.0/8 · AI-Native",
+  "color": "brightgreen"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.42.2",
+  "version": "1.43.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Native Toolkit
 
+[![AI-readiness](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbjcoombs%2Fai-native-toolkit%2Fmain%2F.assess%2Fbadge.json)](.assess/assess-report.md) [![Assess Gate](https://github.com/bjcoombs/ai-native-toolkit/actions/workflows/assess-gate.yml/badge.svg)](https://github.com/bjcoombs/ai-native-toolkit/actions/workflows/assess-gate.yml)
+
 A Claude Code plugin - and a set of standalone skills for **any AI assistant**: skills, agents, and commands for AI-native development. In Claude Code it runs locally against your own codebase using whichever model you already pay for. Several of the skills also ship as standalone [Agent Skills](https://www.anthropic.com/news/skills) ZIPs you can upload to claude.ai, Claude Desktop, Cowork, or any assistant that supports the skills format - no Claude Code required.
 
 > **Want the skills without Claude Code?** Download the ZIPs from the **[latest release](https://github.com/bjcoombs/ai-native-toolkit/releases/latest)** - the release notes link straight to that version's standalone skill bundle - and upload them in your assistant's Skills UI. Full walkthrough: [Standalone skill ZIPs](#standalone-skill-zips-any-ai-assistant). Currently standalone: `/assess`, `/huddle`, `/deslop`, `/skill-forge`, `/semantic-compress`.
@@ -136,6 +138,13 @@ steps:
   - uses: bjcoombs/ai-native-toolkit@v1.42.2
     with:
       config: .assess/config.toml   # optional; warn-only defaults without it
+```
+
+Two badges come with it - GitHub's native status badge for the gate workflow, and a live AI-readiness score badge served from the committed `.assess/badge.json` via shields.io (written by every assess run; deterministic findings-count fallback when no scored run exists):
+
+```markdown
+[![Assess Gate](https://github.com/<owner>/<repo>/actions/workflows/assess-gate.yml/badge.svg)](https://github.com/<owner>/<repo>/actions/workflows/assess-gate.yml)
+![AI-readiness](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F<owner>%2F<repo>%2F<branch>%2F.assess%2Fbadge.json)
 ```
 
 Warn-only by default: the only thing that can fail a PR is what `.assess/config.toml` opts into (`fail_on` findings, complexity floors, `fail_on_regression`). Because the version rides a `uses:` pin on an immutable release tag, **Dependabot and Renovate detect new toolkit releases and open upgrade PRs automatically** - add a `.github/dependabot.yml` with the `github-actions` ecosystem and the gate keeps itself current. The `/assess` end-of-run "freeze into CI" offer emits exactly this workflow.

--- a/skills/assess/SKILL.md
+++ b/skills/assess/SKILL.md
@@ -387,6 +387,12 @@ This replaces:
 - `log.md`'s last entry placeholder `**Top action:** Deterministic ranker not yet wired ...` with your actual Top 1 action.
 - Each `hotspots/<slug>.md`'s `Suggested actions` section with the actions you derived for that file.
 
+`assess_finalize.py` also refreshes `.assess/badge.json` (shields.io endpoint schema) from your score and maturity label - the live README badge. When offering the PR (assess-pr), include the embed snippet if the repo's README has no badge yet:
+
+```markdown
+![AI-readiness](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F<owner>%2F<repo>%2F<default-branch>%2F.assess%2Fbadge.json)
+```
+
 The `actions` array mirrors the report's Top 3 Actions table one-to-one and **must carry every table row** - `rank`, `action`, `done_when`, and `scope_fence` are required per entry (`layer`, `effort`, `files`, `first_step` recommended). `assess_finalize.py` writes it to `.assess/actions.json`, the *durable* machine-readable contract: unlike this input file (consumed and deleted), `actions.json` persists so an executing agent - including a smaller, cheaper model - can pick up the work with its exit criteria and fences intact, without parsing the report's markdown.
 
 Without this step, the `log.md` placeholders above carry forward forever. Hotspot pages you don't supply actions for keep a neutral pointer (`This file is flagged but outside this run's Top 3. See the report's Top 3 Actions, or run a focused /assess pass for file-specific guidance.`) rather than an unfinished-work placeholder - a flagged-but-not-Top-3 page reads as intentional.

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -44,6 +44,12 @@ from lib.agent_instructions_grader import (
     scan_sensitive_content,
 )
 from lib.anomaly_detector import detect_anomalies
+from lib.badge import (
+    badge_exists,
+    concern_count_from_findings,
+    fallback_badge,
+    write_badge,
+)
 from lib.assess_config import load_excludes, load_structure_config
 from lib.doc_graph import build_doc_graph, is_repo_file
 from lib.doc_staleness import analyze_doc_staleness
@@ -381,6 +387,28 @@ def _save_first_flagged(assess_dir: Path, first_flagged: dict[str, str]) -> None
     (assess_dir / "first-flagged.json").write_text(
         json.dumps(first_flagged, indent=2), encoding="utf-8"
     )
+
+
+def _write_fallback_badge_if_absent(
+    assess_dir: Path, promissory: Any, derived_findings: list[dict]
+) -> None:
+    """Deterministic fallback badge - only when none exists.
+
+    A gate-only repo (never LLM-scored) gets a truthful findings-count badge;
+    a repo with a finalized score badge keeps it (a deterministic-only rerun
+    must not downgrade the stronger claim; finalize refreshes it on scored
+    runs).
+    """
+    if badge_exists(assess_dir):
+        return
+    stale = (
+        promissory.get("total_stale", 0)
+        if isinstance(promissory, dict) and promissory.get("available")
+        else 0
+    )
+    write_badge(assess_dir, fallback_badge(
+        concern_count_from_findings(derived_findings), stale,
+    ))
 
 
 def _marker_debt_sentence(debt: dict | None) -> str:
@@ -844,6 +872,8 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     ctx["findings_markdown"] = keyhole["findings_markdown"]
     ctx["keyhole_summary"] = keyhole["keyhole_summary"]
     ctx["prescribed_actions"] = keyhole["prescribed_actions"]
+
+    _write_fallback_badge_if_absent(assess_dir, promissory, ctx["derived_findings"])
 
     ctx["plugin_version"] = _read_plugin_version()
     ctx["anomalies"] = [

--- a/skills/assess/scripts/assess_finalize.py
+++ b/skills/assess/scripts/assess_finalize.py
@@ -38,6 +38,7 @@ from pathlib import Path
 # Make sibling lib package importable when run as a script
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from lib.badge import score_badge, write_badge
 from lib.wiki_writer import slug_for_path
 
 
@@ -177,6 +178,11 @@ def finalize_run(*, assess_dir: Path) -> None:
     actions = data.get("actions")
     if isinstance(actions, list) and actions:
         _write_actions_contract(assess_dir, actions)
+    # The score badge always overwrites: finalize carries the freshest
+    # LLM-scored run, the strongest claim the badge is allowed to make.
+    write_badge(
+        assess_dir, score_badge(data["score"], data["maturity_label"])
+    )
     # Clean up: the input file is consumed - delete from both the cache and
     # the legacy in-tree location so a stale copy can't leak into a commit.
     try:

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -256,6 +256,14 @@ Feeds the `unactioned_intent` derived finding, the hotspot pages' marker-debt
 sentence, and the Layer 3/5/8 erosion rules. New ecosystem marker syntaxes need a
 fixture in `tests/test_promissory_markers.py` - absence is a silent miss.
 
+**`badge.py`**
+Shields.io endpoint badge for the wiki (`.assess/badge.json`). Two producers on an
+honest-degrade ladder: `assess_finalize` always writes the LLM-scored form
+("7.0/8 · AI-Native", colour banded from the score), `assess_core` writes the
+deterministic findings-count fallback only when no badge exists - so a gate-only
+repo gets a truthful badge and a scored badge is never downgraded by a
+deterministic-only rerun. Pure threshold functions, fixture-tested.
+
 **`anomaly_detector.py`**
 Inspects a run-context dict for suspicious results (e.g. zero files scored, implausible
 CCN) and returns typed `Anomaly` records. Detail strings are sanitised (counts and

--- a/skills/assess/scripts/lib/badge.py
+++ b/skills/assess/scripts/lib/badge.py
@@ -1,0 +1,104 @@
+"""Shields.io endpoint badge for the .assess wiki.
+
+Renders ``.assess/badge.json`` in the `shields.io endpoint schema
+<https://shields.io/badges/endpoint-badge>`_ so a README can embed a live
+AI-readiness badge with zero infrastructure::
+
+    ![AI-readiness](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/<owner>/<repo>/<branch>/.assess/badge.json)
+
+Two producers, one honest-degrade ladder:
+
+- ``score_badge`` - the headline form ("7.0/8 · AI-Native"), written by
+  ``assess_finalize.py`` from the LLM-derived layered score. Always overwrites.
+- ``fallback_badge`` - the deterministic form ("2 findings · 0 stale markers"),
+  written by ``assess_core.py`` only when no badge exists yet, so a repo that
+  has never run the interactive scoring (a gate-only consumer) still gets a
+  truthful badge instead of a score it never earned - and an existing score
+  badge is never downgraded by a deterministic-only run.
+
+A badge is a self-description, so it inherits the truth-pressure rule: colours
+and messages are pure functions of run data (tested thresholds, no judgement),
+and the badge only ever claims what the producing run measured.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+BADGE_FILENAME = "badge.json"
+LABEL = "AI-readiness"
+
+# Score -> shields colour. Ordered thresholds, first match wins. The bands
+# mirror the maturity ladder: the top colour starts where "AI-Native" scoring
+# typically lands, the bottom is reserved for near-zero scaffolding.
+_SCORE_COLORS: list[tuple[float, str]] = [
+    (7.0, "brightgreen"),
+    (5.5, "green"),
+    (4.0, "yellowgreen"),
+    (2.5, "yellow"),
+    (1.0, "orange"),
+    (0.0, "red"),
+]
+
+
+def score_color(score: float) -> str:
+    """Deterministic colour band for a 0-8 layered score."""
+    for floor, color in _SCORE_COLORS:
+        if score >= floor:
+            return color
+    return "red"
+
+
+def score_badge(score: float, maturity_label: str) -> dict[str, Any]:
+    """The headline badge: layered score + maturity label."""
+    return {
+        "schemaVersion": 1,
+        "label": LABEL,
+        "message": f"{score}/8 · {maturity_label}",
+        "color": score_color(score),
+    }
+
+
+def fallback_badge(concern_count: int, stale_markers: int) -> dict[str, Any]:
+    """Deterministic badge for repos with no LLM-scored run.
+
+    ``concern_count`` is the number of derived findings with non-empty paths
+    (``refactor_boundary`` excluded - it is the positive finding);
+    ``stale_markers`` is ``promissory_markers.total_stale`` (0 when the scan
+    was unavailable - the message stays truthful because it only counts what
+    was measured).
+    """
+    return {
+        "schemaVersion": 1,
+        "label": LABEL,
+        "message": f"{concern_count} findings · {stale_markers} stale markers",
+        "color": (
+            "green"
+            if concern_count == 0 and stale_markers == 0
+            else "yellow"
+            if concern_count <= 2
+            else "orange"
+        ),
+    }
+
+
+def concern_count_from_findings(derived_findings: list[dict]) -> int:
+    """Count negative findings that actually fired (non-empty paths)."""
+    return sum(
+        1
+        for f in derived_findings
+        if isinstance(f, dict)
+        and f.get("name") != "refactor_boundary"
+        and f.get("paths")
+    )
+
+
+def write_badge(assess_dir: Path, badge: dict[str, Any]) -> None:
+    (assess_dir / BADGE_FILENAME).write_text(
+        json.dumps(badge, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def badge_exists(assess_dir: Path) -> bool:
+    return (assess_dir / BADGE_FILENAME).exists()

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -1153,3 +1153,30 @@ def test_test_pressure_scan_failure_degrades_not_crashes(tmp_path: Path, monkeyp
     # downstream blocks still present - one failed scan never blocks the run.
     assert "anomalies" in ctx
     assert "plugin_version" in ctx
+
+
+def test_core_writes_fallback_badge_only_when_absent(tmp_path: Path) -> None:
+    """A never-scored repo gets the deterministic findings badge; a finalized
+    score badge survives deterministic-only reruns (no downgrade)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 1, "loc": {}, "ccn": {},
+        "top_hotspots": [], "top_complex": [], "top_large": [],
+    }), encoding="utf-8")
+
+    build_run_context(repo_root=repo, run_date="2026-06-12")
+    badge = json.loads((assess_dir / "badge.json").read_text(encoding="utf-8"))
+    assert badge["label"] == "AI-readiness"
+    assert "findings" in badge["message"]  # deterministic fallback form
+
+    # Simulate a finalized score badge, then rerun the deterministic core.
+    (assess_dir / "badge.json").write_text(json.dumps({
+        "schemaVersion": 1, "label": "AI-readiness",
+        "message": "7.0/8 · AI-Native", "color": "brightgreen",
+    }), encoding="utf-8")
+    build_run_context(repo_root=repo, run_date="2026-06-13")
+    badge2 = json.loads((assess_dir / "badge.json").read_text(encoding="utf-8"))
+    assert badge2["message"] == "7.0/8 · AI-Native"

--- a/skills/assess/tests/test_assess_finalize.py
+++ b/skills/assess/tests/test_assess_finalize.py
@@ -365,3 +365,22 @@ def test_finalize_all_actions_malformed_writes_no_contract(tmp_assess_dir: Path)
     finalize_run(assess_dir=tmp_assess_dir)
 
     assert not (tmp_assess_dir / "actions.json").exists()
+
+
+def test_finalize_writes_score_badge(tmp_assess_dir: Path) -> None:
+    """Finalize always (over)writes badge.json with the LLM-scored form."""
+    _seed_log_md(tmp_assess_dir)
+    (tmp_assess_dir / "badge.json").write_text(
+        '{"schemaVersion": 1, "label": "AI-readiness", '
+        '"message": "9 findings · 9 stale markers", "color": "orange"}',
+        encoding="utf-8",
+    )
+    (tmp_assess_dir / "finalize-input.json").write_text(
+        json.dumps(_base_input()), encoding="utf-8"
+    )
+
+    finalize_run(assess_dir=tmp_assess_dir)
+
+    badge = json.loads((tmp_assess_dir / "badge.json").read_text(encoding="utf-8"))
+    assert badge["message"] == "6.0/8 · Solid"
+    assert badge["color"] == "green"

--- a/skills/assess/tests/test_badge.py
+++ b/skills/assess/tests/test_badge.py
@@ -1,0 +1,73 @@
+"""Tests for the shields.io endpoint badge (lib/badge.py) and its producers.
+
+The badge is a self-description, so the contract under test is honesty: colours
+are pure threshold functions, the fallback only claims what was measured, and a
+deterministic-only run never downgrades a finalized score badge.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lib.badge import (
+    badge_exists,
+    concern_count_from_findings,
+    fallback_badge,
+    score_badge,
+    score_color,
+    write_badge,
+)
+
+
+def test_score_color_bands():
+    """Hand-computed band edges: first matching floor wins."""
+    assert score_color(8.0) == "brightgreen"
+    assert score_color(7.0) == "brightgreen"
+    assert score_color(6.5) == "green"
+    assert score_color(5.5) == "green"
+    assert score_color(4.0) == "yellowgreen"
+    assert score_color(2.5) == "yellow"
+    assert score_color(1.0) == "orange"
+    assert score_color(0.5) == "red"
+    assert score_color(0.0) == "red"
+
+
+def test_score_badge_shape():
+    badge = score_badge(7.0, "AI-Native")
+    assert badge == {
+        "schemaVersion": 1,
+        "label": "AI-readiness",
+        "message": "7.0/8 · AI-Native",
+        "color": "brightgreen",
+    }
+
+
+def test_fallback_badge_clean_repo_is_green():
+    badge = fallback_badge(0, 0)
+    assert badge["message"] == "0 findings · 0 stale markers"
+    assert badge["color"] == "green"
+
+
+def test_fallback_badge_colors_scale_with_concerns():
+    assert fallback_badge(1, 3)["color"] == "yellow"
+    assert fallback_badge(2, 0)["color"] == "yellow"
+    assert fallback_badge(3, 0)["color"] == "orange"
+
+
+def test_concern_count_ignores_refactor_boundary_and_empty():
+    findings = [
+        {"name": "hidden_coupling", "paths": ["a.py"], "action": "x"},
+        {"name": "lying_map", "paths": [], "action": "x"},
+        {"name": "unactioned_intent", "paths": ["b.py"], "action": "x"},
+        {"name": "refactor_boundary", "paths": ["safe/"], "action": "x"},
+    ]
+    assert concern_count_from_findings(findings) == 2
+
+
+def test_write_and_exists_roundtrip(tmp_path: Path):
+    assert not badge_exists(tmp_path)
+    write_badge(tmp_path, score_badge(5.0, "Solid"))
+    assert badge_exists(tmp_path)
+    data = json.loads((tmp_path / "badge.json").read_text(encoding="utf-8"))
+    assert data["schemaVersion"] == 1
+    assert data["message"] == "5.0/8 · Solid"


### PR DESCRIPTION
## Summary

Tier-2 badge: a Codecov-style live score badge with zero infrastructure. `.assess/badge.json` (shields.io endpoint schema) is written by every assess run and served straight from the repo via shields.io - no server, no tokens.

## Changes Made

- **`lib/badge.py`**: pure threshold functions. `score_badge` (LLM-scored form, colour banded from the 0-8 score) and `fallback_badge` (deterministic findings-count form for never-scored repos).
- **Producers**: `assess_finalize` always refreshes the scored badge; `assess_core` writes the fallback only when no badge exists - a scored badge is never downgraded by a deterministic-only rerun, and a gate-only consumer never shows a score it didn't earn.
- **Dogfood**: this repo's badge seeded at 7.0/8 · AI-Native; README header carries both the score badge and the native gate-status badge; consumer embed snippets in the action section and SKILL.md.
- 8 new badge tests + finalize/core producer tests.

The ccn ratchet caught `build_run_context` at 16 > 15 during development; fixed by extracting a helper, not by suppression.

## Testing

skills/assess 657 passed; scripts 105; plugin contract 183; ruff + mypy clean.

## Deployment Notes

MINOR bump to 1.43.0.