### PR TITLE
feat: Add accretion growth profile to hotspot pages

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.43.8",
+  "version": "1.43.9",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -466,6 +466,25 @@ def _accretion_block(scan: Any, complexity_stats: dict) -> dict[str, Any]:
     return block
 
 
+def _accretion_lookup(scan: Any) -> dict[str, dict]:
+    """O(1) ``{path: accretion_info}`` for the hotspot pages, from one scan.
+
+    Each entry is the serialized AccretionFile plus the scan-wide ``reliable``
+    flag, so a hotspot page can name a file's growth profile and disclaim it on
+    degenerate history without re-deriving anything. Returns ``{}`` when the
+    scan was unavailable - the hotspot loop then writes pages with no growth
+    line (graceful degradation; the scan never gates page generation).
+    """
+    if not scan.available:
+        return {}
+    lookup: dict[str, dict] = {}
+    for af in scan.files:
+        entry = af.to_dict()
+        entry["reliable"] = scan.reliable
+        lookup[af.path] = entry
+    return lookup
+
+
 def _marker_debt_sentence(debt: dict | None) -> str:
     """One briefing sentence accusing a hotspot of its own stale promises."""
     if not debt:
@@ -597,6 +616,10 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # the complexity band is known, so growth is reported only for files already
     # in the top complexity/size band.
     accretion_scan = scan_accretion_ratchet(repo_root)
+    # O(1) per-file lookup for the hotspot pages, built from the same scan the
+    # run-context block serializes (no re-scan). Empty when the scan was
+    # unavailable - graceful degradation: those files just get no growth line.
+    accretion_by_file = _accretion_lookup(accretion_scan)
 
     # Build status map: which paths are graduated, new, regressed, persistent
     status_map: dict[str, str] = {}
@@ -655,6 +678,7 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
                 + "(Briefing refined by LLM via assess_finalize - see Suggested actions below.)"
             ),
             actions=UNFINALIZED_ACTIONS_POINTER,
+            accretion_data=accretion_by_file.get(path),
         )
 
     # Also surface graduated hotspots in the index. Carry the file's actual

--- a/skills/assess/scripts/lib/wiki_writer.py
+++ b/skills/assess/scripts/lib/wiki_writer.py
@@ -29,6 +29,32 @@ UNFINALIZED_ACTIONS_POINTER = (
 )
 
 
+def _growth_profile_line(accretion: dict | None) -> str:
+    """One briefing line naming a hotspot's monotonic-growth profile, or "".
+
+    ``accretion`` is the per-file accretion-ratchet entry for *this* hotspot
+    (the serialized AccretionFile dict: ``net_additions`` / ``commit_count`` /
+    ``time_span_months``), plus a ``reliable`` flag threaded down from the scan.
+    A file absent from the accretion data (no entry, or None) earns no line -
+    growth that wasn't flagged as pure accretion is normal development, not a
+    ratchet. When the underlying git history is degenerate (shallow/squashed
+    clone) the count is still reported but disclaimed, since the scan can't see
+    the full sequence.
+    """
+    if not accretion:
+        return ""
+    net = accretion.get("net_additions", 0)
+    commits = accretion.get("commit_count", 0)
+    months = round(accretion.get("time_span_months", 0))
+    line = (
+        f"Growth profile: monotonic "
+        f"(+{net} LOC, 0 net reductions over {commits} commits in {months} months)."
+    )
+    if accretion.get("reliable") is False:
+        line += " (history may be incomplete - shallow/squashed repo)"
+    return line
+
+
 @dataclass(frozen=True)
 class HotspotEntry:
     path: str
@@ -176,11 +202,18 @@ def write_hotspot_page(
     history_rows: str,
     briefing: str,
     actions: str,
+    accretion_data: dict | None = None,
 ) -> None:
     """(Re)write hotspots/<slug>.md.
 
     has_tests=None means "we don't know yet" - shown as "unknown" in the page.
     Test-to-code pairing is a deferred feature; honest reporting beats lying.
+
+    ``accretion_data`` is the accretion-ratchet entry for *this* file (the
+    serialized AccretionFile dict plus the scan's ``reliable`` flag), or None
+    when the file isn't accreting. When present, one growth-profile line is
+    appended to the briefing - no new section header - so the page names the
+    monotonic-growth tendency right where an agent is briefed before editing.
     """
     hotspots_dir = assess_dir / "hotspots"
     hotspots_dir.mkdir(exist_ok=True)
@@ -188,6 +221,9 @@ def write_hotspot_page(
         has_tests_str = "unknown"
     else:
         has_tests_str = "yes" if has_tests else "no"
+    growth = _growth_profile_line(accretion_data)
+    if growth:
+        briefing = f"{briefing} {growth}"
     content = _load_template("hotspot.md.template").format(
         path=path,
         first_flagged=first_flagged,

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -234,6 +234,74 @@ def test_unfinalized_hotspot_page_uses_neutral_pointer_not_placeholder(tmp_path:
         assert marker not in page
 
 
+def test_hotspot_page_carries_growth_profile_when_file_accretes(git_repo) -> None:
+    """A top-hotspot file that the accretion scan flags (monotonic growth, low
+    deletion across several commits) gets the growth-profile line wired into its
+    generated hotspot page - tasks 4+5 end-to-end."""
+    from lib.wiki_writer import slug_for_path
+
+    repo, commit = git_repo
+    src = repo / "src"
+    src.mkdir()
+    grower = src / "grower.go"
+    # Five commits that only add lines and never delete: pure accretion.
+    for i in range(1, 6):
+        grower.write_text("\n".join(f"line {n}" for n in range(i * 40)) + "\n")
+        commit(f"grow {i}", days_ago=(6 - i) * 20)
+
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir(exist_ok=True)
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 50,
+        "loc": {"p50": 30, "p95": 200, "max": 500},
+        "ccn": {"p50": 2, "p95": 8, "max": 20},
+        "top_hotspots": [{"path": "src/grower.go", "loc": 200, "ccn": 20, "commits": 5}],
+        "top_complex": [{"path": "src/grower.go", "ccn": 20}],
+        "top_large": [{"path": "src/grower.go", "loc": 200}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+    # Precondition: the scan actually flagged this file (else the test proves nothing).
+    flagged = {f["path"] for f in ctx["accretion_ratchet"].get("files", [])}
+    assert "src/grower.go" in flagged
+
+    page = (assess_dir / "hotspots" / f"{slug_for_path('src/grower.go')}.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Growth profile: monotonic" in page
+    assert "0 net reductions over" in page
+
+
+def test_hotspot_page_omits_growth_profile_when_scan_unavailable(tmp_path: Path) -> None:
+    """Graceful degradation: outside a git repo the accretion scan is
+    unavailable, so the hotspot page is still written - just without a growth
+    line. Hotspot generation never depends on the scan succeeding."""
+    from lib.wiki_writer import slug_for_path
+
+    repo = tmp_path / "repo"  # not a git repo
+    repo.mkdir()
+    assess_dir = repo / ".assess"
+    assess_dir.mkdir()
+    (assess_dir / "complexity-stats.json").write_text(json.dumps({
+        "files_scored": 50,
+        "loc": {"p50": 30, "p95": 200, "max": 500},
+        "ccn": {"p50": 2, "p95": 8, "max": 20},
+        "top_hotspots": [{"path": "src/a.go", "loc": 500, "ccn": 20, "commits": 5}],
+        "top_complex": [{"path": "src/a.go", "ccn": 20}],
+        "top_large": [{"path": "src/a.go", "loc": 500}],
+    }))
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-06-17")
+    assert ctx["accretion_ratchet"]["available"] is False
+
+    page = (assess_dir / "hotspots" / f"{slug_for_path('src/a.go')}.md").read_text(
+        encoding="utf-8"
+    )
+    # Page exists and is complete, but carries no growth profile.
+    assert "## Suggested actions" in page
+    assert "Growth profile" not in page
+
+
 def test_unfinalized_actions_pointer_carries_no_placeholder_marker() -> None:
     """The neutral pointer text itself must be free of TODO-style markers - it is
     the default that ships when a page is never finalized."""

--- a/skills/assess/tests/test_wiki_writer.py
+++ b/skills/assess/tests/test_wiki_writer.py
@@ -249,3 +249,70 @@ def test_write_hotspot_page_unknown_has_tests(tmp_assess_dir: Path) -> None:
     page = next((tmp_assess_dir / "hotspots").iterdir())
     content = page.read_text(encoding="utf-8")
     assert "Has test file | unknown" in content
+
+
+def _hotspot_kwargs(**overrides: object) -> dict:
+    """Baseline write_hotspot_page kwargs; overrides win."""
+    base = dict(
+        path="src/foo.go",
+        first_flagged="2026-01-01",
+        last_seen="2026-06-17",
+        status="active",
+        loc=600,
+        ccn=30,
+        commits=15,
+        has_tests=None,
+        history_rows="| 2026-06-17 | 600 | 30 | 15 | active |",
+        briefing="Go API handler.",
+        actions="- Investigate complexity",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_hotspot_page_includes_growth_profile_when_accreting(tmp_assess_dir: Path) -> None:
+    """A file present in the accretion data gets one growth-profile line in the
+    briefing - the monotonic-growth tendency named where an agent is briefed."""
+    write_hotspot_page(tmp_assess_dir, **_hotspot_kwargs(accretion_data={
+        "path": "src/foo.go", "net_additions": 420, "commit_count": 18,
+        "deletion_fraction": 0.04, "time_span_months": 7.2, "reliable": True,
+    }))
+    page = next((tmp_assess_dir / "hotspots").iterdir())
+    content = page.read_text(encoding="utf-8")
+    assert "Growth profile: monotonic" in content
+    assert "+420 LOC" in content
+    assert "0 net reductions over 18 commits in 7 months" in content
+    # No new section header - the line rides inside the existing briefing.
+    assert "## Growth" not in content
+
+
+def test_hotspot_page_no_growth_profile_without_accretion_data(tmp_assess_dir: Path) -> None:
+    """A file with no accretion entry (None) earns no line - growth that wasn't
+    flagged as pure accretion is normal development, not a ratchet."""
+    write_hotspot_page(tmp_assess_dir, **_hotspot_kwargs(accretion_data=None))
+    page = next((tmp_assess_dir / "hotspots").iterdir())
+    content = page.read_text(encoding="utf-8")
+    assert "Growth profile" not in content
+
+
+def test_hotspot_page_growth_profile_defaults_to_none(tmp_assess_dir: Path) -> None:
+    """accretion_data is optional: a caller that doesn't pass it still works and
+    produces no growth line (back-compat with the pre-accretion call site)."""
+    write_hotspot_page(tmp_assess_dir, **_hotspot_kwargs())
+    page = next((tmp_assess_dir / "hotspots").iterdir())
+    content = page.read_text(encoding="utf-8")
+    assert "Growth profile" not in content
+
+
+def test_hotspot_page_growth_profile_disclaims_unreliable_history(tmp_assess_dir: Path) -> None:
+    """reliable=False (shallow/squashed clone) still reports the profile but
+    appends the incomplete-history disclaimer so the count isn't over-trusted."""
+    write_hotspot_page(tmp_assess_dir, **_hotspot_kwargs(accretion_data={
+        "path": "src/foo.go", "net_additions": 200, "commit_count": 5,
+        "deletion_fraction": 0.02, "time_span_months": 3.0, "reliable": False,
+    }))
+    page = next((tmp_assess_dir / "hotspots").iterdir())
+    content = page.read_text(encoding="utf-8")
+    assert "Growth profile: monotonic" in content
+    assert "history may be incomplete" in content
+    assert "shallow/squashed repo" in content


### PR DESCRIPTION
## Summary

Wires the accretion-ratchet scan into the per-file hotspot pages. A hotspot
that the scan flags as monotonically growing now carries a single growth-profile
line in its briefing, naming the write-side tendency (Accretion) right where an
agent is briefed before editing the file.

Closes assess-accretion task 4 (growth-profile line in `wiki_writer.py`) and
task 5 (wiring the per-file accretion data from `assess_core.py` into hotspot
generation). The two are combined because each is meaningless without the other.

## Changes Made

- `skills/assess/scripts/lib/wiki_writer.py`
  - `write_hotspot_page()` accepts an optional `accretion_data` parameter (the
    per-file accretion entry, or `None`).
  - New `_growth_profile_line()` renders one line from `net_additions` /
    `commit_count` / `time_span_months`:
    `Growth profile: monotonic (+X LOC, 0 net reductions over Y commits in Z months).`
    When the scan's `reliable` flag is `False` (shallow/squashed clone) it
    appends a `(history may be incomplete - shallow/squashed repo)` disclaimer.
  - The line is appended to the existing briefing - no new section header.
- `skills/assess/scripts/assess_core.py`
  - New `_accretion_lookup()` builds an O(1) `{path: accretion_info}` map from
    the already-computed accretion scan (no re-scan), threading the scan-wide
    `reliable` flag onto each entry.
  - The hotspot generation loop passes each file's own entry (or `None`) to
    `write_hotspot_page()`.
  - Graceful degradation: an unavailable scan yields an empty lookup, so hotspot
    pages are still written - just without a growth line.
- `.claude-plugin/plugin.json`: version bump 1.43.8 -> 1.43.9.

## Technical Details

- Reuses the accretion scan and field names task 2 already produces
  (`net_additions`, `commit_count`, `time_span_months`, `reliable`); no second scan.
- Deterministic: the line is a pure function of the serialized scan entry, so the
  hotspot markdown stays byte-identical run-to-run for the same repo.
- `_accretion_lookup()` was extracted to a module-level helper to keep
  `build_run_context` under the C901 complexity ratchet (max 15).

## Testing

- `test_wiki_writer.py`: file with accretion shows the profile line; file without
  shows none; `accretion_data` defaulting to `None` is back-compatible; an
  unreliable scan appends the disclaimer.
- `test_assess_core.py`: a real accreting top-hotspot (monotonic growth across
  several commits in a throwaway git repo) produces a hotspot page that carries
  the growth profile; outside a git repo the scan is unavailable and the page is
  still written without a growth line.
- Required suites green locally: `skills/assess pytest` (657 passed), `scripts/`
  (106 passed), `plugin contract` (183 passed); `ruff + mypy` clean.

## Risk Assessment

Additive change. The new parameter defaults to `None`, so any other caller of
`write_hotspot_page()` is unaffected. The scan never gates page generation.