### PR TITLE
fix: Probe deferred team tools in huddle capability detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.3",
+  "version": "1.43.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/scripts/tests/test_cli_source.py
+++ b/scripts/tests/test_cli_source.py
@@ -99,3 +99,24 @@ def test_huddle_raw_source_keeps_cli_team_mode_path():
     assert "flag enabled" in raw, (
         "CLI team-mode branch (Size 2+, flag enabled → team mode) missing from raw huddle source"
     )
+
+
+def test_huddle_raw_source_instructs_deferred_tool_probe():
+    """Newer Claude Code builds defer TeamCreate / SendMessage behind ToolSearch:
+    the tools are enabled but listed only by name in a system-reminder, not as
+    directly-callable tools. A capability check that only glances at the visible
+    tool list false-negatives and silently drops a size-2+ huddle into phased
+    mode even with the flag live. The CLI source must instruct an active probe
+    (ToolSearch load) before concluding team mode is unavailable, so the chair
+    cannot regress to the naive glance-and-degrade behaviour."""
+    raw = _raw_skill_md("huddle")
+    assert "ToolSearch" in raw, (
+        "raw huddle source must instruct a ToolSearch probe for the deferred team "
+        "tools; without it the chair false-negatives on TeamCreate/SendMessage and "
+        "silently degrades to phased mode"
+    )
+    assert "select:TeamCreate,SendMessage" in raw, (
+        "raw huddle source must name the concrete ToolSearch probe query "
+        '("select:TeamCreate,SendMessage") so the chair loads the deferred tool '
+        "schemas before deciding the execution mode"
+    )

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -19,7 +19,7 @@ Scales from a solo gut check to a board-level deliberation using Fibonacci team 
 ## Capability Requirements
 
 <!-- chat-replace:execution-mode-rule -->
-Three execution modes exist. Pick one **deterministically**: team size = 1 → **solo flat-parallel**; team size ≥ 2 AND you can confirm the team-mode capability (`TeamCreate` / `SendMessage`) is available → **team mode**; otherwise → **phased sub-agent mode**. If you cannot confirm team mode, default to phased - it degrades gracefully, whereas attempting team mode without the capability fails loudly.
+Three execution modes exist. Pick one **deterministically**: team size = 1 → **solo flat-parallel**; team size ≥ 2 AND you can confirm the team-mode capability (`TeamCreate` / `SendMessage`) is available → **team mode**; otherwise → **phased sub-agent mode**. Confirming availability means actively probing, not glancing at your visible tools - these tools may be deferred behind `ToolSearch` (see the capability-detection step). If, after probing, you still cannot reach team mode, default to phased - it degrades gracefully, whereas attempting team mode without the capability fails loudly.
 
 | Mode | When chosen | Mechanism | Cost (relative) |
 |------|-------------|-----------|----------------|
@@ -37,11 +37,13 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 
 Without the flag, `/huddle` still runs multi-perspective deliberations via phased sub-agent mode - it just trades cross-talk between agents for a running synopsis Blue Hat maintains as the persistent memory. Quality drops a little, cost drops a lot.
 
+**Deferred-tool caveat (the silent-fallback trap).** With the flag enabled, newer Claude Code builds do not list `TeamCreate` / `SendMessage` in your live tool set - they defer them behind `ToolSearch`, surfacing only their names in a system-reminder. If you decide between team and phased mode by glancing at your visible tools, you will wrongly conclude team mode is unavailable and degrade to phased with no error. Resolve it at the capability-detection step below by loading the schemas with `ToolSearch("select:TeamCreate,SendMessage")` before you decide - a successful load is confirmation that team mode is reachable.
+
 **Why enable team mode anyway:** persistent professional-lens agents talking to each other across phases produce noticeably deeper synthesis - disagreements get rebutted in real time, edge cases surface from cross-talk, and the verdict feels like real deliberation rather than serially-summarised opinions. Worth it for decisions where being wrong costs 100× more than the analysis: architecture choices, irreversible migrations, hiring calls, contractual commitments.
 <!-- chat-skip:end -->
 
 <!-- chat-replace:capability-detection -->
-**Tell the user which mode you're in** before you start. If the Agent Teams capability (`TeamCreate` / `SendMessage`) is available and team size ≥ 2, announce team mode - one line, e.g. "Running in team mode (3 professional lenses, 5 phases - persistent agents)." Otherwise announce phased sub-agent mode, e.g. "Running in phased sub-agent mode (3 lenses, 5 phases)."
+**Tell the user which mode you're in** before you start, but probe for the team capability first - do not treat "not in my visible tool list" as "unavailable". Newer Claude Code builds defer `TeamCreate` / `SendMessage` behind `ToolSearch`: when the flag is enabled they are listed only by name in a system-reminder, not as directly-callable tools, so a naive availability check false-negatives and silently drops you into phased mode. If they are not already live, run `ToolSearch("select:TeamCreate,SendMessage")` to load their schemas and treat a successful load as confirmation. If they load (or are already callable) and team size ≥ 2, announce team mode - one line, e.g. "Running in team mode (3 professional lenses, 5 phases - persistent agents)." Announce phased sub-agent mode only if the probe genuinely fails to surface them, e.g. "Running in phased sub-agent mode (3 lenses, 5 phases)."
 
 ## No Arguments Behavior
 


### PR DESCRIPTION
## Summary

`/huddle` silently falls back to phased sub-agent mode for size-2+ topics even with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` live. Team mode (`TeamCreate` / `SendMessage` persistent agents with cross-talk) is the skill's headline capability on its primary surface, so the regression is high-impact but invisible - no error is raised; the chair just announces phased mode and proceeds (observed verbatim: *"Agent-teams cross-talk isn't confirmed available, so I'll run phases sequentially"*).

## Root Cause

Newer Claude Code builds **defer** `TeamCreate` / `SendMessage` behind `ToolSearch`. With the flag enabled the tools are reachable, but they appear only by name in a system-reminder - not in the model's directly-callable tool list. The huddle chair's capability check assumed a tool is either live or absent, glanced at its visible tools, found neither, could not *confirm* team mode, and took the skill's safe phased fallback.

This is **distinct** from the `2026-05-27-huddle-cli-team-mode-regression` (leaked standalone prose, already fixed in 1.43.x). That was the standalone-pipeline refactor; this is the harness moving team tools behind the `ToolSearch` deferred-tool mechanism. The skill's "is it available?" logic had no third "deferred, must load first" state.

## Changes Made

- **`skills/huddle/SKILL.md`**
  - `capability-detection` (CLI default line): probe first - `ToolSearch("select:TeamCreate,SendMessage")` to load schemas, treat a successful load as confirmation; announce phased mode only if the probe genuinely fails.
  - Added a **deferred-tool caveat** to the CLI-only (`chat-skip`) flag block explaining the silent-fallback trap.
  - `execution-mode-rule` (CLI default line): "confirming availability means actively probing, not glancing at visible tools."
- **`scripts/tests/test_cli_source.py`**: new guard `test_huddle_raw_source_instructs_deferred_tool_probe` asserting the raw CLI source carries the `ToolSearch` probe + concrete query, so the glance-and-degrade behaviour cannot silently return.
- **`.claude-plugin/plugin.json`**: PATCH bump 1.43.3 → 1.43.4.

## Technical Details

The `ToolSearch` instruction lives in CLI-only locations (the `capability-detection` / `execution-mode-rule` `chat-replace` default lines and a `chat-skip` block), so it never leaks to the standalone ZIP - which has no team mode and no `ToolSearch`. Verified by rebuilding `huddle.zip`: `ToolSearch` count 0, no orphan markers, standalone capability text intact.

## Testing

- `scripts/` pytest: 106 passed (incl. new guard).
- `tests/test_plugin_contract.py`: 182 passed.
- Standalone build of `huddle` rebuilt and inspected: clean.

## Risk Assessment

Low. Markdown + one test + version bump; no executable runtime affected. The new guard plus the existing ZIP forbidden-string tests pin both surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team-mode capability detection in the /huddle skill with more reliable mode selection logic.

* **Tests**
  * Added integration test for team-mode capability verification.

* **Chores**
  * Version bumped to 1.43.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->