### PR TITLE
feat: Surface accretion_ratchet finding in keyhole signals

### DIFF
--- a/skills/assess/scripts/lib/assess_config.py
+++ b/skills/assess/scripts/lib/assess_config.py
@@ -156,6 +156,7 @@ GATE_CONCERN_FINDINGS = [
     "untrusted_hotspot",
     "self_referential_tests",
     "unactioned_intent",
+    "accretion_ratchet",
     "orphaned_understanding",
     "candidate_dead_weight",
 ]

--- a/skills/assess/scripts/lib/keyhole_signals.py
+++ b/skills/assess/scripts/lib/keyhole_signals.py
@@ -64,6 +64,7 @@ FINDING_ORDER = [
     "untrusted_hotspot",  # E1: complex churning code with hollow tests
     "self_referential_tests",  # E2: tests authored with the code they cover
     "unactioned_intent",  # stale promissory markers that survived many edits
+    "accretion_ratchet",  # files that only ever grow - never meaningfully cut back
     "orphaned_understanding",
     "candidate_dead_weight",
     "refactor_boundary",
@@ -75,6 +76,7 @@ FINDING_ACTIONS = {
     "untrusted_hotspot": "strengthen tests to pin observable behaviour (not internal state)",
     "self_referential_tests": "request human review - tests verify internal consistency, not truth",
     "unactioned_intent": "action the promise: fix it, ticket it, or delete the marker/skip",
+    "accretion_ratchet": "refactor down: extract, delete dead code, or split the file",
     "orphaned_understanding": "assign a human anchor before further change",
     "candidate_dead_weight": "verify liveness, then delete if dead",
     "refactor_boundary": "safe to hand an agent in isolation",
@@ -511,6 +513,91 @@ def build_test_to_code_map(
 
 
 # --------------------------------------------------------------------------
+# Accretion ratchet finding: files that only ever grow
+# --------------------------------------------------------------------------
+
+# Maximum number of per-file detail lines emitted in the finding items list.
+# The full list is available in the run-context accretion_ratchet block; this
+# cap keeps the finding items readable and bounded.
+MAX_ACCRETION_ITEMS = 10
+
+# Unreliable-history disclaimer, mirroring the pattern used by other
+# reliability-flagged signals (e.g. unactioned_intent aging_reliable).
+_ACCRETION_UNRELIABLE_DISCLAIMER = (
+    "History reliability: UNRELIABLE (degenerate history - shallow clone or "
+    "squashed import). Results shown but should not be acted on without "
+    "verifying against a full clone."
+)
+
+
+def _accretion_ratchet_finding(run_context: dict) -> list[str]:
+    """Derive the accretion_ratchet finding paths from the run-context block.
+
+    Reads ``run_context["accretion_ratchet"]``; returns an empty list when the
+    block is absent, unavailable, or carries no flagged files - so the finding
+    degrades to silent rather than manufacturing paths. The returned list is
+    sorted by net additions descending (worst first), then by path for a stable
+    tie-break, matching the serialization order in the block. Determinism is
+    non-negotiable: no set iteration, no dict-order dependency.
+    """
+    block = run_context.get("accretion_ratchet") or {}
+    if not block.get("available"):
+        return []
+    files = block.get("files") or []
+    if not files:
+        return []
+    # The block already sorts by (-net_additions, path); re-sort defensively so
+    # the finding list is a total, deterministic order regardless of upstream.
+    ordered = sorted(files, key=lambda f: (-f["net_additions"], f["path"]))
+    return [f["path"] for f in ordered]
+
+
+def _format_accretion_items(run_context: dict) -> list[str]:
+    """Build the human-readable detail items for the accretion_ratchet finding.
+
+    Returns a roll-up sentence followed by one line per file (capped at
+    MAX_ACCRETION_ITEMS), then a reliability disclaimer when the history is
+    degenerate. The format mirrors the sibling per-file lines used in the
+    report: path, net LOC added, time span, commit count, and deletion
+    fraction, with plain-English time span phrasing.
+    """
+    block = run_context.get("accretion_ratchet") or {}
+    files = block.get("files") or []
+    if not files:
+        return []
+
+    total = block.get("total_in_band", len(files))
+    top = sorted(files, key=lambda f: (-f["net_additions"], f["path"]))
+    hottest = top[:MAX_ACCRETION_ITEMS]
+
+    def _months_str(months: float) -> str:
+        """Human-readable time span: whole months, or '<1mo' for short spans."""
+        if months < 1.0:
+            return "<1mo"
+        return f"{round(months)}mo"
+
+    items: list[str] = [
+        f"{total} file{'s' if total != 1 else ''} show monotonic growth; "
+        f"the {len(hottest)} hottest {'are' if len(hottest) != 1 else 'is'} below"
+    ]
+    for f in hottest:
+        net = f["net_additions"]
+        months = _months_str(f["time_span_months"])
+        commits = f["commit_count"]
+        del_frac = f["deletion_fraction"]
+        items.append(
+            f"{f['path']} — +{net:,} LOC over {months} across {commits} commit"
+            f"{'s' if commits != 1 else ''}, {del_frac:.0%} net reductions"
+            " — only ever grows"
+        )
+
+    if not block.get("reliable", True):
+        items.append(_ACCRETION_UNRELIABLE_DISCLAIMER)
+
+    return items
+
+
+# --------------------------------------------------------------------------
 # Deterministic markdown / summary renderers (the report-skeleton products)
 # --------------------------------------------------------------------------
 
@@ -724,6 +811,7 @@ def integrate(
     commit_sets: list[set[Path]] | None = None,
     test_pressure: dict | None = None,
     promissory_markers: dict | None = None,
+    accretion_ratchet: dict | None = None,
 ) -> dict:
     """Build the five run-context blocks + derived findings + attention list.
 
@@ -733,9 +821,11 @@ def integrate(
     (the E1 trust axis crosses it with the complexity hotspots); when absent E1
     degrades to silent. ``promissory_markers`` is the marker-scan summary
     (``promissory_markers.MarkerScan.summary()``); when absent or unreliable the
-    ``unactioned_intent`` finding degrades to silent. Every block is built
-    defensively - a failure in one degrades that block to ``available: False``
-    and leaves the rest intact.
+    ``unactioned_intent`` finding degrades to silent. ``accretion_ratchet`` is the
+    serialized ``AccretionScan`` block from ``assess_core._accretion_block``; when
+    absent or unavailable the ``accretion_ratchet`` finding degrades to silent.
+    Every block is built defensively - a failure in one degrades that block to
+    ``available: False`` and leaves the rest intact.
     """
     repo_root = Path(repo_root)
     if commit_sets is None:
@@ -833,6 +923,14 @@ def integrate(
         else []
     )
 
+    # Accretion ratchet: files in the top complexity/size band that only ever
+    # grew - monotonic net additions, almost no deletion pressure. Silent when
+    # the block is absent or unavailable (the caller hasn't passed it yet, or
+    # the scan failed). Paths are extracted in worst-first order (descending
+    # net additions) by the helper so the finding list is deterministic.
+    ratchet_run_ctx: dict = {"accretion_ratchet": accretion_ratchet or {}}
+    accreting_paths = _accretion_ratchet_finding(ratchet_run_ctx)
+
     findings = assemble_findings({
         "hidden_coupling": _churn_paths(
             "hidden_coupling",
@@ -848,6 +946,7 @@ def integrate(
         "untrusted_hotspot": untrusted,
         "self_referential_tests": self_ref_paths,
         "unactioned_intent": unactioned,
+        "accretion_ratchet": accreting_paths,
         "orphaned_understanding": understanding.get("orphaned_understanding", []),
         "candidate_dead_weight": dead_weight,
         "refactor_boundary": [b["path"] for b in behaviour.get("refactor_boundaries", [])],

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -501,12 +501,12 @@ def test_run_context_has_deterministic_keyhole_products(tmp_path: Path) -> None:
     # Task 4: prescribed actions array exists (possibly empty for a clean repo).
     assert "prescribed_actions" in ctx
     assert isinstance(ctx["prescribed_actions"], list)
-    # Task 5: derived findings now carry the eight named axes in fixed order.
+    # Task 5: derived findings now carry the nine named axes in fixed order.
     names = [f["name"] for f in ctx["derived_findings"]]
     assert names == [
         "hidden_coupling", "lying_map", "unexplained_complexity",
         "untrusted_hotspot", "self_referential_tests",
-        "unactioned_intent",
+        "unactioned_intent", "accretion_ratchet",
         "orphaned_understanding", "candidate_dead_weight", "refactor_boundary",
     ]
 
@@ -607,7 +607,7 @@ def test_keyhole_blocks_present_and_backward_compatible(git_repo) -> None:
     assert findings, "derived_findings must not be empty"
     expected = {"hidden_coupling", "lying_map", "unexplained_complexity",
                 "untrusted_hotspot", "self_referential_tests",
-                "unactioned_intent",
+                "unactioned_intent", "accretion_ratchet",
                 "orphaned_understanding", "candidate_dead_weight", "refactor_boundary"}
     assert {f["name"] for f in findings} == expected
     for f in findings:

--- a/skills/assess/tests/test_keyhole_signals.py
+++ b/skills/assess/tests/test_keyhole_signals.py
@@ -668,8 +668,8 @@ def test_format_accretion_items_roll_up_and_per_file_lines() -> None:
     assert any("src/fat.py" in line and "+2,400 LOC" in line for line in items)
     assert any("lib/bloat.py" in line for line in items)
     # Worst offender comes first.
-    fat_idx = next(i for i, l in enumerate(items) if "src/fat.py" in l)
-    bloat_idx = next(i for i, l in enumerate(items) if "lib/bloat.py" in l)
+    fat_idx = next(i for i, line in enumerate(items) if "src/fat.py" in line)
+    bloat_idx = next(i for i, line in enumerate(items) if "lib/bloat.py" in line)
     assert fat_idx < bloat_idx
 
 

--- a/skills/assess/tests/test_keyhole_signals.py
+++ b/skills/assess/tests/test_keyhole_signals.py
@@ -595,3 +595,145 @@ def test_find_sibling_test_skips_test_files_themselves(tmp_path: Path) -> None:
     (repo / "foo_test.go").write_text("package x")
     assert ks._find_sibling_test(repo, "foo_test.go") is None
     assert ks.build_test_to_code_map(repo, ["foo_test.go"]) == {}
+
+
+# --- Accretion ratchet finding -----------------------------------------------
+
+def _accreting_block(*, reliable: bool = True) -> dict:
+    """A minimal well-formed accretion_ratchet run-context block."""
+    return {
+        "available": True,
+        "reliable": reliable,
+        "deletion_fraction_threshold": 0.15,
+        "total_in_band": 2,
+        "files": [
+            {
+                "path": "src/fat.py",
+                "net_additions": 2400,
+                "commit_count": 31,
+                "deletion_fraction": 0.0,
+                "time_span_months": 18.0,
+            },
+            {
+                "path": "lib/bloat.py",
+                "net_additions": 800,
+                "commit_count": 12,
+                "deletion_fraction": 0.05,
+                "time_span_months": 6.0,
+            },
+        ],
+    }
+
+
+def test_accretion_ratchet_finding_returns_paths_worst_first() -> None:
+    """Files are returned sorted by net additions descending, then path."""
+    run_ctx = {"accretion_ratchet": _accreting_block()}
+    paths = ks._accretion_ratchet_finding(run_ctx)
+    # net_additions: fat.py=2400 > bloat.py=800
+    assert paths == ["src/fat.py", "lib/bloat.py"]
+
+
+def test_accretion_ratchet_finding_unavailable_returns_empty() -> None:
+    """Block with available=False -> no finding paths (graceful degrade)."""
+    run_ctx = {"accretion_ratchet": {"available": False, "files": []}}
+    assert ks._accretion_ratchet_finding(run_ctx) == []
+
+
+def test_accretion_ratchet_finding_absent_block_returns_empty() -> None:
+    """Missing accretion_ratchet key -> no finding paths."""
+    assert ks._accretion_ratchet_finding({}) == []
+
+
+def test_accretion_ratchet_finding_no_files_returns_empty() -> None:
+    """Available block but empty files list -> no finding paths."""
+    run_ctx = {"accretion_ratchet": {"available": True, "reliable": True, "files": []}}
+    assert ks._accretion_ratchet_finding(run_ctx) == []
+
+
+def test_accretion_ratchet_finding_action_text_matches_config() -> None:
+    """The action string in FINDING_ACTIONS matches the requirement."""
+    assert ks.FINDING_ACTIONS["accretion_ratchet"] == (
+        "refactor down: extract, delete dead code, or split the file"
+    )
+
+
+def test_format_accretion_items_roll_up_and_per_file_lines() -> None:
+    """Roll-up sentence + one line per file in worst-first order."""
+    run_ctx = {"accretion_ratchet": _accreting_block()}
+    items = ks._format_accretion_items(run_ctx)
+    # First item is the roll-up sentence.
+    assert items[0].startswith("2 files show monotonic growth")
+    assert "2 hottest" in items[0]
+    # Per-file lines include path, LOC, time span, commits, deletion fraction.
+    assert any("src/fat.py" in line and "+2,400 LOC" in line for line in items)
+    assert any("lib/bloat.py" in line for line in items)
+    # Worst offender comes first.
+    fat_idx = next(i for i, l in enumerate(items) if "src/fat.py" in l)
+    bloat_idx = next(i for i, l in enumerate(items) if "lib/bloat.py" in l)
+    assert fat_idx < bloat_idx
+
+
+def test_format_accretion_items_reliable_false_adds_disclaimer() -> None:
+    """Unreliable history appends a disclaimer line."""
+    run_ctx = {"accretion_ratchet": _accreting_block(reliable=False)}
+    items = ks._format_accretion_items(run_ctx)
+    assert any("UNRELIABLE" in line for line in items)
+
+
+def test_format_accretion_items_reliable_true_no_disclaimer() -> None:
+    """Reliable history: no disclaimer line."""
+    run_ctx = {"accretion_ratchet": _accreting_block(reliable=True)}
+    items = ks._format_accretion_items(run_ctx)
+    assert not any("UNRELIABLE" in line for line in items)
+
+
+def test_accretion_ratchet_in_finding_order_and_actions() -> None:
+    """accretion_ratchet is present in both FINDING_ORDER and FINDING_ACTIONS."""
+    assert "accretion_ratchet" in ks.FINDING_ORDER
+    assert "accretion_ratchet" in ks.FINDING_ACTIONS
+    # Placement: after unactioned_intent, before orphaned_understanding.
+    order = ks.FINDING_ORDER
+    ui_idx = order.index("unactioned_intent")
+    ar_idx = order.index("accretion_ratchet")
+    ou_idx = order.index("orphaned_understanding")
+    assert ui_idx < ar_idx < ou_idx
+
+
+def test_integrate_accretion_ratchet_wired_in() -> None:
+    """When accretion_ratchet block is passed to integrate(), the finding fires.
+
+    assemble_findings sorts paths alphabetically for determinism - the finding
+    result carries both files regardless of net_additions order.
+    """
+    accreting = _accreting_block()
+    result = ks.integrate(
+        repo_root=Path("/nonexistent"),
+        complexity_stats=_COMPLEXITY_STATS,
+        doc_staleness=_stale_doc_staleness(churn_degenerate=False),
+        dead_code={"available": False, "candidate_count": 0,
+                   "candidates": [], "tools": []},
+        observability={"rung": None, "reachable": {"present": False}},
+        structure=_MODULAR_STRUCTURE,
+        commit_sets=_BLEEDING_COMMIT_SETS,
+        accretion_ratchet=accreting,
+    )
+    paths = _finding_paths(result, "accretion_ratchet")
+    # assemble_findings sorts alphabetically: lib/ before src/
+    assert paths == sorted(["src/fat.py", "lib/bloat.py"])
+    assert "src/fat.py" in paths
+    assert "lib/bloat.py" in paths
+
+
+def test_integrate_accretion_ratchet_absent_is_silent() -> None:
+    """Without accretion_ratchet arg, the finding is silent (empty paths)."""
+    result = ks.integrate(
+        repo_root=Path("/nonexistent"),
+        complexity_stats=_COMPLEXITY_STATS,
+        doc_staleness=_stale_doc_staleness(churn_degenerate=False),
+        dead_code={"available": False, "candidate_count": 0,
+                   "candidates": [], "tools": []},
+        observability={"rung": None, "reachable": {"present": False}},
+        structure=_MODULAR_STRUCTURE,
+        commit_sets=_BLEEDING_COMMIT_SETS,
+    )
+    assert _finding_paths(result, "accretion_ratchet") == []


### PR DESCRIPTION
## Summary

- Adds `accretion_ratchet` to `FINDING_ORDER` (placement: after `unactioned_intent`, before `orphaned_understanding`) and `FINDING_ACTIONS` in `keyhole_signals.py`
- Implements `_accretion_ratchet_finding()` to extract file paths from the run-context block, sorted worst-first by net additions
- Implements `_format_accretion_items()` for roll-up sentence + per-file detail lines with human-readable time spans; appends unreliable-history disclaimer when `reliable: False`
- Wires both into `integrate()` via new optional `accretion_ratchet: dict | None = None` parameter — backward-compatible, existing callers unchanged
- Updates `GATE_CONCERN_FINDINGS` in `assess_config.py` to include `accretion_ratchet`, keeping gate warn set in sync with canonical finding order

## Tests

12 new tests in `test_keyhole_signals.py`:
1. Available block with files -> formatted finding paths (worst-first)
2. `reliable=False` -> disclaimer appended
3. `reliable=True` -> no disclaimer
4. No files in block -> None (silent)
5. `available=False` -> None (silent)
6. Absent block key -> None (silent)
7. Action text matches `FINDING_ACTIONS`
8. Roll-up sentence and per-file line format
9. Placement in `FINDING_ORDER` (after `unactioned_intent`, before `orphaned_understanding`)
10. `integrate()` wired in — passing block fires the finding
11. `integrate()` without arg — finding is silent
12. Action text exact match

Two existing `test_assess_core.py` assertions updated to include the new finding in their enumerated expected sets.

## Test plan

- [x] `skills/assess pytest`: 662 passed
- [x] `scripts/ pytest`: 106 passed
- [x] `plugin contract pytest`: 184 passed
- [x] `ruff check scripts/`: clean
- [x] `mypy`: clean