### PR TITLE
fix: Rewire Agent Teams orchestration onto the implicit-team mechanism

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.4",
+  "version": "1.43.5",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/commands/tm.md
+++ b/commands/tm.md
@@ -481,14 +481,9 @@ jq '."<tag>".tasks[] | {id, title: .title[0:50], status, dependencies, complexit
    task-master update-task --id=<task-id> --prompt="Remove dependency on task <X>, these are independent"
    ```
 
-### Step 2: Create Team and Initialize Tracking
+### Step 2: Form Team and Initialize Tracking
 
-```
-TeamCreate(
-  team_name: "<tag>",
-  description: "Marathon mode for tag <tag> - <N> tasks total, <M> ready"
-)
-```
+This build uses a **single implicit team** - there is no `TeamCreate` step. The team forms as you spawn named background teammates: each `Agent(name: "task-<id>", run_in_background: true)` joins the session's implicit team and is addressable via `SendMessage(to: "task-<id>")`. Proceed straight to tracking.
 
 **PR tracking** - persisted in worktree dir (survives crashes and team cleanup):
 
@@ -575,9 +570,9 @@ Haiku cannot reliably handle review loops - never use for teammates.
 
 **Teammate prompt template:**
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
-  team_name: "<tag>",
+  run_in_background: true,
   name: "task-<task-id>",
   model: "<chosen-model>",
   prompt: """
@@ -814,7 +809,7 @@ The lead operates as a **tech lead running a sprint** - not a task router.
 
 ### Crash Recovery
 
-If the session crashes, teammates linger as "active members" preventing `TeamDelete()`.
+If the session crashes, background teammates may linger as active members. The implicit team has no `TeamDelete` to block, but stale team/task state under `~/.claude/` should still be cleared so a re-run starts clean.
 
 ```bash
 # 1. Force-remove stale team
@@ -834,7 +829,7 @@ Worktrees and `pr-tracking.json` survive crashes in `worktree/<tag>/`.
 
 1. Send `shutdown_request` to each remaining teammate
 2. Wait for all shutdown approvals
-3. Call `TeamDelete()` - if it fails with "active members", verify panes are dead and retry. **TeamDelete is mandatory** - without it, teamContext persists and blocks future team creation in this session.
+3. The implicit team has no `TeamDelete` - once every teammate has approved shutdown or already exited, the team is gone. If a stale background teammate lingers, verify its pane/process is dead; nothing persists to block a future marathon.
 4. **PRD delivery check** - re-read the original PRD/issue and its success criteria. Cross-reference against merged PRs. Report:
    - Criteria met (with PR evidence)
    - Criteria not met or partially met (flag for user)

--- a/scripts/tests/test_cli_source.py
+++ b/scripts/tests/test_cli_source.py
@@ -95,28 +95,34 @@ def test_huddle_raw_source_keeps_cli_team_mode_path():
     """The CLI source must positively describe the team-mode path, so a future
     edit cannot quietly strip it while still passing the negative checks."""
     raw = _raw_skill_md("huddle")
-    assert "TeamCreate" in raw, "CLI team-mode infrastructure missing from raw huddle source"
+    assert "run_in_background" in raw, (
+        "CLI team-mode infrastructure missing from raw huddle source - the "
+        "implicit-team spawn (Agent with run_in_background) is how persistent "
+        "teammates are formed in this build"
+    )
     assert "flag enabled" in raw, (
         "CLI team-mode branch (Size 2+, flag enabled → team mode) missing from raw huddle source"
     )
 
 
 def test_huddle_raw_source_instructs_deferred_tool_probe():
-    """Newer Claude Code builds defer TeamCreate / SendMessage behind ToolSearch:
-    the tools are enabled but listed only by name in a system-reminder, not as
-    directly-callable tools. A capability check that only glances at the visible
-    tool list false-negatives and silently drops a size-2+ huddle into phased
-    mode even with the flag live. The CLI source must instruct an active probe
-    (ToolSearch load) before concluding team mode is unavailable, so the chair
-    cannot regress to the naive glance-and-degrade behaviour."""
+    """Newer Claude Code builds defer SendMessage behind ToolSearch: the tool is
+    enabled but listed only by name in a system-reminder, not as a directly-
+    callable tool. A capability check that only glances at the visible tool list
+    false-negatives and silently drops a size-2+ huddle into phased mode even
+    with the flag live. The CLI source must instruct an active probe (ToolSearch
+    load) before concluding team mode is unavailable, so the chair cannot regress
+    to the naive glance-and-degrade behaviour. (This build forms a single implicit
+    team - there is no TeamCreate - so SendMessage is the capability that gates
+    team mode.)"""
     raw = _raw_skill_md("huddle")
     assert "ToolSearch" in raw, (
-        "raw huddle source must instruct a ToolSearch probe for the deferred team "
-        "tools; without it the chair false-negatives on TeamCreate/SendMessage and "
-        "silently degrades to phased mode"
+        "raw huddle source must instruct a ToolSearch probe for the deferred "
+        "SendMessage tool; without it the chair false-negatives on team-mode "
+        "availability and silently degrades to phased mode"
     )
-    assert "select:TeamCreate,SendMessage" in raw, (
+    assert "select:SendMessage" in raw, (
         "raw huddle source must name the concrete ToolSearch probe query "
-        '("select:TeamCreate,SendMessage") so the chair loads the deferred tool '
-        "schemas before deciding the execution mode"
+        '("select:SendMessage") so the chair loads the deferred tool schema '
+        "before deciding the execution mode"
     )

--- a/scripts/tests/test_transform.py
+++ b/scripts/tests/test_transform.py
@@ -434,9 +434,8 @@ def test_huddle_plugin_source_retains_team_mode_infrastructure():
     source = Path("../skills/huddle/SKILL.md").read_text("utf-8")
 
     required_tool_names = [
-        "TeamCreate",          # team creation
-        "SendMessage",         # cross-agent messaging
-        "TeamDelete",          # team shutdown
+        "SendMessage",         # cross-agent messaging (the capability that gates team mode)
+        "run_in_background",   # background-teammate spawn forming the single implicit team
         "subagent_type",       # Agent-tool dispatch path
         "~/.claude/agents",    # hat methodology resolution in plugin
         "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",  # capability env var
@@ -449,10 +448,10 @@ def test_huddle_plugin_source_retains_team_mode_infrastructure():
         )
 
     required_section_headers = [
-        "### Step 2: Create the Team",
+        "### Step 2: Form the Implicit Team",
         "### Step 3: Spawn Team Members",
         "### Step 4: Facilitate Hat Phases",
-        "### Step 6: Shutdown the Team",
+        "### Step 6: Wind Down the Team",
     ]
     for header in required_section_headers:
         assert header in source, (

--- a/skills/ab-equivalence/SKILL.md
+++ b/skills/ab-equivalence/SKILL.md
@@ -108,7 +108,7 @@ The capability runs the same mechanism in every mode; modes differ only in how t
 <!-- chat-skip:start -->
 **Phased sub-agent mode** (Agent Teams flag off): the lead spawns a fresh runner subagent per version per case (the runner pair) and a fresh judge subagent per case. With no persistent agents, the cached teacher transcripts are injected into each round so only the candidate is re-run.
 
-**Team mode** (Agent Teams flag on, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`): the equivalence judge can run as a persistent teammate spawned via `TeamCreate` / `Agent`, communicating with the lead via `SendMessage`; ephemeral runners are spawned per round and shut down after. As with the forge loop, `TeamDelete` is mandatory at the end of the run or teamContext persists and blocks future team creation in this session.
+**Team mode** (Agent Teams flag on, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`): the equivalence judge can run as a persistent background teammate (`Agent` with `run_in_background: true`, joined to the session's single implicit team), communicating with the lead via `SendMessage`; ephemeral runners are spawned per round and shut down after. As with the forge loop, there is no `TeamCreate`/`TeamDelete` - shut each teammate down with a `SendMessage` shutdown_request at the end of the run; nothing persists to block a future run.
 
 No persistent team is required by the capability itself - the judge holds no across-round memory of its own; the cached teacher transcript is the only state carried between rounds, and the caller owns it.
 <!-- chat-skip:end -->

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -19,17 +19,17 @@ Scales from a solo gut check to a board-level deliberation using Fibonacci team 
 ## Capability Requirements
 
 <!-- chat-replace:execution-mode-rule -->
-Three execution modes exist. Pick one **deterministically**: team size = 1 → **solo flat-parallel**; team size ≥ 2 AND you can confirm the team-mode capability (`TeamCreate` / `SendMessage`) is available → **team mode**; otherwise → **phased sub-agent mode**. Confirming availability means actively probing, not glancing at your visible tools - these tools may be deferred behind `ToolSearch` (see the capability-detection step). If, after probing, you still cannot reach team mode, default to phased - it degrades gracefully, whereas attempting team mode without the capability fails loudly.
+Three execution modes exist. Pick one **deterministically**: team size = 1 → **solo flat-parallel**; team size ≥ 2 AND you can confirm the team-mode capability (`SendMessage` plus background `Agent` teammates) is available → **team mode**; otherwise → **phased sub-agent mode**. Confirming availability means actively probing, not glancing at your visible tools - `SendMessage` may be deferred behind `ToolSearch` (see the capability-detection step). If, after probing, you still cannot reach team mode, default to phased - it degrades gracefully, whereas attempting team mode without the capability fails loudly.
 
 | Mode | When chosen | Mechanism | Cost (relative) |
 |------|-------------|-----------|----------------|
 | **Solo flat-parallel** | Size 1 | Hat agents fire in parallel via standard Agent tool; Blue Hat synthesises | 1× |
 | **Phased sub-agent** | Size 2+, no flag | Iterate phases sequentially; spawn N sub-agents per phase (one per lens), each with fresh context, briefed via a running synopsis Blue Hat maintains | 2-4× |
 <!-- chat-replace:team-mode-row -->
-| **Team mode** | Size 2+, flag enabled | Persistent `TeamCreate` agents cross-talk via `SendMessage` across phases | 5-15× |
+| **Team mode** | Size 2+, flag enabled | Persistent background `Agent` teammates in one implicit team cross-talk via `SendMessage` across phases | 5-15× |
 
 <!-- chat-skip:start -->
-**Agent Teams flag** enables `TeamCreate`, `SendMessage`, and related tools. Enable in your environment:
+**Agent Teams flag** enables `SendMessage` and the background-teammate mechanism (`Agent` spawned with `run_in_background: true`, joined into one implicit team). Enable in your environment:
 
 ```bash
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
@@ -37,13 +37,13 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 
 Without the flag, `/huddle` still runs multi-perspective deliberations via phased sub-agent mode - it just trades cross-talk between agents for a running synopsis Blue Hat maintains as the persistent memory. Quality drops a little, cost drops a lot.
 
-**Deferred-tool caveat (the silent-fallback trap).** With the flag enabled, newer Claude Code builds do not list `TeamCreate` / `SendMessage` in your live tool set - they defer them behind `ToolSearch`, surfacing only their names in a system-reminder. If you decide between team and phased mode by glancing at your visible tools, you will wrongly conclude team mode is unavailable and degrade to phased with no error. Resolve it at the capability-detection step below by loading the schemas with `ToolSearch("select:TeamCreate,SendMessage")` before you decide - a successful load is confirmation that team mode is reachable.
+**Deferred-tool caveat (the silent-fallback trap).** With the flag enabled, newer Claude Code builds do not list `SendMessage` in your live tool set - they defer it behind `ToolSearch`, surfacing only its name in a system-reminder. If you decide between team and phased mode by glancing at your visible tools, you will wrongly conclude team mode is unavailable and degrade to phased with no error. Resolve it at the capability-detection step below by loading the schema with `ToolSearch("select:SendMessage")` before you decide - a successful load is confirmation that team mode is reachable. (This build forms a **single implicit team**: there is no `TeamCreate`. You spawn named background `Agent` teammates and they join automatically - so `SendMessage` is the one capability that gates team mode.)
 
 **Why enable team mode anyway:** persistent professional-lens agents talking to each other across phases produce noticeably deeper synthesis - disagreements get rebutted in real time, edge cases surface from cross-talk, and the verdict feels like real deliberation rather than serially-summarised opinions. Worth it for decisions where being wrong costs 100× more than the analysis: architecture choices, irreversible migrations, hiring calls, contractual commitments.
 <!-- chat-skip:end -->
 
 <!-- chat-replace:capability-detection -->
-**Tell the user which mode you're in** before you start, but probe for the team capability first - do not treat "not in my visible tool list" as "unavailable". Newer Claude Code builds defer `TeamCreate` / `SendMessage` behind `ToolSearch`: when the flag is enabled they are listed only by name in a system-reminder, not as directly-callable tools, so a naive availability check false-negatives and silently drops you into phased mode. If they are not already live, run `ToolSearch("select:TeamCreate,SendMessage")` to load their schemas and treat a successful load as confirmation. If they load (or are already callable) and team size ≥ 2, announce team mode - one line, e.g. "Running in team mode (3 professional lenses, 5 phases - persistent agents)." Announce phased sub-agent mode only if the probe genuinely fails to surface them, e.g. "Running in phased sub-agent mode (3 lenses, 5 phases)."
+**Tell the user which mode you're in** before you start, but probe for the team capability first - do not treat "not in my visible tool list" as "unavailable". Newer Claude Code builds defer `SendMessage` behind `ToolSearch`: when the flag is enabled it is listed only by name in a system-reminder, not as a directly-callable tool, so a naive availability check false-negatives and silently drops you into phased mode. If it is not already live, run `ToolSearch("select:SendMessage")` to load its schema and treat a successful load as confirmation. (Team formation needs no separate `TeamCreate` - this build uses a single implicit team that named background `Agent` teammates join on spawn; `SendMessage` is what gates the cross-talk.) If it loads (or is already callable) and team size ≥ 2, announce team mode - one line, e.g. "Running in team mode (3 professional lenses, 5 phases - persistent agents)." Announce phased sub-agent mode only if the probe genuinely fails to surface it, e.g. "Running in phased sub-agent mode (3 lenses, 5 phases)."
 
 ## No Arguments Behavior
 
@@ -100,7 +100,7 @@ Spawn hat agents in parallel based on your chosen sequence. Each agent operates 
 ### Phased Sub-Agent Mode (Size 2+, no team flag)
 
 <!-- chat-skip:start -->
-When team size > 1 but `TeamCreate` is unavailable, do not collapse to flat-parallel - that throws away both phase ordering and multi-lens diversity. Instead, iterate phases sequentially and spawn fresh sub-agents per phase:
+When team size > 1 but team mode is unavailable, do not collapse to flat-parallel - that throws away both phase ordering and multi-lens diversity. Instead, iterate phases sequentially and spawn fresh sub-agents per phase:
 <!-- chat-skip:end -->
 When team size > 1 but team mode is unavailable, do not collapse to flat-parallel - that throws away both phase ordering and multi-lens diversity. Instead, iterate phases sequentially and spawn fresh sub-agents per phase:
 
@@ -126,7 +126,7 @@ When team size > 1 but team mode is unavailable, do not collapse to flat-paralle
 - Multi-lens diversity preserved - N professionals still weigh in per phase.
 - Phase ordering preserved - Black Hat sees White Hat's facts via the synopsis.
 <!-- chat-skip:start -->
-- No `TeamCreate` / `SendMessage` required; uses only the standard Agent tool.
+- No `SendMessage` or background teammates required; uses only foreground Agent calls.
 <!-- chat-skip:end -->
 - No team mode infrastructure required; uses only the standard Agent tool.
 
@@ -138,14 +138,9 @@ When team size > 1 but team mode is unavailable, do not collapse to flat-paralle
 For team modes (size 2+) with the flag enabled, continue to Step 2.
 
 <!-- chat-skip:start -->
-### Step 2: Create the Team
+### Step 2: Form the Implicit Team
 
-```
-TeamCreate(
-  team_name: "6hats-<brief-topic-slug>",
-  description: "Six Hats team analysis of: <topic>"
-)
-```
+This build forms a **single implicit team** - there is no `TeamCreate` call. The team comes into being the moment you spawn named background agents (Step 3): each `Agent(name: ..., run_in_background: true)` joins the session's one implicit team automatically and becomes addressable by name via `SendMessage`. There is nothing to create here; proceed to Step 3.
 <!-- chat-skip:end -->
 
 <!-- chat-skip:start -->
@@ -162,11 +157,13 @@ For each member, use the Agent tool:
 ```
 Agent(
   subagent_type: "general-purpose",
-  team_name: "<team-name>",
-  name: "<role-slug>",  // e.g. "security-eng", "product-mgr"
+  name: "<role-slug>",          // e.g. "security-eng" - addressable via SendMessage(to: "<role-slug>")
+  run_in_background: true,        // persistent teammate: runs concurrently, reports back via SendMessage
   prompt: "<member prompt — see below>"
 )
 ```
+
+`run_in_background: true` is what makes each member a persistent, concurrently-running teammate rather than a blocking sub-call; `name` is what makes it addressable. There is no `team_name` - the session's single implicit team is joined automatically.
 
 **Member prompt template:**
 
@@ -181,7 +178,7 @@ You are a [ROLE] with deep expertise in [DOMAIN]. This identity persists across 
 
 ## Your Teammates
 
-[ROSTER — the chair lists every other member's name slug here, e.g. "security-eng, product-mgr, sre".] You share findings by sending one `SendMessage` per teammate name; there is no broadcast. If this roster is missing, read `~/.claude/teams/{team}/config.json` and use `members[].name` (excluding yourself) as your peer list.
+[ROSTER — the chair lists every other member's name slug here, e.g. "security-eng, product-mgr, sre".] You share findings by sending one `SendMessage` per teammate name; there is no broadcast. If this roster is missing, message the chair (`SendMessage(to: "main", ...)`) and ask for the peer list.
 
 ## IMMEDIATE FIRST TASK
 
@@ -317,18 +314,15 @@ After all hat phases complete, do NOT spawn a blue-hat agent. You ARE Blue Hat. 
 ```
 
 <!-- chat-skip:start -->
-### Step 6: Shutdown the Team
+### Step 6: Wind Down the Team
 
-After delivering the verdict:
+After delivering the verdict, release any teammate still running. A background teammate that has finished its last phase and reported back has already exited and needs no teardown. For any still working, send one shutdown request each and await approval:
 
-1. Send shutdown requests to each member:
-   ```
-   SendMessage(to: "<member-name>", message: { type: "shutdown_request", reason: "Analysis complete" })
-   ```
-2. Wait for all shutdown approvals
-3. Call `TeamDelete()` to clear team context from the session
+```
+SendMessage(to: "<member-name>", message: { type: "shutdown_request", reason: "Analysis complete" })
+```
 
-**TeamDelete is mandatory.** Without it, teamContext persists and blocks future team creation in this session. The sequence is always: shutdown teammates → wait for approvals → TeamDelete.
+The implicit team has no separate team object to tear down - there is no `TeamDelete` step and nothing persists to block a future huddle. Once every teammate has reported or approved shutdown, the huddle is complete.
 <!-- chat-skip:end -->
 
 ## Facilitation Principles

--- a/skills/marathon/SKILL.md
+++ b/skills/marathon/SKILL.md
@@ -72,7 +72,7 @@ The steps below are written for **team mode** — the lead chairs an Agent Team,
 
 | Mode | When | How the body maps |
 |------|------|-------------------|
-| **Team** | `$TEAMS_AVAILABLE` true | Run the body as written: `TeamCreate`, one teammate per unit/combined group, message-driven monitoring. |
+| **Team** | `$TEAMS_AVAILABLE` true | Run the body as written: spawn one background teammate (`Agent` with `run_in_background`) per unit/combined group into the session's single implicit team, message-driven monitoring. |
 | **Phased sub-agent** | `$TEAMS_AVAILABLE` false | No persistent team and no `SendMessage`. The lead runs each wave as a batch of parallel subagents, reads their returned transcripts in place of messages, and drives the same loop. See [Subagent Fallback](#subagent-fallback-no-teams). |
 
 Everything else — the DAG analysis, hot-file combining, tracking file, smart-merge, crash recovery, and retrospective — is identical across modes; only the teammate-coordination mechanism differs. Where a step is team-only (the `SendMessage` events, early-shutdown, and idle-ping handling), the phased fallback simply has no equivalent: subagents return rather than message.
@@ -132,12 +132,7 @@ Enumerate work units via the adapter's **enumerate** operation.
 
 ## Step 2: Team + Tracking
 
-```
-TeamCreate(
-  team_name: "<tag>",
-  description: "Marathon mode for tag <tag> - <N> tasks total, <M> ready"
-)
-```
+This build uses a **single implicit team** - there is no `TeamCreate` step. The team forms as you spawn named background teammates (next): each `Agent(name: "task-<id>", run_in_background: true)` joins the session's implicit team and is addressable via `SendMessage(to: "task-<id>")`. Proceed straight to tracking.
 
 **PR tracking** — persisted in worktree dir (survives crashes and team cleanup):
 
@@ -229,9 +224,9 @@ Haiku cannot reliably handle review loops — never use for teammates.
 
 **Teammate prompt template:**
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
-  team_name: "<tag>",
+  run_in_background: true,
   name: "task-<task-id>",   # combined group: task-<id>+<id> (see Combined-group identity above)
   model: "<chosen-model>",
   prompt: """
@@ -402,7 +397,7 @@ strength of the earlier REVIEW_CLEAR alone.
 
 ## Crash Recovery
 
-If the session crashes, teammates linger as "active members" preventing `TeamDelete()`.
+If the session crashes, background teammates may linger as active members. The implicit team has no `TeamDelete` to block, but stale team/task state under `~/.claude/` should still be cleared so a re-run starts clean.
 
 ```bash
 # 1. Force-remove stale team
@@ -455,7 +450,7 @@ The lead operates as a **tech lead running a sprint** — not a task router.
 
 1. Send `shutdown_request` to each remaining teammate
 2. Wait for all shutdown approvals
-3. Call `TeamDelete()` - if it fails with "active members", verify panes are dead and retry. **TeamDelete is mandatory** - without it, teamContext persists and blocks future team creation in this session.
+3. The implicit team has no `TeamDelete` - once every teammate has approved shutdown or already exited, the team is gone. If a stale background teammate lingers, verify its pane/process is dead; nothing persists to block a future marathon.
 4. **PRD delivery check** — Re-read the original work units' acceptance criteria (PRD, issue bodies, or task details) and cross-reference against merged PRs. Report:
    - Criteria met (with PR evidence)
    - Criteria not met or partially met (flag for user)

--- a/skills/skill-forge/SKILL.md
+++ b/skills/skill-forge/SKILL.md
@@ -110,24 +110,20 @@ Pick the mode **deterministically**: if the Agent Teams capability is confirmed 
 <!-- chat-skip:start -->
 | **Team** | flag on | Persistent judges cross-talk via `SendMessage` and remember prior rounds natively; ephemeral runners are spawned per round. |
 
-**Agent Teams flag.** Team mode needs `TeamCreate`, `SendMessage`, and `TeamDelete`. Enable it in your environment:
+**Agent Teams flag.** Team mode needs `SendMessage` and background `Agent` teammates (one implicit team; no `TeamCreate`/`TeamDelete`). Enable it in your environment:
 
 ```bash
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 ```
 
-In the team lifecycle the lead delegates and never executes, runner teammates are ephemeral (spawned per round, shut down after), and the judge panel is the one persistent team. As illustrative text (do not treat the snippets below as live tool calls):
-
-```text
-TeamCreate(team_name: "forge-<skill-slug>", description: "skill-forge panel for <skill>")
-```
+In the team lifecycle the lead delegates and never executes, runner teammates are ephemeral (spawned per round, shut down after), and the judge panel is the one persistent team. The session forms a **single implicit team** - there is no `TeamCreate` step; each named background agent joins it on spawn. As illustrative text (do not treat the snippet below as a live tool call):
 
 ```text
 # spawn one judge per active lens (persistent) and one runner per test case (ephemeral)
-Agent(subagent_type: "general-purpose", team_name: "forge-<skill-slug>", name: "fidelity", prompt: "<lens brief>")
+Agent(subagent_type: "general-purpose", run_in_background: true, name: "fidelity", prompt: "<lens brief>")
 ```
 
-The panel cross-talks by sending one `SendMessage` per teammate (there is no broadcast). At the end of the run, shut down each teammate, wait for approvals, then call `TeamDelete()` - mandatory, or teamContext persists and blocks future team creation in this session.
+The panel cross-talks by sending one `SendMessage` per teammate (there is no broadcast). At the end of the run, shut down each teammate via a `SendMessage` shutdown_request and await approval; there is no `TeamDelete` - the implicit team leaves nothing to tear down.
 <!-- chat-skip:end -->
 
 ## Test taxonomy


### PR DESCRIPTION
## Summary

Newer Claude Code builds (this session included) **removed `TeamCreate` / `TeamDelete`**. The session now forms a **single implicit team** that named background agents join on spawn (`Agent` with `run_in_background: true`), coordinating via `SendMessage`. The `Agent` tool's own schema confirms it: `team_name` is *"Deprecated; ignored. The session has a single implicit team."*

#196 fixed only the capability-detection **gate** (probe deferred tools before deciding). The execution **bodies** still called `TeamCreate` (Step 2 "Create the Team") and `TeamDelete` (teardown) — tools that no longer exist. The net effect on this build: a probe could "confirm" team mode, then **crash at the first `TeamCreate` call**.

This rewires every team-mode execution path onto the implicit-team mechanism.

## Changes Made

| File | Change |
|------|--------|
| `skills/huddle/SKILL.md` | Probe `select:SendMessage`; spawn members with `Agent(name, run_in_background: true)`; Step 2 → **Form the Implicit Team**, Step 6 → **Wind Down the Team**; drop `TeamCreate`/`TeamDelete` |
| `skills/marathon/SKILL.md` | Drop `TeamCreate` step + `team_name` spawn param; background-Agent teammates; implicit-team crash-recovery + completion |
| `commands/tm.md` | Same marathon-shaped rewire (drives `/tm`) |
| `skills/skill-forge/SKILL.md`, `skills/ab-equivalence/SKILL.md` | Same mechanism swap in team-mode notes |
| `scripts/tests/test_transform.py` | `test_huddle_plugin_keeps_team_mode` now requires `run_in_background` + renamed headers (per that test's own "intentionally changing the mechanism" instruction) |
| `scripts/tests/test_cli_source.py` | Probe `select:SendMessage`, assert `run_in_background` |
| `.claude-plugin/plugin.json` | 1.43.4 → 1.43.5 |

## Technical Details

The team primitive is now `Agent(subagent_type, name, run_in_background: true)` + `SendMessage(to: <name> | "main")`. There is no create or delete step — the implicit team forms on spawn and leaves nothing to tear down. `run_in_background: true` is what makes a member persistent/concurrent; `name` is what makes it addressable.

## Testing

Run locally (all required checks):
- `scripts/` pytest — **106 passed**
- `plugin contract` pytest — **182 passed**
- `skills/assess` pytest — **645 passed, 2 skipped**
- `ruff check` — clean
- Standalone `huddle` + `skill-forge` ZIPs rebuilt and verified **free of all team tokens** (`TeamCreate`/`TeamDelete`/`SendMessage`/`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`)

## Risk Assessment

Per maintainer decision, the legacy `TeamCreate` API is dropped (not kept as a fallback): it matches the `team_name` deprecation direction and is absent from current builds. Users on an older `TeamCreate`-only build would lose team mode and fall through to phased sub-agent mode (graceful degrade), not error.

Follow-up (not in scope): `.github/claude-review-instructions.md` still lists `TeamCreate`/`TeamDelete` as tokens to wrap — harmless, but stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.43.5

* **Documentation**
  * Revised team mode documentation across orchestration instructions and skill templates, including updates to agent team formation, teammate coordination protocols, team management procedures, and shutdown workflows

* **Tests**
  * Updated test cases and assertions to validate team infrastructure changes and verify updated behavior expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->