### PR TITLE
feat: Add Tier 0 path-existence structure drift signal

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -143,6 +143,50 @@ signal regardless of doc state. When a doc carries a `doc_provenance` verdict, f
 comes from the source-vs-doc comparison (a direct, high-confidence signal that bypasses
 the churn-ratio confidence guards) instead of the ratio.
 
+### Ownership and structure drift
+
+**`ownership_parser.py`**
+Parse half for Layer 0 structure-drift. Ownership is *declared* in two places an LLM
+contributor reads as authoritative boundaries: a GitHub `CODEOWNERS` (glob -> owner,
+honoured at the root, `.github/`, or `docs/` by GitHub's precedence) and a
+boundary-declaring `ARCHITECTURE.md` / `DESIGN.md` - or a seam-mapping `README.md`
+admitted only when its prose carries the ownership/seam vocabulary, so a generic project
+README is skipped. `parse_codeowners` resolves each glob against the git-tracked,
+non-excluded file set into `{glob_pattern: {matched_files}}`; `parse_architecture_md`
+sections each doc by markdown header and attributes the path references in a section's
+body (read from inline code, wikilinks, and bare prose paths) to the module the header
+names, keyed `<doc>::<header>` so two docs declaring the same section don't collide, and
+keeping only references that resolve to real files. `find_empty_globs` flags the CODEOWNERS
+patterns that match zero tracked files - the cheapest drift, a boundary the filesystem has
+left behind - and `parse_ownership` runs both with the module-shape degradation contract
+(`available: False`, reason `"no ownership map"` when neither map exists). It mirrors
+`doc_graph.py` deliberately: the same `EXCLUDE_DIRS` / `is_excluded_path` resolution and
+`tracked_files` filtering, the same honest-degrade-over-crash shape, every collection
+sorted at the boundary for byte-identical output. The one inversion is that it *reads*
+inline-code path spans (a path written as code is the boundary declaration we want) where
+the doc graph strips them. This is the parsing foundation the structure-drift signals
+consume; it owns no drift logic itself.
+
+**`structure_drift.py`**
+The Layer 0 structure-drift signal, built entirely on `ownership_parser`'s parse + resolve
+primitives (it re-implements no parsing). A declaration is a self-description under no
+pressure to stay true: a directory is renamed, a module's files scatter, a pattern is
+typo'd - and the map becomes a *lying map of ownership*, the same defect as a stale doc
+(behaviour) or an aged TODO (intent). **Tier 0** - `detect_path_existence_drift()` - is the
+zero-threshold cut: the enumerate-both-sides shape `doc_graph.py` uses for broken links,
+where side A is every declared boundary (CODEOWNERS globs + architecture-doc path
+references) and side B the tracked, non-excluded file set, and the finding is the
+declarations whose match set is empty. Binary, no statistics; a pattern matching only
+excluded files counts as empty (the excludes are not part of the navigable repo). It emits
+a JSON-serialisable `structure_drift` run-context block (`empty_ownership_patterns`, a
+coverage ratio, and legacy-shape `empty_globs` mirrors for the orchestrator's
+enumerate-both-sides view), degrades to `available: False` reason `"no ownership map"`, and
+sorts every list by `(pattern, declared_in)`. Tier 1 (grouping declared boundaries against
+where their files have actually scattered, task 10) will **add** a second function to this
+same module rather than a new one - hence the `tier_0_available` field and the room the
+block schema leaves for a `tier_1` sibling. Co-changes with `ownership_parser.py` (its
+parse foundation) and its test `tests/test_structure_drift.py`.
+
 ### Signal integration
 
 **`keyhole_signals.py`** *(co-change hotspot)*

--- a/skills/assess/scripts/lib/structure_drift.py
+++ b/skills/assess/scripts/lib/structure_drift.py
@@ -1,0 +1,285 @@
+"""Structure-drift signals: declared ownership vs where the code actually lives.
+
+Ownership is *declared* in two maps an LLM contributor reads as authoritative
+boundaries - a GitHub ``CODEOWNERS`` (glob -> owner) and a boundary-declaring
+``ARCHITECTURE.md`` / seam ``README.md`` (prose -> "module X owns these paths").
+A declaration is a self-description under no pressure to stay true: a directory
+gets renamed, a module's files scatter, a pattern is typo'd - and nothing forces
+the map to follow. The map is then a *lying map of ownership*, the same defect as
+a stale doc (a lying map of behaviour) or an aged TODO (a lying map of intent).
+This module converts that drift into a deterministic signal so the honest action
+(fix the map, or the layout) becomes the cheap one.
+
+**Tier 0** (this module, task 9) is the cheapest, zero-threshold cut: a declared
+pattern or path that matches *zero* tracked files on disk. It is the
+enumerate-both-sides shape ``doc_graph.py`` uses for broken links - side A is the
+declared boundaries (every CODEOWNERS glob + every ARCHITECTURE.md path
+reference), side B is the tracked file set, and the finding is the declared
+patterns whose match set is empty. Binary, no statistics: a pattern matches or it
+does not. A pattern that matches only excluded files counts as empty (the
+excludes are not part of the navigable repo a contributor reasons over).
+
+The parse half is entirely ``ownership_parser`` (task 8): the same CODEOWNERS
+glob resolution, the same architecture-doc discovery and path-reference
+resolution, the same ``EXCLUDE_DIRS`` / tracked-file conventions. This module only
+joins the two sides and reports the empty set - it re-implements no parsing.
+
+Determinism is a contract: the same repo must produce byte-identical output, so
+``empty_ownership_patterns`` (and every list) is sorted by a stable key and no
+set/dict iteration order leaks out. The module degrades to ``available: False``
+with a reason when no ownership map of either kind exists - it never crashes the
+assessment.
+
+Tier 1 (grouping declared boundaries against where their files have scattered,
+task 10) is deliberately *not* here yet; it will ADD a second function to this
+same module, so the Tier 0 surface is kept small and the run-context block schema
+leaves room for a ``tier_1`` sibling alongside ``tier_0_available``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.ownership_parser import (
+    _discover_arch_docs,
+    _extract_path_refs,
+    _FENCE_RE,
+    _HEADER_RE,
+    _resolve_ref,
+    _tracked_rel_paths,
+    find_empty_globs,
+    parse_codeowners,
+)
+from lib.git_churn import tracked_files
+
+
+def _empty_codeowners_patterns(repo_root: Path) -> list[dict]:
+    """CODEOWNERS globs that match zero tracked, non-excluded files.
+
+    Pure reuse of task 8: ``parse_codeowners`` resolves each glob against the
+    tracked file set (a pattern matching only excluded files resolves to an empty
+    set there too), and ``find_empty_globs`` flags the empties. Returns
+    ``[{pattern, declared_in, owners}]`` - ``owners`` is empty (CODEOWNERS owner
+    tokens are not retained by the parser) and present only so the architecture
+    and CODEOWNERS rows share one shape.
+    """
+    codeowners = parse_codeowners(repo_root)
+    return [
+        {"pattern": e["pattern"], "declared_in": e["declared_in"], "owners": []}
+        for e in find_empty_globs(codeowners)
+    ]
+
+
+def _empty_architecture_refs(repo_root: Path) -> list[dict]:
+    """Architecture-doc path references that resolve to zero tracked files.
+
+    ``parse_architecture_md`` (task 8) drops references that resolve to nothing -
+    it keeps a declared module's *real* files only - so the stale reference we
+    want to flag is exactly the one it discards. Rather than re-implement that
+    parse, we re-walk the same architecture docs (``_discover_arch_docs``) with
+    the same building blocks (``_FENCE_RE`` strip, ``_HEADER_RE`` sectioning,
+    ``_extract_path_refs``, ``_resolve_ref``) and keep the references whose
+    resolution is empty - a declared boundary the filesystem has left behind (a
+    renamed or deleted directory, a typo'd path).
+
+    The reference text is the ``pattern``; ``declared_in`` is the ``<doc>::<header>``
+    boundary that named it, so two docs declaring the same stale path don't merge.
+    ``owners`` is empty (architecture docs carry no owner tokens). Returns one row
+    per (boundary, reference); a reference repeated within a section is reported
+    once.
+    """
+    docs = _discover_arch_docs(repo_root)
+    if not docs:
+        return []
+
+    tracked = tracked_files(repo_root)
+    rel_paths = set(_tracked_rel_paths(repo_root, tracked))
+
+    out: list[dict] = []
+    for doc in docs:
+        try:
+            text = doc.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            # Best-effort: an unreadable doc is skipped, never aborts the scan
+            # (the same honest-degrade the parser applies).
+            continue
+        doc_rel = doc.relative_to(repo_root).as_posix()
+        out.extend(_empty_refs_in_doc(text, doc_rel, repo_root, rel_paths))
+    return out
+
+
+def _empty_refs_in_doc(
+    text: str, doc_rel: str, repo_root: Path, rel_paths: set[str],
+) -> list[dict]:
+    """Path references in one architecture doc that resolve to no tracked file.
+
+    Mirrors ``ownership_parser._parse_one_arch_doc``: strip fenced code (a fence
+    is a sample listing, not a boundary), section the body by markdown header, and
+    attribute each reference to its section's ``<doc_rel>::<header>`` boundary.
+    References before the first header belong to the doc itself
+    (``<doc_rel>::<doc>``). A reference is flagged only when ``_resolve_ref``
+    returns an empty set against the tracked file universe.
+    """
+    body = _FENCE_RE.sub("\n", text)
+    current = f"{doc_rel}::{Path(doc_rel).name}"
+    buffer: list[str] = []
+    rows: list[dict] = []
+
+    def flush(boundary: str, lines: list[str]) -> None:
+        if not lines:
+            return
+        segment = "\n".join(lines)
+        # Sort the references so a section's empty rows emit in a stable order
+        # regardless of set iteration; the caller sorts the whole list again.
+        for ref in sorted(_extract_path_refs(segment)):
+            if not _resolve_ref(ref, repo_root, rel_paths):
+                rows.append({
+                    "pattern": ref, "declared_in": boundary, "owners": [],
+                })
+
+    for line in body.splitlines():
+        m = _HEADER_RE.match(line)
+        if m:
+            flush(current, buffer)
+            buffer = []
+            current = f"{doc_rel}::{m.group(2).strip()}"
+        else:
+            buffer.append(line)
+    flush(current, buffer)
+    return rows
+
+
+def _count_declared_and_matched(repo_root: Path) -> tuple[int, int]:
+    """Total declared patterns/paths and how many match at least one tracked file.
+
+    Counts both sides' declarations: every CODEOWNERS glob, and every distinct
+    architecture-doc path reference (per declaring boundary). ``matched`` is the
+    declarations whose resolution is non-empty. Reuses the same parse/resolve path
+    as the empty-set detectors so the two never disagree on what "declared" means.
+    """
+    codeowners = parse_codeowners(repo_root)
+    declared = len(codeowners)
+    matched = sum(1 for files in codeowners.values() if files)
+
+    docs = _discover_arch_docs(repo_root)
+    if docs:
+        tracked = tracked_files(repo_root)
+        rel_paths = set(_tracked_rel_paths(repo_root, tracked))
+        for doc in docs:
+            try:
+                text = doc.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            d, m = _declared_refs_in_doc(text, repo_root, rel_paths)
+            declared += d
+            matched += m
+    return declared, matched
+
+
+def _declared_refs_in_doc(
+    text: str, repo_root: Path, rel_paths: set[str],
+) -> tuple[int, int]:
+    """(declared, matched) path-reference counts for one architecture doc.
+
+    Same sectioning as ``_empty_refs_in_doc`` - one declaration per (boundary,
+    distinct reference) - but counts resolution outcomes instead of collecting the
+    empties, so totals and the empty list are derived from the identical walk. The
+    boundary name is irrelevant to a count, so sectioning here only flushes the
+    buffer at each header rather than tracking the current boundary key.
+    """
+    body = _FENCE_RE.sub("\n", text)
+    buffer: list[str] = []
+    declared = 0
+    matched = 0
+
+    def flush(lines: list[str]) -> None:
+        nonlocal declared, matched
+        if not lines:
+            return
+        segment = "\n".join(lines)
+        for ref in _extract_path_refs(segment):
+            declared += 1
+            if _resolve_ref(ref, repo_root, rel_paths):
+                matched += 1
+
+    for line in body.splitlines():
+        if _HEADER_RE.match(line):
+            flush(buffer)
+            buffer = []
+        else:
+            buffer.append(line)
+    flush(buffer)
+    return declared, matched
+
+
+def detect_path_existence_drift(
+    repo_root: Path, extra_exclude_dirs: set[str] | None = None,
+) -> dict:
+    """Tier 0 structure drift: declared ownership patterns that match zero files.
+
+    The cheapest, zero-threshold drift cut. Enumerates both sides - side A every
+    declared boundary (CODEOWNERS globs + ARCHITECTURE.md path references), side B
+    the tracked, non-excluded file set - and reports the declarations whose match
+    set is empty. Binary, no statistics; a pattern matching only excluded files
+    counts as empty.
+
+    Returns a JSON-serialisable run-context ``structure_drift`` block::
+
+        {
+          available, reason,
+          tier_0_available,
+          empty_ownership_patterns: [{pattern, declared_in, owners}],
+          total_patterns, matched_patterns, coverage_ratio,
+          # legacy-shape mirrors for the orchestrator's enumerate-both-sides view:
+          empty_globs: [{pattern, file, owner}],
+          declared_paths, matched_paths,
+        }
+
+    Degrades to ``available: False`` with reason ``"no ownership map"`` when no
+    CODEOWNERS and no boundary doc exists (no map to drift against). Every list is
+    sorted by ``(pattern, declared_in)`` so the same repo yields byte-identical
+    output. ``extra_exclude_dirs`` is accepted for signature parity with the other
+    signals; the underlying parser applies the built-in ``EXCLUDE_DIRS`` already.
+    """
+    repo_root = repo_root.resolve()
+
+    codeowners = parse_codeowners(repo_root)
+    arch_docs = _discover_arch_docs(repo_root)
+    if not codeowners and not arch_docs:
+        return {
+            "available": False,
+            "reason": "no ownership map",
+            "tier_0_available": False,
+            "empty_ownership_patterns": [],
+            "total_patterns": 0,
+            "matched_patterns": 0,
+            "coverage_ratio": 0.0,
+            "empty_globs": [],
+            "declared_paths": 0,
+            "matched_paths": 0,
+        }
+
+    empties = _empty_codeowners_patterns(repo_root) + _empty_architecture_refs(repo_root)
+    empties.sort(key=lambda e: (e["pattern"], e["declared_in"]))
+
+    total, matched = _count_declared_and_matched(repo_root)
+    coverage = round(matched / total, 3) if total else 0.0
+
+    return {
+        "available": True,
+        "reason": "",
+        "tier_0_available": True,
+        "empty_ownership_patterns": empties,
+        "total_patterns": total,
+        "matched_patterns": matched,
+        "coverage_ratio": coverage,
+        # The orchestrator's enumerate-both-sides view (#59c) reads an
+        # ``empty_globs`` list and a declared/matched count pair; mirror the
+        # canonical fields into that shape so wiring stays a rename, not a reshape.
+        "empty_globs": [
+            {"pattern": e["pattern"], "file": e["declared_in"],
+             "owner": (e["owners"][0] if e["owners"] else "")}
+            for e in empties
+        ],
+        "declared_paths": total,
+        "matched_paths": matched,
+    }

--- a/skills/assess/tests/test_structure_drift.py
+++ b/skills/assess/tests/test_structure_drift.py
@@ -1,0 +1,243 @@
+"""Contract suite for the Tier 0 path-existence structure-drift signal.
+
+Tier 0 is the zero-threshold cut: a declared ownership pattern (a CODEOWNERS glob
+or an ARCHITECTURE.md path reference) that matches *zero* tracked files on disk -
+a boundary the filesystem has left behind. These tests pin the enumerate-both-
+sides behaviour, the two contracts the signal inherits from the parser
+(deterministic byte-identical output, honest degradation when no map exists), and
+the excluded-only-matches-as-empty rule.
+
+Fixtures build small repos in ``tmp_path``; resolution is against the *tracked*
+file set, so they commit their files. Ambient git config is neutralised
+process-wide by the package ``conftest.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from lib.structure_drift import detect_path_existence_drift
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args],
+                   check=True, capture_output=True, text=True,
+                   env={**os.environ})
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dev@example.com")
+    _git(repo, "config", "user.name", "Dev")
+    return repo
+
+
+def _write(repo: Path, rel: str, text: str = "x\n") -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _commit_all(repo: Path, message: str = "c") -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+def _patterns(result: dict) -> list[str]:
+    return [e["pattern"] for e in result["empty_ownership_patterns"]]
+
+
+# --- 1. CODEOWNERS empty-glob detection --------------------------------------
+
+def test_empty_codeowners_glob_is_flagged(tmp_path: Path) -> None:
+    """A CODEOWNERS glob matching no tracked file surfaces as drift.
+
+    ``*.py`` matches the committed file (no drift); ``legacy/**`` matches nothing
+    (the directory is gone) and is the sole empty pattern, attributed to
+    ``CODEOWNERS``.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _write(repo, "CODEOWNERS", "*.py @a\nlegacy/** @b\n")
+    _commit_all(repo)
+
+    result = detect_path_existence_drift(repo)
+    assert result["available"] is True
+    assert result["tier_0_available"] is True
+    assert result["empty_ownership_patterns"] == [
+        {"pattern": "legacy/**", "declared_in": "CODEOWNERS", "owners": []}
+    ]
+
+
+def test_all_valid_codeowners_yields_no_findings(tmp_path: Path) -> None:
+    """When every glob matches at least one file, there is no drift.
+
+    The map is still available; the empty list is empty and coverage is full.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "docs/guide.md")
+    _write(repo, "CODEOWNERS", "src/** @a\ndocs/ @b\n")
+    _commit_all(repo)
+
+    result = detect_path_existence_drift(repo)
+    assert result["available"] is True
+    assert result["empty_ownership_patterns"] == []
+    assert result["total_patterns"] == 2
+    assert result["matched_patterns"] == 2
+    assert result["coverage_ratio"] == 1.0
+
+
+def test_mixed_state_reports_only_the_empty_pattern(tmp_path: Path) -> None:
+    """A repo with both live and stale globs reports only the stale one.
+
+    Coverage reflects the split: two of three declared patterns match.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "docs/x.md")
+    _write(repo, "CODEOWNERS", "src/** @a\ndocs/ @b\nghost/** @c\n")
+    _commit_all(repo)
+
+    result = detect_path_existence_drift(repo)
+    assert _patterns(result) == ["ghost/**"]
+    assert result["total_patterns"] == 3
+    assert result["matched_patterns"] == 2
+    assert result["coverage_ratio"] == 0.667
+
+
+# --- 2. ARCHITECTURE.md stale-reference detection ----------------------------
+
+def test_architecture_stale_module_ref_to_deleted_dir(tmp_path: Path) -> None:
+    """A stale ARCHITECTURE.md path reference to a missing dir surfaces as drift.
+
+    The doc declares two boundaries: a live one owning ``src/api/`` (matches) and
+    a stale one owning ``src/legacy/`` (deleted, matches nothing). Only the stale
+    reference is flagged, attributed to its ``<doc>::<header>`` boundary.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/api/server.py")
+    _write(repo, "ARCHITECTURE.md", "\n".join([
+        "## API layer",
+        "The API module owns `src/api/`.",
+        "",
+        "## Legacy",
+        "The legacy module owns `src/legacy/`.",
+    ]) + "\n")
+    _commit_all(repo)
+
+    # The parser normalises a reference's trailing punctuation, so the prose
+    # ``src/legacy/`` is captured as ``src/legacy`` - that normalised form is the
+    # reported pattern.
+    result = detect_path_existence_drift(repo)
+    assert result["empty_ownership_patterns"] == [
+        {"pattern": "src/legacy", "declared_in": "ARCHITECTURE.md::Legacy",
+         "owners": []}
+    ]
+
+
+def test_codeowners_and_architecture_empties_merge_and_sort(tmp_path: Path) -> None:
+    """Empties from both sources merge into one list sorted by (pattern, source).
+
+    A stale CODEOWNERS glob and a stale architecture reference both appear,
+    ordered by pattern then declaring source - the deterministic merge key.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "CODEOWNERS", "src/** @a\nzzz/** @b\n")
+    _write(repo, "ARCHITECTURE.md", "\n".join([
+        "## Core",
+        "owns `src/`",
+        "## Ghost",
+        "owns `aaa/gone/`",
+    ]) + "\n")
+    _commit_all(repo)
+
+    # Architecture prose ``aaa/gone/`` normalises to ``aaa/gone``; the merge then
+    # sorts the two empties by (pattern, source).
+    result = detect_path_existence_drift(repo)
+    assert _patterns(result) == ["aaa/gone", "zzz/**"]
+
+
+# --- 3. Excluded-only patterns count as empty --------------------------------
+
+def test_pattern_matching_only_excluded_files_is_empty(tmp_path: Path) -> None:
+    """A glob whose only matches sit under an excluded dir reports as drift.
+
+    ``node_modules`` is a built-in exclude, so a ``node_modules/**`` glob resolves
+    to an empty set even though files exist there - the excluded tree is not part
+    of the navigable repo a contributor reasons over.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "node_modules/dep/index.js")
+    _write(repo, "CODEOWNERS", "src/** @a\nnode_modules/** @vendor\n")
+    _commit_all(repo)
+
+    result = detect_path_existence_drift(repo)
+    assert _patterns(result) == ["node_modules/**"]
+
+
+# --- 4. Graceful degradation -------------------------------------------------
+
+def test_no_ownership_map_degrades(tmp_path: Path) -> None:
+    """A repo with no CODEOWNERS and no boundary doc reports no ownership map."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _commit_all(repo)
+
+    result = detect_path_existence_drift(repo)
+    assert result["available"] is False
+    assert result["reason"] == "no ownership map"
+    assert result["tier_0_available"] is False
+    assert result["empty_ownership_patterns"] == []
+    assert result["total_patterns"] == 0
+    assert result["coverage_ratio"] == 0.0
+
+
+# --- 5. Determinism ----------------------------------------------------------
+
+def test_output_is_byte_identical_across_runs(tmp_path: Path) -> None:
+    """Two runs over one repo serialize to identical output.
+
+    Sets are sorted at the boundary, so no iteration order leaks. Serialising the
+    full block twice and asserting equality pins the determinism contract.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "src/b.py")
+    _write(repo, "CODEOWNERS", "src/** @a\nghost/** @b\nz/** @c\n")
+    _write(repo, "ARCHITECTURE.md", "## Core\nowns `src/` and `dead/`\n")
+    _commit_all(repo)
+
+    first = json.dumps(detect_path_existence_drift(repo), sort_keys=True)
+    second = json.dumps(detect_path_existence_drift(repo), sort_keys=True)
+    assert first == second
+
+
+# --- 6. Integration: this repo's own seam map --------------------------------
+
+def test_integration_lib_readme_seam_paths_are_not_false_positives() -> None:
+    """This repo's lib README seam declaration does not false-positive.
+
+    ``skills/assess/scripts/lib/README.md`` names ``doc_graph.py`` and the
+    ``skills/assess/...`` seam directories as load-bearing boundaries; they all
+    resolve to real tracked paths, so none of them appears in
+    ``empty_ownership_patterns``. This is the dogfood guard that Tier 0 reads a
+    genuine, human-written ownership map on real data without manufacturing drift.
+    """
+    repo_root = Path(__file__).resolve().parents[3]  # repo top
+    result = detect_path_existence_drift(repo_root)
+
+    assert result["available"] is True
+    seam_doc = "skills/assess/scripts/lib/README.md"
+    offenders = [
+        e for e in result["empty_ownership_patterns"]
+        if e["declared_in"].startswith(seam_doc + "::")
+        and "doc_graph.py" in e["pattern"]
+    ]
+    assert offenders == [], offenders


### PR DESCRIPTION
## Summary

Adds the Tier 0 structure-drift signal: declared ownership patterns that match zero tracked files on disk. This is the cheapest, zero-threshold cut of the structure-drift family - a declared boundary the filesystem has already left behind (a renamed/deleted directory, a typo'd pattern), which makes an ownership map a lying map. Compensates the ownership-drift facet of the *Accretion* contributor tendency named in the repo north star.

## Changes Made

- `skills/assess/scripts/lib/structure_drift.py` - new deterministic module. `detect_path_existence_drift(repo_root, extra_exclude_dirs=None)` enumerates both sides (declared CODEOWNERS globs + ARCHITECTURE.md path references vs the tracked file set) and reports the declarations whose match set is empty.
- `skills/assess/tests/test_structure_drift.py` - contract suite.
- `.claude-plugin/plugin.json` - version bump 1.44.1 -> 1.44.2.

## Technical Details

- **Enumerate-both-sides**, mirroring `doc_graph.py`'s broken-link shape. Side A = declared boundaries, Side B = tracked, non-excluded files; finding = empty-match declarations.
- **Pure reuse of the task-8 parser** (`ownership_parser`): same CODEOWNERS glob resolution (`parse_codeowners` + `find_empty_globs`), same architecture-doc discovery and path-reference resolution (`_discover_arch_docs`, `_extract_path_refs`, `_resolve_ref`), same `EXCLUDE_DIRS` / tracked-file conventions. No glob parsing re-implemented. The stale architecture reference is exactly the one `parse_architecture_md` discards (it keeps only a module's real files), so the empties are recovered by re-walking the same docs with the same building blocks.
- **Zero-threshold / binary**: a pattern matches or it does not; no statistics. A pattern matching only excluded files (e.g. `node_modules/**`) counts as empty.
- **Deterministic**: `empty_ownership_patterns` and every list sorted by a stable `(pattern, declared_in)` key; no set/dict iteration order leaks.
- **Honest degrade**: `available: False` with reason `no ownership map` when neither a CODEOWNERS nor a boundary doc exists.
- **Not wired into `assess_core`** (that is task 11) and **no Tier 1 grouping** (task 10) - the module is structured so a second tier slots in alongside `tier_0_available` cleanly.
- Run-context block carries the canonical fields (`tier_0_available`, `empty_ownership_patterns`, `total_patterns`, `matched_patterns`, `coverage_ratio`) plus the orchestrator's enumerate-both-sides mirror (`empty_globs`, `declared_paths`, `matched_paths`).

## Testing

- New suite (9 cases): empty CODEOWNERS glob, all-valid -> no findings, mixed state, ARCHITECTURE.md stale ref to a deleted dir, both-source merge+sort, excluded-only-matches-as-empty, no-map degradation, byte-identical determinism, and a real-repo dogfood guard that this repo's `lib/README.md` seam declaration does not false-positive.
- Required suites green locally: `skills/assess` (716 passed, 2 skipped), `scripts/` (106), `plugin contract` (183). `ruff + mypy` gates pass. Run with `GIT_CONFIG_GLOBAL=/dev/null` to clear the known local git-config phantom failures.

## Risk Assessment

Low. New, standalone module with no integration into the orchestrator yet; `test_self_architecture.py` confirms it imports no orchestrator. Pure reuse of an already-tested parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structure drift detection that identifies mismatches between code ownership declarations and actual tracked files, with comprehensive coverage metrics and detailed reporting of empty patterns.

* **Tests**
  * Added extensive test suite covering structure drift detection across multiple scenarios including excluded directories, stale declarations, and merging ownership patterns from multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->