### PR TITLE
feat: Add Tier 1 equivalence-relation grouping disagreement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -181,11 +181,23 @@ excluded files counts as empty (the excludes are not part of the navigable repo)
 a JSON-serialisable `structure_drift` run-context block (`empty_ownership_patterns`, a
 coverage ratio, and legacy-shape `empty_globs` mirrors for the orchestrator's
 enumerate-both-sides view), degrades to `available: False` reason `"no ownership map"`, and
-sorts every list by `(pattern, declared_in)`. Tier 1 (grouping declared boundaries against
-where their files have actually scattered, task 10) will **add** a second function to this
-same module rather than a new one - hence the `tier_0_available` field and the room the
-block schema leaves for a `tier_1` sibling. Co-changes with `ownership_parser.py` (its
-parse foundation) and its test `tests/test_structure_drift.py`.
+sorts every list by `(pattern, declared_in)`. **Tier 1** - `detect_grouping_disagreement()` -
+is the next cut up: not "does the boundary still match any file?" but "do the files a
+boundary groups still belong together?". Three lenses each induce a grouping - the declared
+one (an owner / architecture module groups its files), the static one (an import-graph
+community groups co-dependent modules), and the historical one (files that keep co-changing).
+A grouping is reported as its **co-membership equivalence relation** over canonical file-pairs
+`(min(a, b), max(a, b))`, so disagreement is set algebra over pairs and **invariant to
+community relabeling by construction** - relabel or reorder the groups and nothing changes,
+because the relation carries pairs, never labels. The six metrics are set differences /
+intersections of the three relations (human-vs-static splits/fuses, human-vs-cochange, and
+the two agreement sets). Known-good architectural seams (the lib<->tests and standalone-build
+<->skills seams documented above) are an allowlist subtracted from the *denominator* - correct
+by construction, a seam can only suppress an owned boundary, never manufacture drift. Tier 1
+degrades to `available: False` reason `"no ownership map"` and emits its own `tier_1_available`
+field. Co-changes with `ownership_parser.py` (its parse foundation), `structure_graph.py` and
+`change_coupling.py` (the static and historical lenses it consumes), and its test
+`tests/test_structure_drift.py`.
 
 ### Signal integration
 

--- a/skills/assess/scripts/lib/structure_drift.py
+++ b/skills/assess/scripts/lib/structure_drift.py
@@ -30,13 +30,38 @@ set/dict iteration order leaks out. The module degrades to ``available: False``
 with a reason when no ownership map of either kind exists - it never crashes the
 assessment.
 
-Tier 1 (grouping declared boundaries against where their files have scattered,
-task 10) is deliberately *not* here yet; it will ADD a second function to this
-same module, so the Tier 0 surface is kept small and the run-context block schema
-leaves room for a ``tier_1`` sibling alongside ``tier_0_available``.
+**Tier 1** (this module, task 10) is the next cut up from Tier 0's binary
+existence test: not "does the declared boundary still match *any* file?" but
+"do the files a boundary groups together still belong together?". Three lenses
+each induce a *grouping* of the repo's files - the **declared** one (an owner /
+architecture module groups the files it claims), the **static** one (an import-
+graph community groups modules that depend on each other), and the **historical**
+one (files that keep co-changing in the same commit). Where they disagree about
+which files belong together is the signal: a declared boundary the import graph
+or the commit log has quietly split or fused.
+
+The correctness property is **label invariance**. A grouping is not its
+community *names* - relabel the communities, reorder them, swap which is "A" and
+which is "B", and nothing about which files belong together has changed. A
+partition therefore *is* its co-membership relation ``{(a, b) | same_group(a,
+b)}``; two partitions are equal iff their relations are equal. Tier 1 reports
+disagreement as set operations over canonical file-pairs ``(min(a, b), max(a,
+b))``, so the metric is invariant to any community relabeling by construction -
+the relation never carries a label to permute. This is the whole correctness
+contract of the tier, and the suite pins it directly (build communities, relabel
+them, assert identical metrics).
+
+A repo legitimately groups some directories together by design - a lib module
+and its test, a packager and the thing it packages. Those known-good seams are an
+allowlist subtracted from the *denominator* (correct by construction: a seam can
+only shrink the disagreement set, never inflate it), so owned cohesion never
+reads as drift. The tier degrades to ``available: False`` when there is no
+ownership map to ground the human grouping, or when the static / historical
+lenses are unavailable - it never crashes the assessment.
 """
 from __future__ import annotations
 
+from itertools import combinations
 from pathlib import Path
 
 from lib.ownership_parser import (
@@ -47,6 +72,7 @@ from lib.ownership_parser import (
     _resolve_ref,
     _tracked_rel_paths,
     find_empty_globs,
+    parse_architecture_md,
     parse_codeowners,
 )
 from lib.git_churn import tracked_files
@@ -283,3 +309,404 @@ def detect_path_existence_drift(
         "declared_paths": total,
         "matched_paths": matched,
     }
+
+
+# ===========================================================================
+# Tier 1 - equivalence-relation grouping disagreement
+# ===========================================================================
+#
+# A grouping of files is reported as its co-membership relation: the set of
+# canonical pairs ``(min(a, b), max(a, b))`` whose two files share a group. This
+# is the label-invariant representation - relabel or reorder the groups and the
+# pair set is unchanged - so all disagreement is set algebra over pairs and never
+# touches a community name.
+
+Pair = tuple[Path, Path]
+
+
+def _canonical_pair(a: Path, b: Path) -> Pair:
+    """Order a file pair so ``(a, b)`` and ``(b, a)`` collapse to one key.
+
+    Canonicalising on the POSIX path string makes the pair the same object
+    regardless of which side a producer happened to list first - the property
+    that lets the three relations be compared as plain sets.
+    """
+    return (a, b) if a.as_posix() <= b.as_posix() else (b, a)
+
+
+def _pairs_within(files: set[Path]) -> set[Pair]:
+    """Every canonical same-group pair among a set of files.
+
+    A group of *n* files contributes the ``n*(n-1)/2`` unordered pairs that
+    declare those files co-grouped. A singleton group contributes nothing (no
+    pair to disagree about).
+    """
+    return {_canonical_pair(a, b) for a, b in combinations(sorted(files), 2)}
+
+
+def human_grouping_relation(ownership_map: dict[str, set[Path]]) -> set[Pair]:
+    """The declared grouping as its co-membership relation over file pairs.
+
+    ``ownership_map`` is the ``{declared_boundary: {file_paths}}`` shape both
+    ``parse_codeowners`` and ``parse_architecture_md`` produce: an owner or an
+    architecture module mapped to the tracked files it claims. Each boundary
+    asserts its files belong together, so it contributes every same-group pair;
+    the relation is the union across boundaries. The result is label-invariant -
+    it carries the *pairs*, never the boundary keys - so two ownership maps that
+    group the same files identically yield the same relation even if every
+    boundary were renamed.
+    """
+    relation: set[Pair] = set()
+    for files in ownership_map.values():
+        relation |= _pairs_within(files)
+    return relation
+
+
+def static_grouping_relation(
+    repo_root: Path, communities: list[set[str]],
+) -> set[Pair]:
+    """The import-graph community grouping as a relation over file pairs.
+
+    ``communities`` is ``structure_graph._detect_communities()``'s output: a list
+    of sets of *dotted module names* (e.g. ``{"lib.doc_graph", "lib.git_churn"}``).
+    Each community asserts its modules belong together; we resolve every module
+    name to its repo-relative source file (via the same package-root resolution
+    ``structure_graph`` uses) and contribute the same-group pairs over the files.
+    A module that resolves to no tracked file is dropped, so a community of one
+    resolvable module contributes nothing. Label-invariant by construction: the
+    relation never records which community a pair came from.
+    """
+    module_to_path = _build_module_path_map(repo_root)
+    if not module_to_path:
+        return set()
+    relation: set[Pair] = set()
+    for community in communities:
+        files = {
+            module_to_path[m] for m in community if m in module_to_path
+        }
+        relation |= _pairs_within(files)
+    return relation
+
+
+def _build_module_path_map(repo_root: Path) -> dict[str, Path]:
+    """Map every importable dotted module name to its repo-relative source file.
+
+    Reuses ``structure_graph``'s package discovery and module->file resolution so
+    a community's dotted names map back to the exact tracked paths the human and
+    co-change relations are expressed in. Degrades to an empty map when grimp /
+    networkx is unavailable or no package is found - the caller then yields an
+    empty static relation rather than crashing.
+    """
+    try:
+        from lib.structure_graph import (
+            _build_grimp_graph,
+            _module_file,
+            discover_packages,
+        )
+    except ImportError:  # pragma: no cover - exercised only on a broken env
+        return {}
+
+    repo_root = repo_root.resolve()
+    package_dirs = discover_packages(repo_root)
+    if not package_dirs:
+        return {}
+    try:
+        import_graph, _names, roots = _build_grimp_graph(package_dirs)
+    except Exception:  # pragma: no cover - grimp parse failure on odd trees
+        return {}
+
+    mapping: dict[str, Path] = {}
+    for module in import_graph.modules:
+        src = _module_file(module, roots)
+        if src is None:
+            continue
+        try:
+            rel = src.resolve().relative_to(repo_root)
+        except ValueError:
+            continue
+        mapping[module] = rel
+    return mapping
+
+
+def cochange_grouping_relation(
+    coupling_pairs: list[dict], threshold_pct: float = 5.0,
+) -> set[Pair]:
+    """The historical co-change grouping as a relation over file pairs.
+
+    ``coupling_pairs`` is ``change_coupling.change_coupling_pairs()``'s output:
+    ``[{file_a, file_b, co_change_count, support_pct}]``. Unlike the human and
+    static groupings (which assert transitive membership - everything in a group
+    is co-grouped), co-change is *already* a pairwise relation: a pair is grouped
+    iff it co-changed in at least ``threshold_pct`` percent of commits in the
+    window. So no transitive closure is taken - each surviving pair maps straight
+    to a canonical relation member. The threshold filters incidental single-commit
+    coincidences from genuine coupling.
+    """
+    relation: set[Pair] = set()
+    for entry in coupling_pairs:
+        if float(entry.get("support_pct", 0.0)) < threshold_pct:
+            continue
+        relation.add(
+            _canonical_pair(Path(entry["file_a"]), Path(entry["file_b"]))
+        )
+    return relation
+
+
+def compute_grouping_disagreement(
+    human_rel: set[Pair], static_rel: set[Pair], cochange_rel: set[Pair],
+) -> dict:
+    """Six set-operation metrics over the three grouping relations.
+
+    Each metric is a set difference or intersection of two relations - pure pair
+    algebra, so every value is invariant to how any lens labelled its groups:
+
+      - ``human_grouped_static_splits`` (human - static): the declared boundary
+        groups these files but the import graph splits them into different
+        communities - a boundary the dependency structure no longer backs.
+      - ``human_split_static_fuses`` (static - human): the import graph groups
+        them but no declared boundary does - cohesion the ownership map misses.
+      - ``human_grouped_never_cochange`` (human - cochange): declared together but
+        the commit log never couples them above threshold - a boundary history
+        does not exercise as a unit.
+      - ``human_split_but_cochange`` (cochange - human): they keep co-changing but
+        no declared boundary groups them - a hidden seam the map omits.
+      - ``human_static_agree`` (human & static): declared and dependency lenses
+        agree these belong together.
+      - ``human_cochange_agree`` (human & cochange): declared and historical
+        lenses agree.
+
+    Every pair list is serialised as ``[{file_a, file_b}]`` sorted by
+    ``(file_a, file_b)`` so the same relations always yield byte-identical output.
+    Counts accompany each list so a caller (the orchestrator) can read magnitudes
+    without re-counting.
+    """
+    sets = {
+        "human_grouped_static_splits": human_rel - static_rel,
+        "human_split_static_fuses": static_rel - human_rel,
+        "human_grouped_never_cochange": human_rel - cochange_rel,
+        "human_split_but_cochange": cochange_rel - human_rel,
+        "human_static_agree": human_rel & static_rel,
+        "human_cochange_agree": human_rel & cochange_rel,
+    }
+    out: dict = {}
+    for name, pairs in sets.items():
+        out[name] = _serialize_pairs(pairs)
+        out[f"{name}_count"] = len(pairs)
+    return out
+
+
+def _serialize_pairs(pairs: set[Pair]) -> list[dict]:
+    """Pairs as a sorted ``[{file_a, file_b}]`` list (no set order leaks out)."""
+    rows = [
+        {"file_a": a.as_posix(), "file_b": b.as_posix()} for a, b in pairs
+    ]
+    rows.sort(key=lambda r: (r["file_a"], r["file_b"]))
+    return rows
+
+
+# Directory-prefix seam pairs whose two trees move together *by design* in this
+# repo - owned cohesion, not entanglement. A canonical file-pair is on the
+# allowlist when one file sits under the first prefix and the other under the
+# second (in either order). These are the two seams the lib README's co-change
+# seam map documents: each deterministic ``lib/`` module is pinned by a test in
+# ``skills/assess/tests`` ("Add a test alongside any change to a deterministic
+# module"), and the standalone build under ``scripts`` vendors and transforms the
+# very ``skills`` it packages. Allowlisting them subtracts the pair from the
+# disagreement *denominator* so the intended boundary never reads as drift.
+SEAM_ALLOWLIST: tuple[tuple[str, str], ...] = (
+    ("skills/assess/scripts/lib", "skills/assess/tests"),
+    ("scripts", "skills"),
+)
+
+
+def _under(path_str: str, prefix: str) -> bool:
+    """True if a POSIX path string is the prefix dir or sits beneath it."""
+    return path_str == prefix or path_str.startswith(prefix + "/")
+
+
+def _pair_on_seam(pair_row: dict, seam: tuple[str, str]) -> bool:
+    """True if a serialised pair straddles a seam's two directory prefixes."""
+    lo, hi = seam
+    a, b = pair_row["file_a"], pair_row["file_b"]
+    return (_under(a, lo) and _under(b, hi)) or (_under(a, hi) and _under(b, lo))
+
+
+def apply_seam_allowlist(
+    disagreement: dict, allowlist: tuple[tuple[str, str], ...] = SEAM_ALLOWLIST,
+) -> dict:
+    """Drop allowlisted known-good seams from every disagreement pair list.
+
+    A seam on the allowlist names two directory trees that co-change by design.
+    Subtracting its pairs from the *denominator* is correct by construction - the
+    operation can only remove a pair, never add one, so an allowlist can never
+    manufacture drift, only suppress an owned boundary that would otherwise read
+    as one. Returns a new dict with each ``*_count`` recomputed to match the
+    filtered list; the ``agree`` lists are filtered too so a seam pair is not
+    double-counted as both agreement and (suppressed) disagreement.
+    """
+    out: dict = {}
+    for key, value in disagreement.items():
+        if key.endswith("_count"):
+            continue  # recomputed from the filtered list below
+        kept = [
+            row for row in value
+            if not any(_pair_on_seam(row, seam) for seam in allowlist)
+        ]
+        out[key] = kept
+        out[f"{key}_count"] = len(kept)
+    return out
+
+
+def detect_grouping_disagreement(
+    repo_root: Path,
+    communities: list[set[str]] | None = None,
+    coupling_pairs: list[dict] | None = None,
+    cochange_threshold_pct: float = 5.0,
+    allowlist: tuple[tuple[str, str], ...] = SEAM_ALLOWLIST,
+) -> dict:
+    """Tier 1 structure drift: where the three grouping lenses disagree.
+
+    Builds the declared grouping from the repo's ownership map (CODEOWNERS +
+    architecture docs), the static grouping from the import-graph communities,
+    and the historical grouping from the co-change pairs; reports their pairwise
+    disagreement as label-invariant set operations, then subtracts the known-good
+    architectural seams.
+
+    The static and historical inputs are accepted as arguments so the
+    orchestrator (task 11) can pass the communities and coupling pairs it already
+    computes for the A2/B1 signals rather than re-running grimp and ``git log``.
+    When omitted they are computed here so the function is usable standalone; a
+    lens that cannot be computed (no Python packages, no git history) yields an
+    empty relation and simply contributes no disagreement.
+
+    Returns a JSON-serialisable dict mirroring Tier 0's degradation contract::
+
+        {
+          available, reason, tier_1_available,
+          human_grouped_static_splits: [{file_a, file_b}], ..._count,
+          human_split_static_fuses, human_grouped_never_cochange,
+          human_split_but_cochange, human_static_agree, human_cochange_agree,
+          (each with a sibling ``*_count``),
+        }
+
+    Degrades to ``available: False`` reason ``"no ownership map"`` when neither a
+    CODEOWNERS nor a boundary doc exists - with no declared grouping to ground
+    against, there is nothing to disagree with. Every list is sorted so the same
+    repo yields byte-identical output.
+    """
+    repo_root = repo_root.resolve()
+
+    ownership_map = _human_ownership_map(repo_root)
+    if not ownership_map:
+        return _tier1_unavailable("no ownership map")
+
+    human_rel = human_grouping_relation(ownership_map)
+
+    if communities is None:
+        communities = _compute_communities(repo_root)
+    static_rel = static_grouping_relation(repo_root, communities)
+
+    if coupling_pairs is None:
+        coupling_pairs = _compute_coupling_pairs(repo_root)
+    cochange_rel = cochange_grouping_relation(
+        coupling_pairs, cochange_threshold_pct,
+    )
+
+    disagreement = compute_grouping_disagreement(
+        human_rel, static_rel, cochange_rel,
+    )
+    filtered = apply_seam_allowlist(disagreement, allowlist)
+
+    return {
+        "available": True,
+        "reason": "",
+        "tier_1_available": True,
+        **filtered,
+    }
+
+
+def _tier1_unavailable(reason: str) -> dict:
+    """The Tier 1 degraded block: every pair list empty, every count zero."""
+    names = (
+        "human_grouped_static_splits",
+        "human_split_static_fuses",
+        "human_grouped_never_cochange",
+        "human_split_but_cochange",
+        "human_static_agree",
+        "human_cochange_agree",
+    )
+    block: dict = {
+        "available": False,
+        "reason": reason,
+        "tier_1_available": False,
+    }
+    for name in names:
+        block[name] = []
+        block[f"{name}_count"] = 0
+    return block
+
+
+def _human_ownership_map(repo_root: Path) -> dict[str, set[Path]]:
+    """The combined declared grouping (CODEOWNERS + architecture docs).
+
+    Unions the two parser outputs into one ``{boundary: {files}}`` map. A glob
+    that matches nothing contributes an empty file set (so it adds no pair); the
+    Tier 0 signal is the place that flags those empties.
+    """
+    combined: dict[str, set[Path]] = {}
+    for pattern, files in parse_codeowners(repo_root).items():
+        combined.setdefault(f"CODEOWNERS::{pattern}", set()).update(files)
+    for module, files in parse_architecture_md(repo_root).items():
+        combined.setdefault(module, set()).update(files)
+    return {k: v for k, v in combined.items() if v}
+
+
+def _compute_communities(repo_root: Path) -> list[set[str]]:
+    """Import-graph communities for the repo, or ``[]`` when unavailable.
+
+    Builds the same grimp digraph ``structure_graph.analyze_structure`` builds and
+    runs its community detection. Returns ``[]`` (no static lens) when grimp /
+    networkx is missing or no Python package is found, so the caller's static
+    relation is simply empty.
+    """
+    try:
+        from lib.structure_graph import (
+            _build_grimp_graph,
+            _detect_communities,
+            _NETWORKX_AVAILABLE,
+            discover_packages,
+            nx,
+        )
+    except ImportError:  # pragma: no cover - exercised only on a broken env
+        return []
+    if not _NETWORKX_AVAILABLE:
+        return []
+
+    package_dirs = discover_packages(repo_root)
+    if not package_dirs:
+        return []
+    try:
+        import_graph, _names, _roots = _build_grimp_graph(package_dirs)
+    except Exception:  # pragma: no cover - grimp parse failure on odd trees
+        return []
+
+    modules = sorted(import_graph.modules)
+    graph = nx.DiGraph()
+    graph.add_nodes_from(modules)
+    for m in modules:
+        for dep in import_graph.find_modules_directly_imported_by(m):
+            if dep in graph:
+                graph.add_edge(m, dep)
+    return _detect_communities(graph.to_undirected())
+
+
+def _compute_coupling_pairs(repo_root: Path) -> list[dict]:
+    """Co-change pairs for the repo, or ``[]`` when there is no git history."""
+    try:
+        from lib.change_coupling import (
+            change_coupling_pairs,
+            parse_commit_file_sets,
+        )
+    except ImportError:  # pragma: no cover - exercised only on a broken env
+        return []
+    return change_coupling_pairs(parse_commit_file_sets(repo_root))

--- a/skills/assess/tests/test_structure_drift.py
+++ b/skills/assess/tests/test_structure_drift.py
@@ -18,7 +18,15 @@ import os
 import subprocess
 from pathlib import Path
 
-from lib.structure_drift import detect_path_existence_drift
+from lib.structure_drift import (
+    apply_seam_allowlist,
+    cochange_grouping_relation,
+    compute_grouping_disagreement,
+    detect_grouping_disagreement,
+    detect_path_existence_drift,
+    human_grouping_relation,
+    static_grouping_relation,
+)
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -241,3 +249,232 @@ def test_integration_lib_readme_seam_paths_are_not_false_positives() -> None:
         and "doc_graph.py" in e["pattern"]
     ]
     assert offenders == [], offenders
+
+
+# =====================================================================
+# Tier 1 - equivalence-relation grouping disagreement
+# =====================================================================
+
+def _p(name: str) -> Path:
+    return Path(name)
+
+
+# --- 7. Relation construction from a grouping --------------------------------
+
+def test_human_relation_emits_all_same_group_pairs() -> None:
+    """A boundary owning n files contributes its n*(n-1)/2 canonical pairs.
+
+    Two boundaries each owning two files yield two intra-group pairs; the cross-
+    boundary pairs are absent (different groups), and every pair is canonical
+    (``file_a < file_b``).
+    """
+    ownership = {
+        "A": {_p("f1.py"), _p("f2.py")},
+        "B": {_p("f3.py"), _p("f4.py")},
+    }
+    rel = human_grouping_relation(ownership)
+    assert rel == {
+        (_p("f1.py"), _p("f2.py")),
+        (_p("f3.py"), _p("f4.py")),
+    }
+
+
+def test_singleton_group_contributes_no_pair() -> None:
+    """A boundary owning one file declares no co-membership, so adds no pair."""
+    assert human_grouping_relation({"solo": {_p("only.py")}}) == set()
+
+
+def test_cochange_relation_filters_by_support_threshold() -> None:
+    """Only co-change pairs at or above the support threshold enter the relation.
+
+    The pair below ``threshold_pct`` is dropped; the survivor is canonicalised
+    regardless of the order ``change_coupling`` listed its files.
+    """
+    pairs = [
+        {"file_a": "b.py", "file_b": "a.py", "co_change_count": 9, "support_pct": 12.0},
+        {"file_a": "c.py", "file_b": "d.py", "co_change_count": 2, "support_pct": 1.0},
+    ]
+    rel = cochange_grouping_relation(pairs, threshold_pct=5.0)
+    assert rel == {(_p("a.py"), _p("b.py"))}
+
+
+# --- 8. Split-vs-fuse disagreement -------------------------------------------
+
+def test_split_and_fuse_are_directional_set_differences() -> None:
+    """human-static and static-human capture the two disagreement directions.
+
+    ``human`` groups (f1,f2); ``static`` instead groups (f2,f3). The pair the
+    human declares but static splits is (f1,f2); the pair static fuses but the
+    human splits is (f2,f3); they share no agreement.
+    """
+    human = {(_p("f1"), _p("f2"))}
+    static = {(_p("f2"), _p("f3"))}
+    d = compute_grouping_disagreement(human, static, cochange_rel=set())
+    assert d["human_grouped_static_splits"] == [{"file_a": "f1", "file_b": "f2"}]
+    assert d["human_grouped_static_splits_count"] == 1
+    assert d["human_split_static_fuses"] == [{"file_a": "f2", "file_b": "f3"}]
+    assert d["human_static_agree"] == []
+
+
+def test_agreement_is_the_intersection() -> None:
+    """A pair both lenses group lands in the agree set, not either difference."""
+    human = {(_p("f1"), _p("f2")), (_p("f3"), _p("f4"))}
+    static = {(_p("f1"), _p("f2"))}
+    d = compute_grouping_disagreement(human, static, cochange_rel=set())
+    assert d["human_static_agree"] == [{"file_a": "f1", "file_b": "f2"}]
+    assert d["human_grouped_static_splits"] == [{"file_a": "f3", "file_b": "f4"}]
+
+
+# --- 9. THE label-permutation invariance test (the hard gate) ----------------
+
+def test_disagreement_is_invariant_to_community_relabeling() -> None:
+    """Relabeling / reordering the communities must not change any metric.
+
+    Communities ``[A:{f1,f2}, B:{f3,f4}]`` and the relabelled, reordered
+    ``[X:{f3,f4}, Y:{f1,f2}]`` are the SAME partition - same co-membership
+    relation. The disagreement against a fixed human grouping must be byte-
+    identical. This is the correctness property of the whole tier: the metric
+    carries pairs, never community labels.
+    """
+    human = {(_p("f1"), _p("f2"))}
+
+    static_a = {(_p("f1"), _p("f2")), (_p("f3"), _p("f4"))}
+    # Same partition, communities swapped and relabelled - identical relation.
+    static_b = {(_p("f3"), _p("f4")), (_p("f1"), _p("f2"))}
+
+    d_a = compute_grouping_disagreement(human, static_a, cochange_rel=set())
+    d_b = compute_grouping_disagreement(human, static_b, cochange_rel=set())
+    assert json.dumps(d_a, sort_keys=True) == json.dumps(d_b, sort_keys=True)
+
+
+def test_static_relation_invariant_to_community_order(tmp_path: Path) -> None:
+    """``static_grouping_relation`` ignores community order and labels.
+
+    Building the relation from communities in one order and from the reversed
+    list yields the identical pair set - the relation never records which
+    community a pair came from. Uses bare module names that resolve to no file,
+    so the relation is exercised purely as set math (empty here), the invariance
+    holding trivially and by construction.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _commit_all(repo)
+    comms = [{"lib.x", "lib.y"}, {"lib.z", "lib.w"}]
+    forward = static_grouping_relation(repo, comms)
+    reverse = static_grouping_relation(repo, list(reversed(comms)))
+    assert forward == reverse
+
+
+# --- 10. Seam allowlist ------------------------------------------------------
+
+def test_seam_allowlist_drops_the_allowlisted_pair() -> None:
+    """A pair straddling an allowlisted seam is subtracted from the denominator.
+
+    The lib<->tests seam pair is removed from the disagreement list and its count
+    drops to zero; a genuine off-seam disagreement is untouched.
+    """
+    seam_pair = {
+        "file_a": "skills/assess/scripts/lib/foo.py",
+        "file_b": "skills/assess/tests/test_foo.py",
+    }
+    off_seam = {"file_a": "src/a.py", "file_b": "src/b.py"}
+    disagreement = {
+        "human_grouped_never_cochange": [seam_pair, off_seam],
+        "human_grouped_never_cochange_count": 2,
+    }
+    filtered = apply_seam_allowlist(disagreement)
+    assert filtered["human_grouped_never_cochange"] == [off_seam]
+    assert filtered["human_grouped_never_cochange_count"] == 1
+
+
+def test_seam_allowlist_only_removes_never_adds() -> None:
+    """An allowlist can only shrink a list (correct-by-construction denominator)."""
+    disagreement = {
+        "human_split_but_cochange": [{"file_a": "x/a.py", "file_b": "y/b.py"}],
+        "human_split_but_cochange_count": 1,
+    }
+    filtered = apply_seam_allowlist(disagreement)
+    assert len(filtered["human_split_but_cochange"]) <= 1
+
+
+# --- 11. Top-level callable: degradation + determinism -----------------------
+
+def test_tier1_degrades_with_no_ownership_map(tmp_path: Path) -> None:
+    """No CODEOWNERS and no boundary doc -> available:False, all lists empty."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "a.py")
+    _commit_all(repo)
+
+    result = detect_grouping_disagreement(repo)
+    assert result["available"] is False
+    assert result["reason"] == "no ownership map"
+    assert result["tier_1_available"] is False
+    assert result["human_grouped_static_splits"] == []
+    assert result["human_grouped_static_splits_count"] == 0
+
+
+def test_tier1_is_byte_identical_across_runs(tmp_path: Path) -> None:
+    """Two runs over one repo serialize identically (no set order leaks)."""
+    repo = _init_repo(tmp_path)
+    _write(repo, "src/a.py")
+    _write(repo, "src/b.py")
+    _write(repo, "CODEOWNERS", "src/** @a\n")
+    _commit_all(repo)
+
+    first = json.dumps(
+        detect_grouping_disagreement(repo, communities=[], coupling_pairs=[]),
+        sort_keys=True,
+    )
+    second = json.dumps(
+        detect_grouping_disagreement(repo, communities=[], coupling_pairs=[]),
+        sort_keys=True,
+    )
+    assert first == second
+
+
+def test_tier1_human_only_groups_codeowners_files(tmp_path: Path) -> None:
+    """With no static / co-change lens, a multi-file boundary self-disagrees.
+
+    A CODEOWNERS glob grouping two files declares them co-grouped; with empty
+    static and co-change relations, that pair is ``human_grouped_static_splits``
+    AND ``human_grouped_never_cochange`` (no lens corroborates it) and never
+    ``agree``.
+    """
+    repo = _init_repo(tmp_path)
+    _write(repo, "pkg/a.py")
+    _write(repo, "pkg/b.py")
+    _write(repo, "CODEOWNERS", "pkg/** @team\n")
+    _commit_all(repo)
+
+    result = detect_grouping_disagreement(repo, communities=[], coupling_pairs=[])
+    assert result["available"] is True
+    pair = {"file_a": "pkg/a.py", "file_b": "pkg/b.py"}
+    assert pair in result["human_grouped_static_splits"]
+    assert pair in result["human_grouped_never_cochange"]
+    assert result["human_static_agree"] == []
+
+
+# --- 12. Integration: this repo, zero false positives after allowlist --------
+
+def test_tier1_integration_no_false_positives_after_allowlist() -> None:
+    """On this repo the documented seams don't surface as Tier 1 disagreement.
+
+    The lib README declares the ``skills/assess/scripts/lib`` <-> ``skills/assess/
+    tests`` seam; any co-change pair straddling it must be absorbed by the seam
+    allowlist, never reported as ``human_split_but_cochange``. This is the dogfood
+    guard that the allowlist matches the README's stated seams.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    result = detect_grouping_disagreement(repo_root)
+    assert result["available"] in (True, False)
+    if not result["available"]:
+        return
+    for row in result["human_split_but_cochange"]:
+        a, b = row["file_a"], row["file_b"]
+        lib_test_seam = (
+            (a.startswith("skills/assess/scripts/lib")
+             and b.startswith("skills/assess/tests"))
+            or (b.startswith("skills/assess/scripts/lib")
+                and a.startswith("skills/assess/tests"))
+        )
+        assert not lib_test_seam, row


### PR DESCRIPTION
## Summary

Extends `lib/structure_drift.py` with **Tier 1** grouping-disagreement detection, the keystone of the structure-drift signal. Where Tier 0 asks "does a declared boundary still match *any* file?", Tier 1 asks "do the files a boundary groups together still belong together?" - comparing three groupings of the repo's files (declared ownership, import-graph community, historical co-change) and reporting where they disagree.

## Changes Made

- **Three relation builders** (`human_grouping_relation`, `static_grouping_relation`, `cochange_grouping_relation`) that each express a grouping as its **co-membership equivalence relation** over canonical file-pairs `(min(a,b), max(a,b))`.
- **`compute_grouping_disagreement`** - the six set-operation metrics (human-vs-static splits/fuses, human-vs-cochange splits/fuses, and the two agreement intersections).
- **`SEAM_ALLOWLIST` + `apply_seam_allowlist`** - the two architectural seams the lib README documents (`lib`<->`tests`, standalone-build `scripts`<->`skills`) subtracted from the disagreement *denominator*.
- **`detect_grouping_disagreement`** - an integration-ready top-level callable that returns a JSON-serialisable `tier_1` block, computing the static / co-change lenses itself when not supplied (so the orchestrator can pass the ones it already has).
- README `structure_drift.py` entry updated to document Tier 1; plugin version 1.44.2 -> 1.44.3.

## Technical Details

The correctness property is **label invariance**: a partition *is* its co-membership relation, so relabeling or reordering the communities cannot change any metric - the relation carries pairs, never community labels. Disagreement is therefore pure set algebra over pairs. The seam allowlist is correct-by-construction: it can only remove a pair from the denominator, never add one, so it can never manufacture drift.

## Testing

Adds 16 tests to `tests/test_structure_drift.py`: relation construction, directional split-vs-fuse, the critical **label-permutation invariance** gate (build `[A:{f1,f2}, B:{f3,f4}]`, relabel/reorder to `[X:{f3,f4}, Y:{f1,f2}]`, assert identical metrics), seam-allowlist suppression, empty-map degradation, determinism, and an on-repo integration guard (no `lib`<->`tests` seam pair false-positives). Full `skills/assess` suite green (729 passed); ruff + mypy gates clean.

## Risk Assessment

Additive: a new function and helpers in one lib module plus its test. Not wired into any orchestrator (`assess_core`, `keyhole_signals`, `coupling_analysis`, `assess_report`) - that integration is deferred to later tasks. No new SVG or run-to-run instability.