### PR TITLE
feat: Add CODEOWNERS/ARCHITECTURE ownership parser

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/ownership_parser.py
+++ b/skills/assess/scripts/lib/ownership_parser.py
@@ -1,0 +1,470 @@
+"""Ownership-map parsing for Layer 0 structure-drift detection.
+
+Ownership is declared in two places an LLM contributor reads as authoritative
+boundaries: a GitHub ``CODEOWNERS`` file (glob -> owner) and a freeform
+``ARCHITECTURE.md`` (prose -> "module X owns these paths"). Both are *declared*
+maps of how the code is meant to be organised. The structure-drift signals
+(tasks 9/10) compare those declarations against where the code actually lives
+and how it actually changes - a glob that matches nothing, a declared module
+whose files have scattered, a boundary the commit history no longer respects.
+
+This module is only the parse half: turn the two declaration formats into
+``{declared_boundary: {matched_file_paths}}`` maps and flag the globs that
+already match zero files (the cheapest drift - a boundary the filesystem has
+left behind). It mirrors ``doc_graph.py`` for module shape: a single shared
+file walk with the same ``EXCLUDE_DIRS`` / ``is_excluded_path`` resolution,
+``tracked_files`` to honour ``.gitignore``, and honest degradation to an
+``available=False`` result rather than ever crashing the assessment.
+
+Determinism is a contract: the same repo must produce byte-identical output, so
+every returned collection is sorted at the boundary and no set/dict iteration
+order leaks out. The drift signals that consume this module (tasks 9/10) and the
+orchestrator wiring (task 11) are deliberately not here - this is the parser and
+empty-glob detector only.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+from lib.doc_graph import is_excluded_path, is_repo_file
+from lib.git_churn import tracked_files
+
+# Where an ownership map can legitimately live. CODEOWNERS is recognised by
+# GitHub at the repo root, in ``.github/``, or in ``docs/`` - we honour the same
+# three so a repo that keeps it in any of them is read, not missed.
+CODEOWNERS_LOCATIONS: tuple[str, ...] = (
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    "docs/CODEOWNERS",
+)
+
+# Markdown docs that declare module boundaries in prose. ``ARCHITECTURE.md`` is
+# the convention, but a repo often carries the same boundary map in a top-level
+# or per-package ``README.md`` (a "co-change seam map" / module reference). We
+# scan the conventional names wherever they sit so the declaration is read from
+# whatever file actually holds it, not only one hard-coded path.
+ARCHITECTURE_BASENAMES: frozenset[str] = frozenset({
+    "architecture.md",
+    "design.md",
+})
+
+# A README only counts as an architecture doc when it actually declares module
+# boundaries - a generic project README is not an ownership map. We treat a
+# README as a boundary declaration when its prose carries an ownership/seam
+# vocabulary (see ``_declares_boundaries``); otherwise it is skipped.
+README_BASENAMES: frozenset[str] = frozenset({"readme.md"})
+
+# Prose that marks a markdown doc as declaring module ownership/boundaries. Used
+# to admit a README as an architecture doc only when it genuinely maps modules.
+_BOUNDARY_VOCAB_RE = re.compile(
+    r"\b(owns?|owner|ownership|boundar(?:y|ies)|module(?:s)?|seam(?:s)?|"
+    r"co-?change|cohesion|co-?locat)",
+    re.IGNORECASE,
+)
+
+# Inline-code spans and fenced blocks carry the path references we extract from
+# prose - ``doc_graph.py`` strips these to *avoid* phantom links, but here a
+# path written as code (`` `skills/assess/scripts` ``) is exactly the boundary
+# declaration we want, so we read them rather than strip them.
+_FENCE_RE = re.compile(r"```.*?\n.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]{1,200})`")
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]]+?)\]\]")
+# A bare path reference in prose: a slash-bearing token that looks like a repo
+# path. Anchored on a path separator so plain words don't match; trailing
+# punctuation is trimmed by the caller.
+_BARE_PATH_RE = re.compile(r"(?<![\w./-])([A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+)")
+
+# A markdown section header (``#``..``######``). The text after the hashes names
+# the module the section is about; its path references are attributed to it.
+_HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*$")
+
+# Glob characters that make a CODEOWNERS pattern a wildcard rather than a literal
+# path. Used only to classify a pattern for reporting; matching uses fnmatch.
+_GLOB_CHARS = set("*?[")
+
+
+def _warn(msg: str) -> None:
+    """Best-effort warning to stderr; never raises, never blocks the scan."""
+    print(f"note: ownership_parser: {msg}", file=sys.stderr)
+
+
+def _strip_anchor(target: str) -> str:
+    """Drop a ``|alias`` (wikilink) and ``#anchor`` / ``?query`` from a target."""
+    target = target.split("|", 1)[0]
+    target = target.split("#", 1)[0]
+    target = target.split("?", 1)[0]
+    return target.strip().strip("\"'")
+
+
+def _codeowners_path(repo_root: Path) -> Path | None:
+    """The single CODEOWNERS file in effect, by GitHub's location precedence."""
+    for rel in CODEOWNERS_LOCATIONS:
+        candidate = repo_root / rel
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _glob_to_fnmatch(pattern: str) -> tuple[str, ...]:
+    """Translate a CODEOWNERS glob to the fnmatch patterns it matches against.
+
+    Returns one or more fnmatch patterns (any match counts), normalising the two
+    places CODEOWNERS rules differ from shell globs:
+
+    - A leading ``/`` anchors to the repo root; without it the pattern matches at
+      any depth. fnmatch has no anchor concept, so an unanchored pattern is
+      tried both as-is (matching at root) *and* prefixed with ``*/`` (matching in
+      any subdirectory) - so a bare ``Makefile`` claims both ``Makefile`` and
+      ``tools/Makefile``. An anchored or already-path-qualified pattern is tried
+      root-relative only.
+    - A trailing ``/`` (a directory) matches everything beneath it, so ``docs/``
+      becomes ``docs/*``.
+
+    fnmatch's ``*`` crosses ``/`` for us, so ``**`` and ``*`` behave the same;
+    every ``**`` is collapsed to ``*`` for one predictable form.
+    """
+    pat = pattern.strip()
+    anchored = pat.startswith("/")
+    pat = pat.lstrip("/")
+    if pat.endswith("/"):
+        pat = pat + "*"
+    pat = pat.replace("**", "*")
+    # An anchored or path-qualified pattern is root-relative; a bare, unanchored
+    # pattern matches at any depth, so also try the subdirectory form.
+    if anchored or "/" in pat.rstrip("*"):
+        return (pat,)
+    return (pat, "*/" + pat)
+
+
+def _match_glob(pattern: str, rel_paths: list[str]) -> set[Path]:
+    """Repo-relative paths matching a CODEOWNERS glob.
+
+    Matches both the file itself and any file beneath a directory pattern, so a
+    ``src/`` rule claims every file under ``src``. A path matches when it matches
+    any of the fnmatch forms ``_glob_to_fnmatch`` derives for the pattern.
+    """
+    forms = _glob_to_fnmatch(pattern)
+    out: set[Path] = set()
+    for rp in rel_paths:
+        if any(fnmatch.fnmatch(rp, form) for form in forms):
+            out.add(Path(rp))
+    return out
+
+
+def parse_codeowners(repo_root: Path) -> dict[str, set[Path]]:
+    """Parse the repo's CODEOWNERS into ``{glob_pattern: {matched_file_paths}}``.
+
+    GitHub CODEOWNERS format: each non-comment line is ``pattern @owner...``;
+    we keep the pattern (the declared boundary) and resolve it against the
+    git-tracked file set so ``.gitignore``'d files never count. Comment (``#``)
+    and blank lines are skipped. A pattern that appears twice is unioned. Every
+    returned path set is the resolved match set; the empty-glob detector reads
+    these to flag patterns that match nothing.
+
+    Degrades to an empty dict when no CODEOWNERS file exists - the caller reads
+    that as ``available: False`` ("no ownership map"). A malformed individual
+    line is skipped with a warning rather than aborting the parse.
+    """
+    repo_root = repo_root.resolve()
+    path = _codeowners_path(repo_root)
+    if path is None:
+        return {}
+
+    tracked = tracked_files(repo_root)
+    rel_paths = _tracked_rel_paths(repo_root, tracked)
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        _warn(f"could not read {path}: {exc}")
+        return {}
+
+    out: dict[str, set[Path]] = {}
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # ``pattern @owner1 @owner2`` - the pattern is the first whitespace token.
+        try:
+            pattern = line.split()[0]
+        except IndexError:  # pragma: no cover - split() of non-empty never empty
+            _warn(f"{path}:{lineno}: could not parse line, skipping")
+            continue
+        out.setdefault(pattern, set()).update(_match_glob(pattern, rel_paths))
+    return out
+
+
+def _tracked_rel_paths(
+    repo_root: Path, tracked: frozenset[Path] | None,
+) -> list[str]:
+    """Repo-relative POSIX path strings for every tracked, non-excluded file.
+
+    Honours the same ``EXCLUDE_DIRS`` / ``is_excluded_path`` resolution the doc
+    graph uses, and falls back to a filesystem walk (with the symlink guard)
+    when the tree is not under git, so the glob resolver always has a file set.
+    """
+    rels: list[str] = []
+    if tracked is not None:
+        for abs_path in tracked:
+            try:
+                rel = abs_path.relative_to(repo_root)
+            except ValueError:
+                continue
+            if is_excluded_path(rel):
+                continue
+            rels.append(rel.as_posix())
+        return sorted(rels)
+    # Non-git tree: walk the filesystem, applying the same excludes + symlink guard.
+    for abs_path in repo_root.rglob("*"):
+        if not abs_path.is_file():
+            continue
+        try:
+            rel = abs_path.relative_to(repo_root)
+        except ValueError:
+            continue
+        if is_excluded_path(rel):
+            continue
+        if not is_repo_file(abs_path, repo_root, None):
+            continue
+        rels.append(rel.as_posix())
+    return sorted(rels)
+
+
+def _discover_arch_docs(repo_root: Path) -> list[Path]:
+    """Markdown docs that declare module boundaries, in deterministic order.
+
+    Admits the conventional architecture filenames (``ARCHITECTURE.md`` /
+    ``DESIGN.md``) wherever they sit, plus any ``README.md`` whose prose carries
+    the ownership/seam vocabulary (a generic README is skipped). Mirrors the doc
+    graph's exclude resolution and symlink guard so vendored or build-artifact
+    docs never count.
+    """
+    repo_root = repo_root.resolve()
+    tracked = tracked_files(repo_root)
+    found: list[Path] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() != ".md":
+            continue
+        try:
+            rel = path.relative_to(repo_root)
+        except ValueError:
+            continue
+        if is_excluded_path(rel):
+            continue
+        if not is_repo_file(path, repo_root, tracked):
+            continue
+        name = path.name.lower()
+        if name in ARCHITECTURE_BASENAMES:
+            found.append(path)
+        elif name in README_BASENAMES and _readme_declares_boundaries(path):
+            found.append(path)
+    return sorted(found)
+
+
+def _readme_declares_boundaries(path: Path) -> bool:
+    """True if a README's prose carries the module-ownership/seam vocabulary."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return _declares_boundaries(text)
+
+
+def _declares_boundaries(text: str) -> bool:
+    """True if ``text`` reads as a module-ownership / seam declaration."""
+    return bool(_BOUNDARY_VOCAB_RE.search(text))
+
+
+def _extract_path_refs(segment: str) -> set[str]:
+    """All path references in a prose segment: inline code, wikilinks, bare paths.
+
+    Reads code spans rather than stripping them (the opposite of the doc graph),
+    because a path written as code is exactly the boundary declaration we want.
+    Returns raw, repo-relative-looking path strings; resolution to real files is
+    the caller's job.
+    """
+    refs: set[str] = set()
+    for m in _INLINE_CODE_RE.finditer(segment):
+        token = _strip_anchor(m.group(1))
+        if "/" in token or token.endswith(".md") or token.endswith(".py"):
+            refs.add(token.rstrip("/.,;:)"))
+    for m in _WIKILINK_RE.finditer(segment):
+        token = _strip_anchor(m.group(1))
+        if token:
+            refs.add(token.rstrip("/.,;:)"))
+    # Bare paths in plain prose, but not inside the code spans we already read
+    # (those are caught above with cleaner boundaries).
+    defenced = _INLINE_CODE_RE.sub(" ", segment)
+    for m in _BARE_PATH_RE.finditer(defenced):
+        token = _strip_anchor(m.group(1))
+        refs.add(token.rstrip("/.,;:)"))
+    return {r for r in refs if r}
+
+
+def _resolve_ref(
+    ref: str, repo_root: Path, rel_paths: set[str],
+) -> set[Path]:
+    """Resolve a declared path reference to the tracked files it names.
+
+    A reference can be an exact file (``lib/doc_graph.py``), a directory whose
+    every file is claimed (``skills/assess/scripts``), or a bare note name
+    (``doc_graph.py``) matched by basename. Returns the set of repo-relative
+    file paths it resolves to; empty when it matches nothing tracked.
+    """
+    norm = ref.lstrip("/").rstrip("/")
+    if not norm:
+        return set()
+    # Exact tracked file.
+    if norm in rel_paths:
+        return {Path(norm)}
+    # Directory prefix: claim every tracked file beneath it.
+    prefix = norm + "/"
+    under = {Path(rp) for rp in rel_paths if rp.startswith(prefix)}
+    if under:
+        return under
+    # Bare basename: match any tracked file with this name.
+    if "/" not in norm:
+        by_name = {Path(rp) for rp in rel_paths if Path(rp).name == norm}
+        if by_name:
+            return by_name
+    return set()
+
+
+def parse_architecture_md(repo_root: Path) -> dict[str, set[Path]]:
+    """Parse boundary-declaring docs into ``{declared_module: {file_paths}}``.
+
+    Walks each architecture doc (``ARCHITECTURE.md`` / ``DESIGN.md`` / a
+    boundary-declaring ``README.md``), splits it into sections by markdown
+    header, and attributes every path reference in a section's body to the
+    module the header names. Path references are read from inline code,
+    wikilinks, and bare prose paths, then resolved against the tracked file set;
+    references that resolve to nothing are dropped (a declared module keeps only
+    its real files).
+
+    The declared-module key is namespaced by the doc that declares it
+    (``<rel-doc>::<header>``) so two docs declaring a "Module reference" section
+    don't collide. Degrades to an empty dict when no boundary doc exists. A doc
+    that fails to read is skipped with a warning; the rest still parse.
+    """
+    repo_root = repo_root.resolve()
+    docs = _discover_arch_docs(repo_root)
+    if not docs:
+        return {}
+
+    tracked = tracked_files(repo_root)
+    rel_paths = set(_tracked_rel_paths(repo_root, tracked))
+
+    out: dict[str, set[Path]] = {}
+    for doc in docs:
+        try:
+            text = doc.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            _warn(f"could not read {doc}: {exc}")
+            continue
+        doc_rel = doc.relative_to(repo_root).as_posix()
+        _parse_one_arch_doc(text, doc_rel, repo_root, rel_paths, out)
+    return out
+
+
+def _parse_one_arch_doc(
+    text: str,
+    doc_rel: str,
+    repo_root: Path,
+    rel_paths: set[str],
+    out: dict[str, set[Path]],
+) -> None:
+    """Attribute one doc's path references to the modules its headers name.
+
+    Mutates ``out`` in place, keying each declared module ``<doc_rel>::<header>``
+    and unioning the files its section's references resolve to. References before
+    the first header are attributed to the doc itself (``<doc_rel>::<doc>``).
+    """
+    # Strip fenced code blocks: a fence is a sample/listing, and the bare-path
+    # regex over its contents would manufacture spurious module->file edges.
+    body = _FENCE_RE.sub("\n", text)
+    current = f"{doc_rel}::{Path(doc_rel).name}"
+    buffer: list[str] = []
+
+    def flush(section_key: str, lines: list[str]) -> None:
+        if not lines:
+            return
+        segment = "\n".join(lines)
+        files: set[Path] = set()
+        for ref in _extract_path_refs(segment):
+            files |= _resolve_ref(ref, repo_root, rel_paths)
+        if files:
+            out.setdefault(section_key, set()).update(files)
+
+    for line in body.splitlines():
+        m = _HEADER_RE.match(line)
+        if m:
+            flush(current, buffer)
+            buffer = []
+            header_text = m.group(2).strip()
+            current = f"{doc_rel}::{header_text}"
+        else:
+            buffer.append(line)
+    flush(current, buffer)
+
+
+def is_glob(pattern: str) -> bool:
+    """True if a CODEOWNERS pattern is a wildcard rather than a literal path."""
+    return any(c in _GLOB_CHARS for c in pattern) or pattern.endswith("/")
+
+
+def find_empty_globs(ownership_map: dict[str, set[Path]]) -> list[dict]:
+    """CODEOWNERS patterns that match zero tracked files.
+
+    An empty glob is the cheapest structure-drift signal: a declared boundary
+    the filesystem has already left behind (a renamed directory, a deleted
+    module, a typo'd pattern). Returns ``[{pattern, declared_in}]`` sorted by
+    pattern for deterministic output. ``declared_in`` is the fixed source
+    ``"CODEOWNERS"`` - the only producer of these glob keys.
+    """
+    empties = [
+        {"pattern": pattern, "declared_in": "CODEOWNERS"}
+        for pattern, files in ownership_map.items()
+        if not files
+    ]
+    return sorted(empties, key=lambda e: e["pattern"])
+
+
+def parse_ownership(repo_root: Path) -> dict:
+    """Combined ownership parse with the module-shape degradation contract.
+
+    Runs both parsers and the empty-glob detector and returns a JSON-serialisable
+    summary mirroring ``doc_graph.py``'s ``available``/``reason`` shape: when no
+    ownership map of either kind is found, ``available`` is False with reason
+    ``"no ownership map"``. Every collection is sorted at the boundary (sets ->
+    sorted lists) so the same repo yields byte-identical output.
+    """
+    repo_root = repo_root.resolve()
+    codeowners = parse_codeowners(repo_root)
+    architecture = parse_architecture_md(repo_root)
+
+    if not codeowners and not architecture:
+        return {
+            "available": False,
+            "reason": "no ownership map",
+            "codeowners_globs": [],
+            "architecture_modules": [],
+            "empty_globs": [],
+        }
+
+    empty = find_empty_globs(codeowners)
+    return {
+        "available": True,
+        "reason": "",
+        "codeowners_globs": [
+            {"pattern": pattern, "matched_files": sorted(str(p) for p in files)}
+            for pattern, files in sorted(codeowners.items())
+        ],
+        "architecture_modules": [
+            {"module": module, "files": sorted(str(p) for p in files)}
+            for module, files in sorted(architecture.items())
+        ],
+        "empty_globs": empty,
+    }

--- a/skills/assess/tests/test_ownership_parser.py
+++ b/skills/assess/tests/test_ownership_parser.py
@@ -1,0 +1,385 @@
+"""Contract suite for the ownership-map parser.
+
+The parser turns the two declaration formats - GitHub ``CODEOWNERS`` (glob ->
+owner) and a boundary-declaring markdown doc (``ARCHITECTURE.md`` / a seam-map
+``README.md``) - into ``{declared_boundary: {matched_file_paths}}`` maps, and
+flags the globs that already match zero files. These tests pin that behaviour
+plus the two contracts the structure-drift signals depend on: deterministic,
+byte-identical output run to run, and honest degradation (missing / malformed
+input never crashes the assessment).
+
+Fixtures build small repos in ``tmp_path``. CODEOWNERS resolution is against the
+*tracked* file set, so a fixture that asserts on matched files commits them; a
+fixture that only exercises parsing of patterns need not. Ambient git config is
+neutralised process-wide by the package ``conftest.py``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from lib.ownership_parser import (
+    find_empty_globs,
+    is_glob,
+    parse_architecture_md,
+    parse_codeowners,
+    parse_ownership,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args],
+                   check=True, capture_output=True, text=True,
+                   env={**os.environ})
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dev@example.com")
+    _git(repo, "config", "user.name", "Dev")
+    return repo
+
+
+def _write(repo: Path, rel: str, text: str = "x\n") -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _commit_all(repo: Path, message: str = "c") -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+def _matched_strs(files: set[Path]) -> set[str]:
+    return {p.as_posix() for p in files}
+
+
+# --- 1. CODEOWNERS parsing ---------------------------------------------------
+
+def test_codeowners_multi_owner_comments_and_globs(tmp_path: Path) -> None:
+    """A CODEOWNERS with multi-owner lines, comments, and globs parses cleanly.
+
+    The parser keeps the glob pattern (the declared boundary), drops comment and
+    blank lines, and ignores the owner tokens. Patterns are resolved against the
+    tracked file set: ``*.js`` claims the two committed JS files, ``docs/`` claims
+    everything under ``docs``, and ``src/**/*.py`` claims the nested python file.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.js")
+    _write(repo, "b.js")
+    _write(repo, "src/pkg/mod.py")
+    _write(repo, "docs/guide.md")
+    _write(repo, "docs/api/ref.md")
+    _write(repo, "README.md")
+    _write(repo, "CODEOWNERS", "\n".join([
+        "# top comment",
+        "",
+        "*.js   @frontend @web-team",
+        "docs/  @docs-team",
+        "src/**/*.py  @backend",
+        "  # indented comment",
+    ]) + "\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+
+    assert set(owners) == {"*.js", "docs/", "src/**/*.py"}
+    assert _matched_strs(owners["*.js"]) == {"a.js", "b.js"}
+    assert _matched_strs(owners["docs/"]) == {"docs/guide.md", "docs/api/ref.md"}
+    assert _matched_strs(owners["src/**/*.py"]) == {"src/pkg/mod.py"}
+
+
+def test_codeowners_anchored_and_bare_pattern_depth(tmp_path: Path) -> None:
+    """A leading ``/`` anchors to root; a bare name matches at any depth.
+
+    ``/config.yml`` matches only the root file, not the nested one. A bare
+    ``Makefile`` (no slash, unanchored) matches at any depth - GitHub semantics.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "config.yml")
+    _write(repo, "sub/config.yml")
+    _write(repo, "Makefile")
+    _write(repo, "tools/Makefile")
+    _write(repo, "CODEOWNERS", "/config.yml @a\nMakefile @b\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+    assert _matched_strs(owners["/config.yml"]) == {"config.yml"}
+    assert _matched_strs(owners["Makefile"]) == {"Makefile", "tools/Makefile"}
+
+
+def test_codeowners_duplicate_pattern_is_unioned(tmp_path: Path) -> None:
+    """The same pattern on two lines unions its match set rather than overwriting."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "x.py")
+    _write(repo, "CODEOWNERS", "*.py @a\n*.py @b\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+    assert set(owners) == {"*.py"}
+    assert _matched_strs(owners["*.py"]) == {"x.py"}
+
+
+def test_codeowners_respects_gitignore(tmp_path: Path) -> None:
+    """An ignored file never counts toward a glob's match set.
+
+    ``tracked_files`` is the file universe, so a ``*.py`` glob over a repo with a
+    gitignored ``secret.py`` claims only the tracked python file.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, ".gitignore", "secret.py\n")
+    _write(repo, "kept.py")
+    _write(repo, "secret.py")  # ignored, never tracked
+    _write(repo, "CODEOWNERS", "*.py @a\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+    assert _matched_strs(owners["*.py"]) == {"kept.py"}
+
+
+def test_codeowners_in_github_dir_is_found(tmp_path: Path) -> None:
+    """``.github/CODEOWNERS`` is honoured - GitHub's standard location."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _write(repo, ".github/CODEOWNERS", "*.py @a\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+    assert _matched_strs(owners["*.py"]) == {"a.py"}
+
+
+# --- 2. ARCHITECTURE.md parsing ----------------------------------------------
+
+def test_architecture_md_module_extraction(tmp_path: Path) -> None:
+    """Section headers name modules; their path references resolve to files.
+
+    Two ``##`` sections each declare a module owning a directory and naming files
+    in inline code. The parser attributes each section's references to that
+    section's header (keyed ``<doc>::<header>``) and resolves directory and bare
+    references to the tracked files.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/api/server.py")
+    _write(repo, "src/api/routes.py")
+    _write(repo, "src/db/models.py")
+    _write(repo, "ARCHITECTURE.md", "\n".join([
+        "# System",
+        "",
+        "## API layer",
+        "The API module owns `src/api/` and exposes the HTTP surface.",
+        "",
+        "## Data layer",
+        "The data module owns `src/db/models.py`.",
+    ]) + "\n")
+    _commit_all(repo)
+
+    modules = parse_architecture_md(repo)
+    api = modules["ARCHITECTURE.md::API layer"]
+    data = modules["ARCHITECTURE.md::Data layer"]
+    assert _matched_strs(api) == {"src/api/server.py", "src/api/routes.py"}
+    assert _matched_strs(data) == {"src/db/models.py"}
+
+
+def test_architecture_md_ignores_fenced_code_paths(tmp_path: Path) -> None:
+    """Paths inside a fenced code block are samples, not boundary declarations.
+
+    A fenced listing of a path the module does *not* own must not be attributed
+    to it - only the inline-code reference in prose counts.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/real.py")
+    _write(repo, "examples/sample.py")
+    _write(repo, "DESIGN.md", "\n".join([
+        "## Core",
+        "The core module owns `src/real.py`.",
+        "",
+        "```",
+        "examples/sample.py  # illustrative only",
+        "```",
+    ]) + "\n")
+    _commit_all(repo)
+
+    modules = parse_architecture_md(repo)
+    core = modules["DESIGN.md::Core"]
+    assert _matched_strs(core) == {"src/real.py"}
+    assert all("sample.py" not in str(p) for files in modules.values() for p in files)
+
+
+def test_architecture_readme_only_when_it_declares_boundaries(tmp_path: Path) -> None:
+    """A generic README is skipped; a seam-declaring README is parsed.
+
+    A README without ownership/seam vocabulary contributes no module. A README
+    whose prose declares module ownership does, so a repo carrying its boundary
+    map in a README (rather than ARCHITECTURE.md) is still read.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "lib/core.py")
+    _write(repo, "plain/README.md", "Just a project. Run `make`.\n")
+    _write(repo, "lib/README.md", "\n".join([
+        "## Module reference",
+        "The core module owns `lib/core.py` - this seam is owned by design.",
+    ]) + "\n")
+    _commit_all(repo)
+
+    modules = parse_architecture_md(repo)
+    keys = set(modules)
+    assert any(k.startswith("lib/README.md::") for k in keys)
+    assert not any(k.startswith("plain/README.md::") for k in keys)
+
+
+def test_architecture_wikilink_references_resolve(tmp_path: Path) -> None:
+    """A ``[[wikilink]]`` path reference resolves to its tracked file."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "docs/payments.md")
+    _write(repo, "ARCHITECTURE.md", "\n".join([
+        "## Payments",
+        "The payments module owns [[docs/payments.md]].",
+    ]) + "\n")
+    _commit_all(repo)
+
+    modules = parse_architecture_md(repo)
+    assert _matched_strs(modules["ARCHITECTURE.md::Payments"]) == {"docs/payments.md"}
+
+
+# --- 3. Empty-glob detection -------------------------------------------------
+
+def test_find_empty_globs_flags_zero_match_patterns(tmp_path: Path) -> None:
+    """A glob matching no tracked file is reported; a matching one is not.
+
+    ``*.py`` matches the committed file; ``legacy/**`` matches nothing (the
+    directory is gone). Only the latter surfaces, with its declared source.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _write(repo, "CODEOWNERS", "*.py @a\nlegacy/** @b\n")
+    _commit_all(repo)
+
+    owners = parse_codeowners(repo)
+    empties = find_empty_globs(owners)
+    assert empties == [{"pattern": "legacy/**", "declared_in": "CODEOWNERS"}]
+
+
+def test_find_empty_globs_is_sorted(tmp_path: Path) -> None:
+    """Empty globs are returned sorted by pattern for deterministic output."""
+    owners = {
+        "z/**": set(),
+        "a/**": set(),
+        "m.py": {Path("m.py")},  # matches - excluded
+        "k/**": set(),
+    }
+    empties = find_empty_globs(owners)
+    assert [e["pattern"] for e in empties] == ["a/**", "k/**", "z/**"]
+
+
+def test_is_glob_classification() -> None:
+    """Wildcard and directory patterns are globs; a literal file path is not."""
+    assert is_glob("*.py")
+    assert is_glob("src/**/*.ts")
+    assert is_glob("docs/")  # trailing slash = directory
+    assert is_glob("a[bc].py")
+    assert not is_glob("README.md")
+    assert not is_glob("src/main.py")
+
+
+# --- 4. Graceful degradation -------------------------------------------------
+
+def test_no_ownership_map_degrades(tmp_path: Path) -> None:
+    """A repo with no CODEOWNERS and no boundary doc reports no ownership map."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _commit_all(repo)
+
+    assert parse_codeowners(repo) == {}
+    assert parse_architecture_md(repo) == {}
+
+    summary = parse_ownership(repo)
+    assert summary["available"] is False
+    assert summary["reason"] == "no ownership map"
+    assert summary["codeowners_globs"] == []
+    assert summary["architecture_modules"] == []
+    assert summary["empty_globs"] == []
+
+
+def test_malformed_codeowners_line_is_skipped(tmp_path: Path) -> None:
+    """A blank-ish / comment-only file parses to an empty map, never raises.
+
+    Comment and blank lines carry no pattern; a file of only those yields an
+    empty (but available-elsewhere) parse rather than crashing.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _write(repo, "CODEOWNERS", "# only comments\n\n   \n")
+    _commit_all(repo)
+
+    assert parse_codeowners(repo) == {}
+
+
+def test_non_git_directory_resolves_via_filesystem(tmp_path: Path) -> None:
+    """Outside git, the glob resolver falls back to a filesystem walk.
+
+    No git history means ``tracked_files`` is None; the parser walks the tree
+    (with the same excludes + symlink guard) so a CODEOWNERS still resolves.
+    """
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "a.py").write_text("x\n", encoding="utf-8")
+    (plain / "CODEOWNERS").write_text("*.py @a\n", encoding="utf-8")
+
+    owners = parse_codeowners(plain)
+    assert _matched_strs(owners["*.py"]) == {"a.py"}
+
+
+# --- 5. Determinism ----------------------------------------------------------
+
+def test_parse_ownership_is_byte_identical_across_runs(tmp_path: Path) -> None:
+    """Two parses of one repo serialize to identical output.
+
+    Sets are sorted at the boundary, so no iteration order leaks. Serialising the
+    full summary twice and asserting equality pins the determinism contract the
+    structure-drift signals rely on.
+    """
+    import json
+
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "src/b.py")
+    _write(repo, "docs/x.md")
+    _write(repo, "CODEOWNERS", "src/** @a\ndocs/ @b\nghost/** @c\n")
+    _write(repo, "ARCHITECTURE.md", "## Core\nowns `src/`\n")
+    _commit_all(repo)
+
+    first = json.dumps(parse_ownership(repo), sort_keys=True)
+    second = json.dumps(parse_ownership(repo), sort_keys=True)
+    assert first == second
+
+    summary = parse_ownership(repo)
+    assert summary["available"] is True
+    assert {e["pattern"] for e in summary["empty_globs"]} == {"ghost/**"}
+
+
+# --- 6. Integration: this repo's own seam map --------------------------------
+
+def test_integration_parses_lib_readme_seam_declaration() -> None:
+    """Parsing this repo finds the lib README's co-change seam declaration.
+
+    ``skills/assess/scripts/lib/README.md`` declares the module-ownership seam
+    map (the ``assess_core.py -> lib`` seam and the wider co-change seams). Its
+    boundary-declaring prose admits it as an architecture doc, and its seam
+    section names ``doc_graph.py`` as a load-bearing module, which resolves to
+    the real tracked file. This is the dogfood guard that the parser reads a
+    genuine, human-written ownership declaration on real data.
+    """
+    repo_root = Path(__file__).resolve().parents[3]  # repo top
+    modules = parse_architecture_md(repo_root)
+
+    lib_readme = "skills/assess/scripts/lib/README.md"
+    lib_sections = {k: v for k, v in modules.items() if k.startswith(lib_readme + "::")}
+    assert lib_sections, "lib README should be parsed as a boundary declaration"
+
+    # The seam map names doc_graph.py; it resolves to the real module file.
+    resolved = {p.as_posix() for files in lib_sections.values() for p in files}
+    assert "skills/assess/scripts/lib/doc_graph.py" in resolved


### PR DESCRIPTION
## Summary

Adds the parse half of Layer 0 structure-drift detection: a deterministic parser that turns the two declared ownership-map formats into `{declared_boundary: {matched_file_paths}}` maps, plus empty-glob detection. The drift signals that consume it (tasks 9/10) and the orchestrator wiring (task 11) are deliberately out of scope here.

## Changes Made

- `skills/assess/scripts/lib/ownership_parser.py`
  - **CODEOWNERS parsing** (GitHub format): `pattern @owner...` lines; multi-owner, comment (`#`), and blank-line handling; globs (`*.js`, `docs/`, `src/**/*.py`) resolved against the git-tracked file set so `.gitignore`'d files never count. Honours GitHub location precedence (root, `.github/`, `docs/`) and glob semantics (leading-`/` anchor, bare-name any-depth, trailing-`/` directory).
  - **ARCHITECTURE.md parsing** (freeform markdown): walks `ARCHITECTURE.md` / `DESIGN.md` and any boundary-declaring `README.md` (admitted only when its prose carries ownership/seam vocabulary). Splits by section header, attributes each section's path references (inline code, `[[wikilinks]]`, bare prose paths) to the module the header names, and resolves them to real files. Fenced code blocks are skipped so listings don't manufacture spurious edges.
  - **Empty-glob detection**: `find_empty_globs` flags CODEOWNERS patterns matching zero tracked files, sorted by pattern.
  - **Graceful degradation**: no map of either kind -> `available: False, reason: "no ownership map"`; unreadable files skipped with a warning; non-git tree falls back to a filesystem walk.
- `skills/assess/tests/test_ownership_parser.py` - 17 tests: CODEOWNERS (multi-owner/comments/globs, anchoring/depth, duplicate union, gitignore, `.github/` location), ARCHITECTURE module extraction (sections, fenced-code exclusion, README admission, wikilinks), empty-glob detection, graceful degradation (missing/malformed/non-git), byte-identical determinism, and an integration test parsing this repo's own `skills/assess/scripts/lib/README.md` seam map.
- `.claude-plugin/plugin.json` - version 1.44.0 -> 1.44.1.

## Technical Details

Mirrors `doc_graph.py` for module shape: shared exclude resolution via `is_excluded_path` (so `EXCLUDE_DIRS` and `tests/fixtures` are honoured identically), `tracked_files` for the file universe, `is_repo_file` symlink guard on the non-git fallback. Determinism is a contract - sets are sorted to lists at the boundary, so no iteration order leaks and the same repo yields byte-identical output.

## Testing

- `skills/assess` pytest: 707 passed, 2 skipped (includes `test_self_architecture.py` - the new module imports only `lib/` modules, no orchestrator).
- `scripts/` pytest: 106 passed. `plugin contract` pytest: 183 passed.
- `ruff check .` (skills/assess) and `mypy` (deterministic core) both clean.

## Risk Assessment

Additive: a new `lib/` module and its test, plus a patch version bump. No existing module imports it yet, so behaviour of the current assessment is unchanged.