### PR TITLE
docs: Improve marathon version-rule locality and make team-mode assumption explicit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/marathon/SKILL.md
+++ b/skills/marathon/SKILL.md
@@ -66,6 +66,17 @@ Proceeding with defaults: base branch=main, 1 approval, no bot reviewer rules.
 
 Defaults apply for non-marathon use (single task mode, planning mode) without prompting. The template below uses `$BASE_BRANCH` where previous versions hardcoded `develop`.
 
+## Execution Modes
+
+The steps below are written for **team mode** — the lead chairs an Agent Team, spawns one ephemeral teammate per unit, and coordinates via `SendMessage` and `shutdown_request`. Phase 0's `$TEAMS_AVAILABLE` selects the mode:
+
+| Mode | When | How the body maps |
+|------|------|-------------------|
+| **Team** | `$TEAMS_AVAILABLE` true | Run the body as written: `TeamCreate`, one teammate per unit/combined group, message-driven monitoring. |
+| **Phased sub-agent** | `$TEAMS_AVAILABLE` false | No persistent team and no `SendMessage`. The lead runs each wave as a batch of parallel subagents, reads their returned transcripts in place of messages, and drives the same loop. See [Subagent Fallback](#subagent-fallback-no-teams). |
+
+Everything else — the DAG analysis, hot-file combining, tracking file, smart-merge, crash recovery, and retrospective — is identical across modes; only the teammate-coordination mechanism differs. Where a step is team-only (the `SendMessage` events, early-shutdown, and idle-ping handling), the phased fallback simply has no equivalent: subagents return rather than message.
+
 ## Step 1: DAG + Hot-File Analysis
 
 **CRITICAL: Global Source-of-Truth Write Rule**
@@ -94,7 +105,7 @@ Enumerate work units via the adapter's **enumerate** operation.
 
    Some hot files are touched by *every* PR and want **sequential merge, never combining**: a version counter (`.claude-plugin/plugin.json` `.version`), a changelog, a lockfile. Assign each teammate its target value explicitly at spawn and merge in order (highest version wins) — combining all PRs to dodge a one-line version conflict is the trap, not the fix.
 
-   **Version values assigned at spawn are final.** If readiness order ends up differing from the planned merge order, fix it *at merge time* — hold the lower-version PR, or lead-resolve the conflict to the highest value — **never re-message a new version to an in-flight teammate**: that instruction races with PR_CREATED/REVIEW_CLEAR and produces crossed-message churn. The usual trigger is an externally-merged PR advancing the base mid-run; lead-resolve it at merge time.
+   **Version values assigned at spawn are final — never re-message a new version to an in-flight teammate** (it races with PR_CREATED/REVIEW_CLEAR and produces crossed-message churn). If readiness order ends up differing from the planned merge order, that is handled at merge time, not by re-messaging — see [Smart Merge](#smart-merge).
 
    **One caveat overrides "identical bumps merge cleanly":** if the repo auto-publishes an *immutable per-version artifact* on a version *change* (e.g. a `standalone-skills-v<version>` build that fires on the `plugin.json` bump), identical bumps across parallel PRs silently break it — the first merge fires the build from an incomplete tree and permanently consumes that version's tag, and the later identical bumps don't change the version so the build never re-fires. There, do **not** use identical bumps: have the **last-merging PR bump one step higher** (or bump once at the very end, after all merges) so the complete tree republishes.
 7. **Fallback: dependencies** — when combining isn't feasible or would breach the ceiling above (any task complexity 8+, a real dependency between the tasks, fundamentally different concerns despite a shared file, or 5+ tasks on one file):
@@ -345,6 +356,13 @@ an advisory AI review, a regression gate that re-runs on base advance) is mid-ru
 After a merge, close the unit via the adapter's **close on merge** operation, then proceed to
 the wave transition below.
 
+**Version-counter conflicts resolve here, never by re-messaging.** Each teammate's target version
+was fixed at spawn (Step 1). When a PR becomes ready out of the planned merge order — usually because
+an externally-merged PR advanced the base mid-run — either hold the lower-version PR until its
+predecessor merges, or lead-resolve the `plugin.json` conflict to the highest version (per
+[Lead conflict resolution](#step-4-lead-monitoring)). Re-messaging a new version to an in-flight
+teammate races with its own PR_CREATED/REVIEW_CLEAR — don't.
+
 **Teammate shutdown and cleanup are two separate stages — don't conflate them.** The teammate is shut
 down *early*, at REVIEW_CLEAR (see [Step 4](#step-4-lead-monitoring)) — the moment its PR is required-green
 with threads resolved, never held live through the claude-review wait or the merge. *Cleanup* (worktree
@@ -494,4 +512,4 @@ For each that was exercised: did it help, hurt, or not apply? Mark validated.>
 
 ## Subagent Fallback (no teams)
 
-When `$TEAMS_AVAILABLE` is `false`, use parallel subagents after each cleanup cycle: enumerate next-ready units via the adapter's enumerate operation and spawn parallel subagents for each.
+When `$TEAMS_AVAILABLE` is `false`, run the same loop without a persistent team (see [Execution Modes](#execution-modes)). Per wave: enumerate the next-ready units via the adapter, spawn one parallel subagent per unit (or combined group), and wait for their returned transcripts in place of `SendMessage` events. The lead still owns CI watching, smart-merge, and cleanup exactly as in team mode, and the tracking file (Step 2) carries cross-wave state in place of live teammates. There is no `shutdown_request` or idle-churn to manage — subagents return when done — so the early-shutdown and idle-ping guidance simply has no equivalent here.


### PR DESCRIPTION
## Summary

The two structural follow-ups deferred from #194. Both are **polish, not bugs** — the marathon behavioural fixes already shipped in #193/#194; these improve where rules live and make an implicit assumption explicit.

## Changes Made

**1. Version-rule locality.** Step 1 (DAG + Hot-File Analysis) had become the most overloaded step, carrying three version paragraphs including the *merge-time* resolution detail — which a lead actually executes ~250 lines later in Smart Merge. Moved the execution detail (hold-the-lower-version-PR or lead-resolve-to-highest, the out-of-order-readiness case) to **Smart Merge**, where it's used. Step 1 keeps the spawn-time *policy* (values are final, never re-message an in-flight teammate) and points forward. No rule dropped; the publish-trap and combining caveats stay in Step 1 because they're planning-time decisions.

**2. Team-mode assumption made explicit.** The whole skill body speaks team mode (`TeamCreate`/`SendMessage`/`shutdown_request`) with a single buried fallback line. Added an **Execution Modes** table after Phase 0 (mirroring skill-forge's mode table) stating that the body is team-mode and mapping it to the phased-subagent fallback. Fleshed out the previously-one-line **Subagent Fallback** section so it's genuinely usable: what differs (no `SendMessage` events, no shutdown/idle-churn handling) and what stays identical (lead owns CI watch, smart-merge, cleanup; tracking file carries cross-wave state).

## Deliberately scoped down
**Item 2 is NOT a full mode-agnostic rewrite.** `$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is always on in this environment and marathon is a personal `/tm`,`/issues` tool, so the no-teams path is near-vestigial. An honest signpost + usable fallback section is proportionate; rewriting all four steps to be mode-neutral would be high blast-radius churn on a working skill for a path that rarely executes. Flagged here so the scoping is a visible decision, not a silent omission.

## Testing
`plugin contract pytest` (internal-link + leaked-tag sweep over all shipped markdown): 181 passed locally. All four new same-file anchor links (`#execution-modes`, `#smart-merge`, `#subagent-fallback-no-teams`, `#step-4-lead-monitoring`) resolve to existing headings. No Python touched.

## Risk Assessment
Doc-only skill change. Relocation preserves every rule; the new section is additive legibility. Version 1.43.2 -> 1.43.3 (PATCH). This is the natural stopping point for marathon-skill churn (4th PR today) — structure is now clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Marathon skill documentation with explicit execution modes and expanded guidance on version conflict handling and subagent fallback behavior.

* **Chores**
  * Updated plugin version to 1.43.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->