### PR TITLE
feat: Emit accretion_ratchet block in assess run-context

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.7",
+  "version": "1.43.8",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -37,6 +37,7 @@ from typing import Any
 # Make sibling lib package importable when run as a script
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from lib.accretion_ratchet import scan_accretion_ratchet
 from lib.agent_instructions_grader import (
     detect_alias,
     detect_skills_dir,
@@ -411,6 +412,60 @@ def _write_fallback_badge_if_absent(
     ))
 
 
+# Cap on accretion files carried into run-context.json. The scanner measures
+# every file; the run-context list keeps only the worst few that also score in
+# the top complexity/size band, so a growing-but-simple file never earns a line.
+MAX_ACCRETION_FILES = 12
+
+
+def _top_band_paths(complexity_stats: dict) -> set[str]:
+    """Paths already in the top complexity/size band of this run's stats.
+
+    Union of the three ranked top-N lists (``top_hotspots``/``top_complex``/
+    ``top_large``). Accretion is only surfaced for a file already in this set:
+    a growing file that scores low on complexity *and* size isn't a hotspot, so
+    flagging its growth would be noise. Mirrors lib.keyhole_signals._paths_from_stats.
+    """
+    paths: set[str] = set()
+    for key in ("top_hotspots", "top_complex", "top_large"):
+        for entry in complexity_stats.get(key) or []:
+            path = entry.get("path")
+            if path:
+                paths.add(path)
+    return paths
+
+
+def _accretion_block(scan: Any, complexity_stats: dict) -> dict[str, Any]:
+    """Serialize an AccretionScan into the run-context ``accretion_ratchet`` block.
+
+    On an unavailable scan, emits the same shape with an empty file list and the
+    scan's reason (graceful degradation - a failed scan is never read as "no
+    accretion"). On success, the flagged files are filtered to those already in
+    the top complexity/size band (the noise budget), sorted by net additions
+    descending with a path tie-break for a total, deterministic order, and capped
+    at MAX_ACCRETION_FILES.
+    """
+    block: dict[str, Any] = {
+        "available": scan.available,
+        "reason": scan.reason,
+        "reliable": scan.reliable,
+        "deletion_fraction_threshold": scan.deletion_fraction_threshold,
+        "files": [],
+    }
+    if not scan.available:
+        return block
+
+    band = _top_band_paths(complexity_stats)
+    in_band = [f for f in scan.files if f.path in band]
+    # The scan already sorts by (-net_additions, path); re-sort defensively so
+    # the serialized order is a total, clone-independent order regardless of the
+    # filtered subset's incoming order.
+    in_band.sort(key=lambda f: (-f.net_additions, f.path))
+    block["total_in_band"] = len(in_band)
+    block["files"] = [f.to_dict() for f in in_band[:MAX_ACCRETION_FILES]]
+    return block
+
+
 def _marker_debt_sentence(debt: dict | None) -> str:
     """One briefing sentence accusing a hotspot of its own stale promises."""
     if not debt:
@@ -533,6 +588,15 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     marker_debt_by_file = (
         promissory.get("stale_by_file", {}) if promissory.get("available") else {}
     )
+
+    # Accretion ratchet (files whose line count only ever grows): the first of
+    # the three write-side tendencies. scan_accretion_ratchet never raises - it
+    # degrades to available=False internally - and returns an AccretionScan
+    # dataclass (not a dict), so it is called directly rather than through _safe
+    # (whose degrade path yields a dict). The block is serialized below, after
+    # the complexity band is known, so growth is reported only for files already
+    # in the top complexity/size band.
+    accretion_scan = scan_accretion_ratchet(repo_root)
 
     # Build status map: which paths are graduated, new, regressed, persistent
     status_map: dict[str, str] = {}
@@ -847,6 +911,12 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # Layer 3/5/8 scoring rules; stale_by_file feeds the unactioned_intent
     # finding and the hotspot pages (already written above with marker debt).
     ctx["promissory_markers"] = promissory
+
+    # Accretion ratchet (write-side tendency: files that only ever grow). The
+    # scan measured every file above; here it is filtered to files already in the
+    # top complexity/size band, sorted worst-first, and capped - so a file earns
+    # a line only by scoring high on complexity/LOC *and* growing monotonically.
+    ctx["accretion_ratchet"] = _accretion_block(accretion_scan, current)
 
     keyhole = integrate_keyhole_signals(
         repo_root=repo_root,

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -1180,3 +1180,120 @@ def test_core_writes_fallback_badge_only_when_absent(tmp_path: Path) -> None:
     build_run_context(repo_root=repo, run_date="2026-06-13")
     badge2 = json.loads((assess_dir / "badge.json").read_text(encoding="utf-8"))
     assert badge2["message"] == "7.0/8 · AI-Native"
+
+
+# --------------------------------------------------------------------------
+# Accretion ratchet block (files that only ever grow)
+# --------------------------------------------------------------------------
+
+def _accreting_history(repo: Path, commit, rel_path: str, *, commits: int = 5) -> None:
+    """Grow ``rel_path`` monotonically across ``commits`` commits, never deleting.
+
+    Each commit appends lines and removes none, so the file's running net-delta
+    is non-decreasing and its deletion fraction is zero - the pure-accretion
+    fingerprint the scanner flags (it needs >= MIN_COMMITS_FOR_ACCRETION commits).
+    Commits are backdated in descending order so author time advances forward.
+    """
+    src = repo / rel_path
+    src.parent.mkdir(parents=True, exist_ok=True)
+    body = ""
+    for i in range(commits):
+        body += "".join(f"line_{i}_{j} = {j}\n" for j in range(10))
+        src.write_text(body)
+        commit(f"grow {rel_path} step {i}", days_ago=commits - i)
+
+
+def test_accretion_ratchet_block_present_and_well_formed(git_repo) -> None:
+    """run-context.json carries a well-formed accretion_ratchet block, and a
+    monotonically-growing file that is also a complexity/size hotspot earns a row."""
+    repo, commit = git_repo
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    _accreting_history(repo, commit, "src/grower.py")
+
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 1, "loc": {"p50": 50, "p95": 50, "max": 50},
+        "ccn": {"p50": 1, "p95": 1, "max": 1},
+        "top_hotspots": [{"path": "src/grower.py", "loc": 50, "ccn": 1, "commits": 5}],
+        "top_complex": [{"path": "src/grower.py", "ccn": 1}],
+        "top_large": [{"path": "src/grower.py", "loc": 50}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+
+    assert "accretion_ratchet" in ctx
+    block = ctx["accretion_ratchet"]
+    assert set(block) >= {"available", "reliable", "deletion_fraction_threshold", "files"}
+    assert block["available"] is True
+    assert isinstance(block["files"], list)
+    paths = [f["path"] for f in block["files"]]
+    assert "src/grower.py" in paths
+    flagged = next(f for f in block["files"] if f["path"] == "src/grower.py")
+    assert set(flagged) == {
+        "path", "net_additions", "commit_count", "deletion_fraction", "time_span_months"
+    }
+    assert flagged["net_additions"] > 0
+    assert flagged["deletion_fraction"] == 0.0
+
+
+def test_accretion_ratchet_noise_budget_filters_non_hotspots(git_repo) -> None:
+    """A file that grows but is NOT in the top complexity/size band earns no row -
+    growth alone doesn't cry wolf; only band-resident files are surfaced."""
+    repo, commit = git_repo
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    # Two accreting files, but only one is declared a hotspot in the stats.
+    _accreting_history(repo, commit, "src/in_band.py")
+    _accreting_history(repo, commit, "src/out_of_band.py")
+
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 2, "loc": {"p50": 50, "p95": 50, "max": 50},
+        "ccn": {"p50": 1, "p95": 1, "max": 1},
+        "top_hotspots": [{"path": "src/in_band.py", "loc": 50, "ccn": 1, "commits": 5}],
+        "top_complex": [{"path": "src/in_band.py", "ccn": 1}],
+        "top_large": [{"path": "src/in_band.py", "loc": 50}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+    paths = [f["path"] for f in ctx["accretion_ratchet"]["files"]]
+    assert "src/in_band.py" in paths
+    assert "src/out_of_band.py" not in paths  # grew, but not a hotspot -> filtered
+
+
+def test_accretion_ratchet_degenerate_history_unreliable(tmp_path: Path) -> None:
+    """A non-git target degrades to available:false; the block is still emitted
+    with the degrade shape (a failed scan is never read as 'no accretion')."""
+    repo = _minimal_repo(tmp_path)  # plain dir, not a git repo
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+    block = ctx["accretion_ratchet"]
+    assert block["available"] is False
+    assert block["files"] == []
+    assert block["reason"]
+
+
+def test_accretion_ratchet_files_sorted_worst_first(git_repo) -> None:
+    """Serialized files are a total, deterministic order: net additions desc,
+    path tie-break - so the deterministic core stays byte-identical per repo."""
+    repo, commit = git_repo
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    _accreting_history(repo, commit, "src/big.py", commits=8)    # more growth
+    _accreting_history(repo, commit, "src/small.py", commits=4)  # less growth
+
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 2, "loc": {"p50": 50, "p95": 80, "max": 80},
+        "ccn": {"p50": 1, "p95": 1, "max": 1},
+        "top_hotspots": [
+            {"path": "src/big.py", "loc": 80, "ccn": 1, "commits": 8},
+            {"path": "src/small.py", "loc": 40, "ccn": 1, "commits": 4},
+        ],
+        "top_complex": [{"path": "src/big.py", "ccn": 1}],
+        "top_large": [{"path": "src/big.py", "loc": 80}, {"path": "src/small.py", "loc": 40}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+    files = ctx["accretion_ratchet"]["files"]
+    nets = [f["net_additions"] for f in files]
+    assert nets == sorted(nets, reverse=True)  # worst (largest growth) first
+    assert files[0]["path"] == "src/big.py"


### PR DESCRIPTION
## Summary

Integrates the `accretion_ratchet` scanner (merged in #199) into the `/assess` deterministic core, emitting an `accretion_ratchet` block in `run-context.json`. This is the first of the three write-side tendencies named in the north star: files that only ever grow.

## Changes Made

- `skills/assess/scripts/assess_core.py`
  - Import `scan_accretion_ratchet` from `lib.accretion_ratchet`.
  - Call the scanner once per run (directly, not via `_safe`: the scanner returns an `AccretionScan` dataclass and never raises, degrading to `available=False` internally).
  - Add `_top_band_paths()` and `_accretion_block()` helpers. The block serializes the scan result, applies the noise budget, and degrades gracefully.
  - Emit `ctx["accretion_ratchet"]` alongside `promissory_markers`.
- `skills/assess/tests/test_assess_core.py` - four tests covering block shape, the noise budget, degenerate/non-git history, and deterministic sort order.
- `.claude-plugin/plugin.json` - version bump 1.43.7 -> 1.43.8.

## Technical Details

**Noise budget.** A file earns a row only if it scores in the top complexity/size band (union of `top_hotspots` / `top_complex` / `top_large`) *and* grows monotonically. A growing-but-simple file is filtered out, so the signal doesn't cry wolf.

**Determinism.** Filtered files are sorted by net additions descending with a path tie-break (a total order), then capped at 12, so the serialized block is byte-identical for the same repo.

**Graceful degradation.** An unavailable scan still emits the block with `available:false`, an empty file list, and the scan's reason, so a failed scan is never read as "no accretion".

## Testing

All four required suites green locally, plus ruff + mypy:
- `skills/assess pytest`: 651 passed, 2 skipped
- `scripts/ pytest`: 106 passed
- `plugin contract pytest`: 183 passed
- `ruff` (skills/assess + scripts) + `mypy` (deterministic core): clean

## Risk Assessment

Additive. The new block sits beside existing run-context keys; no existing block shape changed. Scope is `assess_core.py` plus the version bump. Does not touch `keyhole_signals.py`, `wiki_writer.py`, the report, or `test_accretion_ratchet.py` (owned by sibling tasks).

Part of the assess-accretion wave (follows #199).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file growth analysis to identify monotonic changes and report associated risk metrics in assessments.

* **Chores**
  * Updated plugin version to 1.43.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->