### PR TITLE
feat: Add accretion_ratchet git-numstat scanner

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -256,6 +256,22 @@ Feeds the `unactioned_intent` derived finding, the hotspot pages' marker-debt
 sentence, and the Layer 3/5/8 erosion rules. New ecosystem marker syntaxes need a
 fixture in `tests/test_promissory_markers.py` - absence is a silent miss.
 
+**`accretion_ratchet.py`**
+Write-side accretion instrument: detects files that only ever grow. Walks each
+file's full numstat history in author-time order (one `git log --no-merges
+--no-renames --numstat` pass, sorted explicitly by `%at` then SHA so the
+accumulation order is clone-independent) and flags a file when its running
+net-delta is non-decreasing *and* its deletion fraction (deletions over total
+churn) stays below a threshold - growth with almost no deletion pressure, the
+fingerprint of pure append-only accretion rather than ordinary maintenance. A
+multi-commit gate drops single-touch rename artifacts; binary files (numstat
+`-`) are skipped. Compensates the *Accretion* contributor tendency named in the
+repo north star. Degrades to `available: False` on git failure and
+`reliable: False` on degenerate history (same verdict as `git_churn`). Reuses
+`git_churn`'s `GIT_TIMEOUT_SECONDS` and `churn_is_degenerate`; imports no
+orchestrator. Add a fixture-backed test in `tests/test_accretion_ratchet.py`
+alongside any change to the flagging rule.
+
 **`badge.py`**
 Shields.io endpoint badge for the wiki (`.assess/badge.json`). Two producers on an
 honest-degrade ladder: `assess_finalize` always writes the LLM-scored form

--- a/skills/assess/scripts/lib/accretion_ratchet.py
+++ b/skills/assess/scripts/lib/accretion_ratchet.py
@@ -1,0 +1,369 @@
+"""Accretion-ratchet scan: files that only ever grow.
+
+The first of the three write-side tendencies named in this repo's north star.
+An agent does what is asked, and what is asked is feature after feature -
+nothing in that loop ever asks for a refactor, so files only grow. Absent a
+consciously requested restructuring, size and complexity ratchet monotonically
+upward. This module turns that tendency into a deterministic signal: the file
+whose accumulated line count never meaningfully comes back down.
+
+The instrument walks a file's full numstat history in *author-time order* and
+accumulates net delta (additions - deletions). A file is flagged when two
+conditions hold together:
+
+  - **Monotonic growth.** The running net-delta is non-decreasing across the
+    history - the file gained lines and effectively never gave them back. A
+    single late refactor that cuts the file is enough to clear the flag.
+  - **Low deletion fraction.** Across its whole history, deletions are a small
+    share of total churn (``deletions / (additions + deletions)`` below a
+    threshold). A file that churns by rewriting - deleting as much as it adds -
+    is being maintained, not merely accreted, even if its net size still drifts
+    up.
+
+Both are required: net growth alone is normal for any developing file; it is
+growth *with almost no deletion pressure* that fingerprints pure accretion.
+
+Determinism is non-negotiable - same repo, byte-identical output. The history
+is parsed once and sorted by author time (``%at``) with the commit SHA as a
+tie-breaker, so the accumulation order never depends on git's traversal
+heuristics or clone-to-clone ref ordering. ``--no-renames`` keeps a file under
+its current name only (a rename is not accretion), and ``--no-merges`` keeps
+merge double-counts out of the totals.
+
+Pure subprocess (git) + stdlib. No LLM calls, no heavy dependencies, every git
+call capped by ``GIT_TIMEOUT_SECONDS``. Degrades to ``available: False`` on any
+git failure and to ``reliable: False`` on degenerate history (shallow clone,
+squashed import - same verdict as every other churn consumer), never raises out
+of ``scan_accretion_ratchet``.
+
+CLI (standalone use)::
+
+    uv run accretion_ratchet.py <repo_root> [--deletion-threshold 0.15] [--json OUT]
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from lib.git_churn import GIT_TIMEOUT_SECONDS, churn_is_degenerate
+except ImportError:  # standalone CLI: script dir is lib/, put scripts/ on path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from lib.git_churn import GIT_TIMEOUT_SECONDS, churn_is_degenerate
+
+# A file is flagged only when deletions are below this share of its total churn:
+# deletions / (additions + deletions). 0.15 means "fewer than ~1 deleted line
+# for every 6 lines of churn" - the fingerprint of a file that is appended to
+# rather than reworked. A file that churns by rewriting clears the flag.
+DELETION_FRACTION_THRESHOLD = 0.15
+
+# Renames register as a single all-additions commit under the new name, which
+# would read as perfect accretion. Requiring at least this many commits filters
+# those single-touch artifacts: accretion is a property of repeated growth.
+MIN_COMMITS_FOR_ACCRETION = 3
+
+# Average days per month for the time-span readout (Gregorian mean).
+DAYS_PER_MONTH = 30.44
+
+# Cap the files carried into run-context.json so a pathological repo can't bloat
+# the bus; the scan still measures every file, only the report list is capped.
+MAX_TOP_OFFENDERS = 10
+
+
+@dataclass(frozen=True)
+class AccretionFile:
+    """A file whose line count only ever ratcheted upward.
+
+    ``net_additions`` is the final accumulated additions - deletions (always
+    positive for a flagged file). ``deletion_fraction`` is deletions over total
+    churn across the whole history. ``time_span_months`` is the span from the
+    file's first to last commit, a context cue for how long the ratchet ran.
+    """
+
+    path: str
+    net_additions: int
+    commit_count: int
+    deletion_fraction: float
+    time_span_months: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "net_additions": self.net_additions,
+            "commit_count": self.commit_count,
+            "deletion_fraction": round(self.deletion_fraction, 4),
+            "time_span_months": round(self.time_span_months, 1),
+        }
+
+
+@dataclass
+class AccretionScan:
+    """Result of an accretion-ratchet scan.
+
+    ``available`` is False when the directory is not a git repo or git is
+    unreachable. ``reliable`` is False on degenerate history (shallow clone,
+    squashed import) where the per-file commit distribution carries no signal -
+    same verdict definition as every other churn consumer. ``files`` holds the
+    flagged ``AccretionFile`` records, sorted by net additions descending.
+    """
+
+    available: bool
+    reason: str = ""
+    reliable: bool = True
+    deletion_fraction_threshold: float = DELETION_FRACTION_THRESHOLD
+    files: list[AccretionFile] = field(default_factory=list)
+
+    def summary(self) -> dict[str, Any]:
+        top = self.files[:MAX_TOP_OFFENDERS]
+        return {
+            "available": self.available,
+            "reason": self.reason,
+            "reliable": self.reliable,
+            "deletion_fraction_threshold": self.deletion_fraction_threshold,
+            "total_accreting": len(self.files),
+            "top_offenders": [f.to_dict() for f in top],
+        }
+
+
+@dataclass
+class _FileHistory:
+    """Per-file accumulation state, built up while walking the commit history."""
+
+    additions: int = 0
+    deletions: int = 0
+    commit_count: int = 0
+    first_time: int = 0
+    last_time: int = 0
+    # Running net delta after each commit, in author-time order. Monotonicity is
+    # judged off this sequence, not the endpoints, so a file that grew, was cut
+    # back, then grew again is not mistaken for a pure ratchet.
+    net_sequence: list[int] = field(default_factory=list)
+
+
+def _unavailable_summary(reason: str) -> dict[str, Any]:
+    return AccretionScan(available=False, reason=reason).summary()
+
+
+def _repo_top(repo_root: Path) -> str | None:
+    """Absolute repo top-level for ``repo_root``, or None if not in a git repo."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def _accumulate_history(repo_top: str) -> dict[str, _FileHistory]:
+    """Walk the full numstat history and accumulate per-file growth.
+
+    Returns ``{repo-relative-path: _FileHistory}``. Each commit contributes its
+    author time (``%at``) plus the numstat rows that follow it. The history is
+    sorted by (author_time, sha) before accumulation so the running net-delta
+    sequence is built in a clone-independent order - the load-bearing
+    reproducibility guarantee. Binary files (numstat ``-`` for added/removed)
+    are skipped: they carry no line-count signal.
+    """
+    # \x1e (RS) opens each commit record; the header is "<author_time> <sha>",
+    # then the numstat rows ("added\tremoved\tpath") on their own lines.
+    cmd = [
+        "git", "-C", repo_top, "log",
+        "--no-merges", "--no-renames", "--numstat",
+        "--pretty=format:\x1e%at %H",
+    ]
+    try:
+        raw = subprocess.run(
+            cmd, capture_output=True, text=True, check=True, errors="replace",
+            timeout=GIT_TIMEOUT_SECONDS,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return {}
+
+    # Parse into (author_time, sha, [(added, removed, path), ...]) per commit,
+    # then sort. We do NOT trust git's emission order: --reverse / traversal
+    # order can differ across clones, so the ordering pin is an explicit sort
+    # on (author_time, sha) rather than the order git happened to print.
+    commits: list[tuple[int, str, list[tuple[int, int, str]]]] = []
+    for chunk in raw.split("\x1e"):
+        if not chunk.strip():
+            continue
+        lines = chunk.splitlines()
+        header = lines[0].split(" ", 1)
+        if len(header) != 2:
+            continue
+        try:
+            author_time = int(header[0])
+        except ValueError:
+            continue
+        sha = header[1]
+        rows: list[tuple[int, int, str]] = []
+        for row in lines[1:]:
+            parts = row.split("\t")
+            if len(parts) < 3:
+                continue
+            added_s, removed_s, path = parts[0], parts[1], parts[2]
+            # Binary files numstat as "-\t-\t<path>": no line-count signal.
+            if not added_s.isdigit() or not removed_s.isdigit():
+                continue
+            rows.append((int(added_s), int(removed_s), path))
+        commits.append((author_time, sha, rows))
+
+    commits.sort(key=lambda c: (c[0], c[1]))
+
+    histories: dict[str, _FileHistory] = defaultdict(_FileHistory)
+    for author_time, _sha, rows in commits:
+        for added, removed, path in rows:
+            hist = histories[path]
+            hist.additions += added
+            hist.deletions += removed
+            hist.commit_count += 1
+            if hist.first_time == 0:
+                hist.first_time = author_time
+            hist.last_time = author_time
+            hist.net_sequence.append(hist.additions - hist.deletions)
+    return histories
+
+
+def _is_monotonic_nondecreasing(sequence: list[int]) -> bool:
+    """True when the running net-delta never falls below an earlier high.
+
+    A single step down (a commit that deleted more than it added, net) breaks
+    the ratchet - that is the deletion pressure the signal looks for. An empty
+    or single-point sequence is vacuously monotonic.
+    """
+    return all(b >= a for a, b in zip(sequence, sequence[1:]))
+
+
+def _build_accretion_file(path: str, hist: _FileHistory) -> AccretionFile | None:
+    """Promote one file's history to an AccretionFile, or None if it isn't accreting.
+
+    Applies the multi-commit gate, the monotonic-growth test, and the
+    deletion-fraction threshold. A file passes only when it grew across multiple
+    commits, its running net-delta never came back down, and its deletions stayed
+    below the threshold share of total churn.
+    """
+    if hist.commit_count < MIN_COMMITS_FOR_ACCRETION:
+        return None
+
+    total_churn = hist.additions + hist.deletions
+    if total_churn == 0:
+        return None
+    deletion_fraction = hist.deletions / total_churn
+    if deletion_fraction >= DELETION_FRACTION_THRESHOLD:
+        return None
+
+    net = hist.additions - hist.deletions
+    # A net-zero or net-negative file is not accreting even if its history reads
+    # as non-decreasing (e.g. a file that was only ever deleted from).
+    if net <= 0:
+        return None
+    if not _is_monotonic_nondecreasing(hist.net_sequence):
+        return None
+
+    span_days = max(0, (hist.last_time - hist.first_time)) / 86400
+    time_span_months = span_days / DAYS_PER_MONTH
+    return AccretionFile(
+        path=path,
+        net_additions=net,
+        commit_count=hist.commit_count,
+        deletion_fraction=deletion_fraction,
+        time_span_months=time_span_months,
+    )
+
+
+def scan_accretion_ratchet(
+    repo_root: Path,
+    deletion_threshold: float = DELETION_FRACTION_THRESHOLD,
+) -> AccretionScan:
+    """Full pipeline: parse numstat history -> accumulate -> flag pure-growth files.
+
+    Returns an :class:`AccretionScan`. ``available`` is False when ``repo_root``
+    is not inside a git repo or git is unreachable; ``reliable`` is False on
+    degenerate history. Flagged files are sorted by net additions descending,
+    then by path for a stable tie-break.
+    """
+    repo_top = _repo_top(repo_root)
+    if repo_top is None:
+        return AccretionScan(available=False, reason="not a git repository")
+
+    try:
+        histories = _accumulate_history(repo_top)
+        if not histories:
+            return AccretionScan(available=False, reason="no commit history")
+
+        # Degenerate history (every file ~1 commit: shallow clone, squashed
+        # import) means the accumulation sequence carries no signal. Report what
+        # we found but mark it unreliable so nothing downstream reads it as a
+        # clean bill of health. Same verdict definition as git_churn.
+        commit_counts = [h.commit_count for h in histories.values()]
+        reliable = not churn_is_degenerate(commit_counts)
+
+        files: list[AccretionFile] = []
+        for path, hist in histories.items():
+            accreting = _build_accretion_file(path, hist)
+            if accreting is not None and accreting.deletion_fraction < deletion_threshold:
+                files.append(accreting)
+
+        files.sort(key=lambda f: (-f.net_additions, f.path))
+        return AccretionScan(
+            available=True,
+            reliable=reliable,
+            deletion_fraction_threshold=deletion_threshold,
+            files=files,
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade, never crash the core
+        return AccretionScan(
+            available=False, reason=f"{type(exc).__name__}: {exc}"
+        )
+
+
+def main() -> int:
+    import argparse
+    import time
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("repo_root", type=Path)
+    ap.add_argument(
+        "--deletion-threshold", type=float, default=DELETION_FRACTION_THRESHOLD,
+        help="flag files whose deletion fraction is below this (default 0.15)",
+    )
+    ap.add_argument("--json", type=Path, help="write full summary JSON here")
+    args = ap.parse_args()
+
+    t0 = time.monotonic()
+    scan = scan_accretion_ratchet(args.repo_root.resolve(), args.deletion_threshold)
+    elapsed = time.monotonic() - t0
+    s = scan.summary()
+    s["elapsed_seconds"] = round(elapsed, 2)
+
+    if args.json:
+        args.json.write_text(json.dumps(s, indent=2))
+
+    if not scan.available:
+        print(f"unavailable: {scan.reason}")
+        return 1
+    reliability = "reliable" if scan.reliable else "UNRELIABLE (degenerate history)"
+    print(
+        f"scanned in {elapsed:.2f}s  threshold={scan.deletion_fraction_threshold} "
+        f"deletion-fraction  {reliability}"
+    )
+    print(f"accreting files: {s['total_accreting']}")
+    print("\ntop offenders (net additions, never meaningfully cut back):")
+    for f in s["top_offenders"]:
+        print(
+            f"  +{f['net_additions']:>7}  {f['commit_count']:>3} commits  "
+            f"del {f['deletion_fraction']:.2f}  over {f['time_span_months']:.1f}mo  "
+            f"{f['path']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/assess/scripts/lib/accretion_ratchet.py
+++ b/skills/assess/scripts/lib/accretion_ratchet.py
@@ -146,10 +146,6 @@ class _FileHistory:
     net_sequence: list[int] = field(default_factory=list)
 
 
-def _unavailable_summary(reason: str) -> dict[str, Any]:
-    return AccretionScan(available=False, reason=reason).summary()
-
-
 def _repo_top(repo_root: Path) -> str | None:
     """Absolute repo top-level for ``repo_root``, or None if not in a git repo."""
     try:
@@ -241,13 +237,17 @@ def _is_monotonic_nondecreasing(sequence: list[int]) -> bool:
     return all(b >= a for a, b in zip(sequence, sequence[1:]))
 
 
-def _build_accretion_file(path: str, hist: _FileHistory) -> AccretionFile | None:
+def _build_accretion_file(
+    path: str, hist: _FileHistory, deletion_threshold: float
+) -> AccretionFile | None:
     """Promote one file's history to an AccretionFile, or None if it isn't accreting.
 
     Applies the multi-commit gate, the monotonic-growth test, and the
     deletion-fraction threshold. A file passes only when it grew across multiple
     commits, its running net-delta never came back down, and its deletions stayed
-    below the threshold share of total churn.
+    below ``deletion_threshold`` share of total churn. The threshold is the
+    caller's value (see :func:`scan_accretion_ratchet`) so the cut applied is the
+    one reported, with no second filter downstream.
     """
     if hist.commit_count < MIN_COMMITS_FOR_ACCRETION:
         return None
@@ -256,7 +256,7 @@ def _build_accretion_file(path: str, hist: _FileHistory) -> AccretionFile | None
     if total_churn == 0:
         return None
     deletion_fraction = hist.deletions / total_churn
-    if deletion_fraction >= DELETION_FRACTION_THRESHOLD:
+    if deletion_fraction >= deletion_threshold:
         return None
 
     net = hist.additions - hist.deletions
@@ -307,8 +307,8 @@ def scan_accretion_ratchet(
 
         files: list[AccretionFile] = []
         for path, hist in histories.items():
-            accreting = _build_accretion_file(path, hist)
-            if accreting is not None and accreting.deletion_fraction < deletion_threshold:
+            accreting = _build_accretion_file(path, hist, deletion_threshold)
+            if accreting is not None:
                 files.append(accreting)
 
         files.sort(key=lambda f: (-f.net_additions, f.path))

--- a/skills/assess/tests/test_accretion_ratchet_threshold.py
+++ b/skills/assess/tests/test_accretion_ratchet_threshold.py
@@ -1,0 +1,55 @@
+"""Regression: the caller's --deletion-threshold is the cut actually applied.
+
+`_build_accretion_file` once hard-coded the module constant
+(DELETION_FRACTION_THRESHOLD = 0.15) for its deletion-fraction filter, while
+`scan_accretion_ratchet` re-filtered on, and reported, the caller's
+`deletion_threshold`. The effective cut was min(0.15, deletion_threshold), so any
+caller-supplied threshold above 0.15 was silently ignored - the API contradicted
+its reported `deletion_fraction_threshold`. This pins the contract: a file at
+deletion fraction 0.20 is admitted under `--deletion-threshold 0.30` and dropped
+under the 0.15 default.
+
+The comprehensive suite is owned by a separate task; this is the focused
+regression only, in a minimally-named module to avoid colliding with it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from lib.accretion_ratchet import (  # noqa: E402
+    _FileHistory,
+    _build_accretion_file,
+)
+
+
+def _history_at_fraction_020() -> _FileHistory:
+    """A monotonically-growing file whose deletion fraction is exactly 0.20.
+
+    Three appending commits (multi-commit gate cleared), running net-delta never
+    falls back (monotonic), 80 additions to 20 deletions => 20/100 = 0.20.
+    """
+    return _FileHistory(
+        additions=80,
+        deletions=20,
+        commit_count=3,
+        first_time=1_000,
+        last_time=1_000 + 86_400,
+        net_sequence=[20, 40, 60],
+    )
+
+
+def test_threshold_above_fraction_admits_file() -> None:
+    """--deletion-threshold 0.30 admits a 0.20-fraction file (old code dropped it)."""
+    result = _build_accretion_file("grower.py", _history_at_fraction_020(), 0.30)
+    assert result is not None
+    assert result.path == "grower.py"
+    assert result.deletion_fraction == 0.20
+
+
+def test_default_threshold_drops_same_file() -> None:
+    """At the 0.15 default the same file is correctly excluded (0.20 >= 0.15)."""
+    result = _build_accretion_file("grower.py", _history_at_fraction_020(), 0.15)
+    assert result is None


### PR DESCRIPTION
## Summary

Adds `skills/assess/scripts/lib/accretion_ratchet.py`, the deterministic-core instrument for the **Accretion** write-side tendency named in the repo north star: an agent does what is asked, and what is asked is feature after feature, so files only ever grow. This module turns that tendency into a signal - the file whose accumulated line count never meaningfully comes back down.

Module only - it is **not** wired into `assess_core.py` (that is a separate task) and the comprehensive test suite (`test_accretion_ratchet.py`) is owned by a parallel PR, so this PR deliberately does not create that file.

## Changes Made

- `skills/assess/scripts/lib/accretion_ratchet.py` - new module: `scan_accretion_ratchet(repo_root, ...) -> AccretionScan` plus frozen `AccretionFile` and `AccretionScan` dataclasses.
- `skills/assess/scripts/lib/README.md` - module-reference entry added, naming the contributor tendency it compensates for.
- `.claude-plugin/plugin.json` - version bump 1.43.6 -> 1.43.7 (PATCH: new internal module, no user-visible behaviour change yet).

## Technical Details

- **Signal:** a file is flagged when its running net-delta (additions - deletions, accumulated in author-time order) is non-decreasing **and** its deletion fraction (`deletions / (additions + deletions)`) stays below a threshold (default 0.15). Both required: net growth alone is normal; growth with almost no deletion pressure is the accretion fingerprint. A single late refactor that cuts the file clears the flag.
- **Determinism:** parses one `git log --no-merges --no-renames --numstat` pass and sorts explicitly by `(author_time, sha)` before accumulating. The ordering pin is an explicit sort, not git's emission order (`--reverse`/traversal order can differ across clones), so output is byte-identical clone-to-clone. Verified: two runs produce diff-clean JSON.
- **Multi-commit gate** (`MIN_COMMITS_FOR_ACCRETION = 3`) drops single-touch rename artifacts.
- **Binary-file guard:** numstat `-` rows skipped (reuses the `isdigit()` check pattern).
- **Graceful degradation:** `available=False` on any git failure or non-repo; `reliable=False` on degenerate history via `churn_is_degenerate` (same verdict as every other churn consumer).
- Reuses `git_churn.GIT_TIMEOUT_SECONDS` and `churn_is_degenerate`; imports no orchestrator (passes `test_self_architecture.py`).

## Testing

- `import lib.accretion_ratchet` clean.
- CLI smoke test against this repo surfaces the known append-only hotspots (`doc_graph.py`, `assess_core.py`, `keyhole_signals.py`).
- Determinism verified: byte-identical JSON across two runs.
- ruff + mypy: clean on the new module.
- Full suites green locally: `skills/assess` (645 passed, 2 skipped), `scripts/` (106 passed), plugin contract (183 passed), `test_self_architecture` (2 passed).

## Risk Assessment

Low. Net-new module with no call sites in the orchestrator, so it cannot affect any existing `/assess` output until task 2 wires it in. Pure subprocess + stdlib, every git call capped by the shared 20s timeout, degrades rather than raises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accretion ratchet scanning capability to detect append-only file patterns in repository history.

* **Documentation**
  * Added module reference documentation for the accretion ratchet scanner.

* **Chores**
  * Updated plugin manifest version to 1.43.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->