### PR TITLE
feat: Integrate structure_drift into assess core and run-context

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -60,6 +60,10 @@ from lib.liveness_scan import scan_liveness
 from lib.promissory_markers import scan_promissory_markers
 from lib.structure_graph import analyze_structure
 from lib.stats_diff import diff_stats, hotspot_commits, load_stats
+from lib.structure_drift import (
+    SEAM_ALLOWLIST,
+    detect_path_existence_drift,
+)
 from lib.test_pressure import scan_test_pressure
 from lib.wiki_writer import (
     UNFINALIZED_ACTIONS_POINTER,
@@ -483,6 +487,87 @@ def _accretion_lookup(scan: Any) -> dict[str, dict]:
         entry["reliable"] = scan.reliable
         lookup[af.path] = entry
     return lookup
+
+
+# The six Tier 1 grouping-disagreement counts, in a fixed order so the
+# run-context tier_1 sub-block is deterministic regardless of dict iteration.
+_TIER1_DISAGREEMENT_KEYS = (
+    "human_grouped_static_splits",
+    "human_split_static_fuses",
+    "human_grouped_never_cochange",
+    "human_split_but_cochange",
+    "human_static_agree",
+    "human_cochange_agree",
+)
+
+
+def _structure_drift_block(
+    repo_root: Path, tier_1: dict,
+) -> dict | None:
+    """Build the run-context ``structure_drift`` block (Tier 0 + Tier 1).
+
+    Tier 0 (``detect_path_existence_drift``) is the zero-threshold cut: declared
+    ownership patterns matching no tracked file. It runs whenever an ownership
+    map exists; when none does it degrades to ``available: False`` and the whole
+    block is omitted (the caller drops a ``None``), keeping non-owned repos'
+    run-context byte-stable.
+
+    ``tier_1`` is the grouping-disagreement result ``keyhole_signals.integrate``
+    already computed from the behaviour block's co-change pairs (no second
+    ``git log`` parse, no double computation) - either the six disagreement
+    counts or an ``available: False`` marker when the static import graph was
+    unavailable or no ownership map existed. The seam allowlist was applied
+    inside the detector, so the counts here are already post-allowlist.
+
+    Returns ``None`` when Tier 0 is unavailable (no ownership map) - a graceful,
+    half-block-free omission. Otherwise returns a JSON-serialisable block whose
+    ``tier_0`` always carries data and whose ``tier_1`` is either the six
+    disagreement counts or ``{"available": False}``.
+    """
+    tier_0 = detect_path_existence_drift(repo_root)
+    if not tier_0.get("available"):
+        return None  # no ownership map - omit the block entirely
+
+    block: dict[str, Any] = {
+        "tier_0": {
+            "available": True,
+            "empty_ownership_patterns": tier_0["empty_ownership_patterns"],
+            "total_patterns": tier_0["total_patterns"],
+            "matched_patterns": tier_0["matched_patterns"],
+        },
+    }
+
+    if not tier_1.get("available"):
+        block["tier_1"] = {"available": False}
+        return block
+
+    tier_1_block: dict[str, Any] = {"available": True}
+    for key in _TIER1_DISAGREEMENT_KEYS:
+        tier_1_block[f"{key}_count"] = tier_1.get(f"{key}_count", 0)
+    tier_1_block["seam_allowlist_applied"] = True
+    tier_1_block["allowlist_pairs_count"] = len(SEAM_ALLOWLIST)
+    block["tier_1"] = tier_1_block
+    return block
+
+
+def _attach_structure_drift(
+    ctx: dict[str, Any], repo_root: Path, tier_1: dict,
+) -> None:
+    """Attach the structure_drift block to ctx, or omit it on a graceful degrade.
+
+    Builds the block via :func:`_structure_drift_block` (Tier 0 + the supplied
+    Tier 1 result) under :func:`_safe`. Attaches only a real block (one carrying
+    a ``tier_0``): the no-ownership-map path returns ``None`` and a scan failure
+    returns ``_safe``'s degrade dict (no ``tier_0``); both omit the block rather
+    than emit a half-block, keeping the contract that absence means "nothing to
+    drift against / not assessed", never "no drift".
+    """
+    block = _safe(
+        "structure_drift",
+        lambda: _structure_drift_block(repo_root, tier_1),
+    )
+    if isinstance(block, dict) and "tier_0" in block:
+        ctx["structure_drift"] = block
 
 
 def _marker_debt_sentence(debt: dict | None) -> str:
@@ -967,6 +1052,16 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     ctx["findings_markdown"] = keyhole["findings_markdown"]
     ctx["keyhole_summary"] = keyhole["keyhole_summary"]
     ctx["prescribed_actions"] = keyhole["prescribed_actions"]
+
+    # Structure drift (third write-side tendency surface: a declared ownership
+    # map that no longer matches where the code lives). Tier 0 is the cheap
+    # path-existence cut; Tier 1 the grouping-disagreement cut keyhole_signals
+    # already computed from the behaviour block's co-change pairs (no second
+    # git-log parse). The block is omitted entirely when no ownership map exists
+    # - a graceful, half-block-free degrade that keeps a non-owned repo's
+    # run-context byte-stable - and its Tier 1 hidden-seam already flows into the
+    # report's B3 attention list via keyhole_signals; this block is the record.
+    _attach_structure_drift(ctx, repo_root, keyhole["structure_drift_tier1"])
 
     _write_fallback_badge_if_absent(assess_dir, promissory, ctx["derived_findings"])
 

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -195,8 +195,13 @@ the two agreement sets). Known-good architectural seams (the lib<->tests and sta
 <->skills seams documented above) are an allowlist subtracted from the *denominator* - correct
 by construction, a seam can only suppress an owned boundary, never manufacture drift. Tier 1
 degrades to `available: False` reason `"no ownership map"` and emits its own `tier_1_available`
-field. Co-changes with `ownership_parser.py` (its parse foundation), `structure_graph.py` and
-`change_coupling.py` (the static and historical lenses it consumes), and its test
+field. `keyhole_signals.py` orchestrates Tier 1 (feeding it the behaviour block's already-parsed
+co-change pairs) and folds the hidden-seam direction (`human_split_but_cochange`) into the
+existing `hidden_coupling` finding - a recurring directory pair, not the version hot-file's
+repo-wide couplings; `assess_core.py` serialises the Tier 0 + Tier 1 result into the
+`structure_drift` run-context block. Co-changes with `ownership_parser.py` (its parse foundation),
+`structure_graph.py` and `change_coupling.py` (the static and historical lenses it consumes),
+`keyhole_signals.py` / `assess_core.py` (its orchestrator and serialiser), and its test
 `tests/test_structure_drift.py`.
 
 ### Signal integration
@@ -211,7 +216,11 @@ outputs. Emits the eight named derived findings as a fixed-order structured arra
 `refactor_boundary` (the two trust-axis findings, `untrusted_hotspot` and
 `self_referential_tests`, were added after this module's first cut). Each block build
 is wrapped in a catch-all so one signal's failure degrades that block to
-`available: False` rather than crashing the run.
+`available: False` rather than crashing the run. It also runs `structure_drift.py`'s Tier 1
+grouping disagreement (fed the behaviour block's co-change pairs so no second git-log parse
+happens) and folds its hidden-seam direction into the `hidden_coupling` finding, returning the
+Tier 1 result for `assess_core` to serialise into the `structure_drift` run-context block - so
+structure-drift findings flow through this barrier rather than being assembled in the orchestrator.
 
 **`coupling_analysis.py`**
 B3 static-vs-historical disagreement cross: compares the import-graph view

--- a/skills/assess/scripts/lib/keyhole_signals.py
+++ b/skills/assess/scripts/lib/keyhole_signals.py
@@ -40,6 +40,7 @@ from lib.doc_complexity_join import (
     analyze_doc_complexity_join,
 )
 from lib.liveness_scan import STATIC_REACHABILITY_CAVEAT
+from lib.structure_drift import detect_grouping_disagreement
 from lib.understanding_analysis import analyze_understanding
 
 # Caps so a pathological repo can't bloat run-context.json. The treemap and
@@ -598,6 +599,72 @@ def _format_accretion_items(run_context: dict) -> list[str]:
 
 
 # --------------------------------------------------------------------------
+# Structure drift (Tier 1) as a B3 hidden-coupling signal
+# --------------------------------------------------------------------------
+#
+# Tier 1's ``human_split_but_cochange`` is, by construction, a B3 signal: file
+# pairs the commit log keeps coupling that *no* declared ownership boundary
+# groups - a hidden seam the map omits, exactly the question B3
+# (static-vs-historical disagreement) already asks. So it folds into the
+# *existing* ``hidden_coupling`` finding rather than a new finding type, after
+# the seam allowlist (applied inside ``detect_grouping_disagreement``) has
+# absorbed the known-good seams.
+#
+# The aggregation tests directory *pairs*, not single directories: a genuine
+# hidden seam is two trees that keep co-changing across several distinct file
+# pairs, not one hub file that touches everything. The version hot-file
+# ``plugin.json`` co-changes with a file in every tree on each PR - inflating its
+# own directory's single-dir count - but each of those couplings is a *different*
+# counterpart directory through the *same* hub file, so no directory *pair*
+# recurs. Requiring a directory pair to recur (``min_pairs`` distinct file pairs
+# straddling the same two trees) is the recurrence test that distinguishes a
+# mutual entanglement from a repo-wide hub, and yields no false positive from the
+# version-bump ritual.
+
+MIN_DRIFT_PAIRS_FOR_HIDDEN_COUPLING = 2
+
+
+def _parent_dir(path_str: str) -> str:
+    """The repo-relative parent directory of a file path (``.`` for repo root)."""
+    return Path(path_str).parent.as_posix()
+
+
+def structure_drift_hidden_coupling_dirs(
+    tier1: dict, min_pairs: int = MIN_DRIFT_PAIRS_FOR_HIDDEN_COUPLING,
+) -> list[str]:
+    """Directories entangled by a recurring Tier 1 hidden seam.
+
+    Aggregates the post-allowlist ``human_split_but_cochange`` pairs (co-change
+    with no declared boundary) to *directory pairs* and keeps the directories of
+    any directory pair straddled by at least ``min_pairs`` distinct file pairs.
+    Testing directory pairs (not single directories) is what filters a repo-wide
+    hub - the version hot-file couples with every tree, inflating its own
+    directory's appearances, but always through a *different* counterpart
+    directory, so no directory pair recurs and it never reads as a seam. A pair
+    where both files share a directory is ignored (intra-directory cohesion is
+    not a cross-tree seam), as is any pair touching the repo root ``.`` (vacuous
+    containment, never an attention unit). Returns a sorted, deduped path list
+    matching the dir granularity of the existing ``hidden_coupling`` finding so
+    the attention list stays deterministic.
+    """
+    if not tier1.get("available"):
+        return []
+    dir_pair_counts: Counter[tuple[str, str]] = Counter()
+    for row in tier1.get("human_split_but_cochange", []):
+        da, db = _parent_dir(row["file_a"]), _parent_dir(row["file_b"])
+        if da == db or "." in (da, db):
+            continue
+        key: tuple[str, str] = (da, db) if da <= db else (db, da)
+        dir_pair_counts[key] += 1
+    out: set[str] = set()
+    for (da, db), n in dir_pair_counts.items():
+        if n >= min_pairs:
+            out.add(da)
+            out.add(db)
+    return sorted(out)
+
+
+# --------------------------------------------------------------------------
 # Deterministic markdown / summary renderers (the report-skeleton products)
 # --------------------------------------------------------------------------
 
@@ -782,6 +849,32 @@ def _safe_block(label: str, fn, fallback: dict) -> dict:
         return {**fallback, "available": False, "reason": f"{label} failed: {e}"}
 
 
+def _structure_drift_tier1(
+    repo_root: Path, structure: dict | None, behaviour: dict,
+) -> dict:
+    """Tier 1 grouping disagreement, fed the behaviour block's co-change pairs.
+
+    Returns ``{"available": False}`` (no disagreement to surface) whenever the
+    static import graph is unavailable - with no static lens there is nothing to
+    disagree with. Otherwise calls ``detect_grouping_disagreement`` with the
+    co-change pairs the behaviour block already computed (no second git-log
+    parse); the static communities are recomputed inside the detector from the
+    same grimp packages ``structure`` was built from, since the structure block
+    keeps only modularity_q, not the partition. Any failure degrades to an empty
+    available:False result - this is additive B3 context, never a gate.
+    """
+    if not structure or not structure.get("available"):
+        return {"available": False}
+    coupling_pairs = (
+        behaviour.get("change_coupling_pairs", [])
+        if behaviour.get("available") else []
+    )
+    try:
+        return detect_grouping_disagreement(repo_root, coupling_pairs=coupling_pairs)
+    except Exception:  # noqa: BLE001 - degrade, never crash
+        return {"available": False}
+
+
 def _paths_from_stats(complexity_stats: dict, cap: int = MAX_AUTHORSHIP_PATHS) -> list[str]:
     """The ranked-list paths to run authorship analysis over (capped).
 
@@ -931,10 +1024,24 @@ def integrate(
     ratchet_run_ctx: dict = {"accretion_ratchet": accretion_ratchet or {}}
     accreting_paths = _accretion_ratchet_finding(ratchet_run_ctx)
 
+    # Structure drift (Tier 1): grouping disagreement between the declared
+    # ownership map, the static import graph, and the commit-log co-change. Run
+    # only when the static lens exists (no graph -> nothing to disagree with);
+    # fed the behaviour block's already-computed co-change pairs so no second
+    # git-log parse happens. Its hidden-seam direction folds into the existing
+    # hidden_coupling finding below. Degrades to an empty (available:False) result
+    # when no ownership map exists or the detector fails - never crashes the run.
+    structure_drift_tier1 = _structure_drift_tier1(repo_root, structure, behaviour)
+    # The hidden-seam dirs are co-change-derived, so a degenerate history (which
+    # maximally inflates co-change) must suppress them exactly as it suppresses
+    # the containment-derived hidden_coupling - via the same _churn_paths gate.
+    drift_hidden_dirs = structure_drift_hidden_coupling_dirs(structure_drift_tier1)
+
     findings = assemble_findings({
         "hidden_coupling": _churn_paths(
             "hidden_coupling",
-            [h["path"] for h in behaviour.get("hidden_coupling_findings", [])],
+            [h["path"] for h in behaviour.get("hidden_coupling_findings", [])]
+            + drift_hidden_dirs,
         ),
         "lying_map": _churn_paths(
             "lying_map",
@@ -964,4 +1071,8 @@ def integrate(
         "findings_markdown": render_findings_markdown(findings, attention),
         "keyhole_summary": build_keyhole_summary(findings),
         "prescribed_actions": build_prescribed_actions(attention, findings),
+        # The Tier 1 grouping disagreement, computed once here from the behaviour
+        # block's co-change pairs, so the orchestrator can build the run-context
+        # structure_drift tier_1 sub-block from it without a second computation.
+        "structure_drift_tier1": structure_drift_tier1,
     }

--- a/skills/assess/tests/fixtures/golden/run-context-baseline.json
+++ b/skills/assess/tests/fixtures/golden/run-context-baseline.json
@@ -2550,5 +2550,1450 @@
     ],
     "orphaned_understanding": []
   },
-  "untracked_instruction_files": []
+  "untracked_instruction_files": [],
+  "structure_drift": {
+    "tier_0": {
+      "available": true,
+      "empty_ownership_patterns": [
+        {
+          "pattern": "../../commands/README.md",
+          "declared_in": "docs/superpowers/README.md::Design history",
+          "owners": []
+        },
+        {
+          "pattern": "../../skills/README.md",
+          "declared_in": "docs/superpowers/README.md::Design history",
+          "owners": []
+        },
+        {
+          "pattern": "../CLAUDE.md",
+          "declared_in": "skills/README.md::Skills",
+          "owners": []
+        },
+        {
+          "pattern": "../README.md",
+          "declared_in": "commands/README.md::Commands",
+          "owners": []
+        },
+        {
+          "pattern": "../commands/fix-develop.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "../commands/fix-pr.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "../commands/issues.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "../commands/tm.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "../docs/index.md",
+          "declared_in": "commands/README.md::Commands",
+          "owners": []
+        },
+        {
+          "pattern": "../docs/index.md",
+          "declared_in": "skills/README.md::Skills",
+          "owners": []
+        },
+        {
+          "pattern": "../index.md",
+          "declared_in": "docs/superpowers/README.md::Design history",
+          "owners": []
+        },
+        {
+          "pattern": "../skills/huddle/SKILL.md",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "../skills/marathon/SKILL.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "../skills/pr-review-merge/SKILL.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./6hats.md",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./ab-equivalence/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "./assess-findings/SKILL.md",
+          "declared_in": "skills/README.md::Assessment helpers",
+          "owners": []
+        },
+        {
+          "pattern": "./assess-pr/SKILL.md",
+          "declared_in": "skills/README.md::Assessment helpers",
+          "owners": []
+        },
+        {
+          "pattern": "./assess/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./deslop/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./deslop/references/full-checklist.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./fix-develop.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./fix-pr.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./ghsync/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./huddle/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./issues.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./marathon/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-22-assess-deterministic-wiki.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-22-assess-v1.5-real-use-fixes.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-23-standalone-skill-pipeline.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-27-assess-truth-pressure-signals.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-27-huddle-broadcast-per-recipient.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-27-huddle-cli-team-mode-regression.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-28-assess-dismiss-false-positives.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-29-assess-keyhole-readiness.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-29-assess-write-side-truth-pressure.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-29-issues-marathon-shared-skills.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-31-assess-dogfooded-analysis.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-05-31-assess-dogfooded.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./plans/2026-06-02-skill-forge.md",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "./pr-review-merge/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "./semantic-compress/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./skill-forge/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-05-29-issues-marathon-shared-skills-design.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-06-02-skill-forge-design.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-06-03-instruction-optimizer-directive-clarity-design.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-06-03-semantic-compress-distillation-design.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-06-03-skill-forge-extraction-verification.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./specs/2026-06-03-skill-forge-hardening-and-ab-extraction-design.md",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "./tm-marathon-config-example.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./tm.md",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "./understand.md",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": ".assess",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": ".assess",
+          "declared_in": "skills/assess/scripts/lib/README.md::Output and formatting",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/assess-report.md",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/assess-report.md",
+          "declared_in": "README.md::Assess a codebase",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/badge.json",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/badge.json",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/complexity-heatmap.svg",
+          "declared_in": "README.md::Assess a codebase",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/complexity-stats.json",
+          "declared_in": "README.md::Assess a codebase",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/config.toml",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/config.toml",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/config.toml",
+          "declared_in": "skills/assess/scripts/lib/README.md::Configuration",
+          "owners": []
+        },
+        {
+          "pattern": ".assess/doc-graph.svg",
+          "declared_in": "README.md::Assess a codebase",
+          "owners": []
+        },
+        {
+          "pattern": ".github/copilot-instructions.md",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": ".next",
+          "declared_in": "README.md::Build artifacts and generated code are filtered by default",
+          "owners": []
+        },
+        {
+          "pattern": ".nuxt",
+          "declared_in": "README.md::Build artifacts and generated code are filtered by default",
+          "owners": []
+        },
+        {
+          "pattern": ".obsidian",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats",
+          "declared_in": "README.md::Agents (invoked by skills, or directly via `Task(subagent_type=...)`)",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats <q>",
+          "declared_in": "README.md::Run a huddle on a hard decision",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats <question>",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/6hats review please",
+          "declared_in": "README.md::Why Six Hats?",
+          "owners": []
+        },
+        {
+          "pattern": "/ai-native-toolkit:assess",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/ai-native-toolkit:deslop",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/ai-native-toolkit:huddle",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Capability differences vs Claude Code",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Contributors",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Prerequisites for the ZIP path",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Standalone skill ZIPs (any AI assistant)",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::What `/assess` produces",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "README.md::Why this matters for an AI-driven codebase",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/README.md::Assessment helpers",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/assess/scripts/lib/README.md::The wider co-change seams (cohesion, not entanglement)",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/assess/scripts/lib/README.md::skills/assess/scripts/lib",
+          "owners": []
+        },
+        {
+          "pattern": "/assess",
+          "declared_in": "skills/assess/tests/README.md::skills/assess/tests",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::Prerequisites for the ZIP path",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::Standalone skill ZIPs (any AI assistant)",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "/deslop",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-develop",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-develop",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-develop",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-develop",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-develop",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-pr",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-pr",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-pr",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-pr",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "/fix-pr",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "/ghsync",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/ghsync",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Agents (invoked by skills, or directly via `Task(subagent_type=...)`)",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Capability differences vs Claude Code",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Contributors",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Prerequisites for the ZIP path",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Standalone skill ZIPs (any AI assistant)",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/huddle",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/issues",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/issues",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "/issues",
+          "declared_in": "docs/superpowers/README.md::Plans",
+          "owners": []
+        },
+        {
+          "pattern": "/issues",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "/issues",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin install",
+          "declared_in": "README.md::Two install paths - pick by where you work",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin remove ai-native-toolkit",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin update",
+          "declared_in": "README.md::Two install paths - pick by where you work",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin update ai-native-toolkit",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "/plugin update ai-native-toolkit",
+          "declared_in": "README.md::Staying notified of new versions",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::Prerequisites for the ZIP path",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::Standalone skill ZIPs (any AI assistant)",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "/semantic-compress",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::AI Native Toolkit",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::Prerequisites for the ZIP path",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::Standalone skill ZIPs (any AI assistant)",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-forge",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/skill-name",
+          "declared_in": "README.md::Verify the auto-trigger works",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "README.md::Git workflow assumed by `/tm`, `/fix-pr`, `/fix-develop`",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "/tm",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "/tm-marathon-config-example",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "/tm-marathon-config-example",
+          "declared_in": "commands/README.md::Workflow (personal setup, opt-in)",
+          "owners": []
+        },
+        {
+          "pattern": "/understand",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "/understand",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "/understand",
+          "declared_in": "commands/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "/understand <thing>",
+          "declared_in": "README.md::Commands (slash-only, no bundled assets)",
+          "owners": []
+        },
+        {
+          "pattern": "2.5/8",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "2/8",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "3/5/8",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "4.0/8",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "5.5/8",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "7.0/8",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "8/8",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "<name>/SKILL.md",
+          "declared_in": "skills/README.md::Skills",
+          "owners": []
+        },
+        {
+          "pattern": "<name>/references",
+          "declared_in": "skills/README.md::Skills",
+          "owners": []
+        },
+        {
+          "pattern": "<name>/scripts",
+          "declared_in": "skills/README.md::Skills",
+          "owners": []
+        },
+        {
+          "pattern": "<repo>-main",
+          "declared_in": "README.md::Git workflow assumed by `/tm`, `/fix-pr`, `/fix-develop`",
+          "owners": []
+        },
+        {
+          "pattern": "<repo>-main",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "<repo>/<repo>-main",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "<repo>/worktree",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "A/B",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "A/B",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "A/B",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "A/B",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "A/B",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "A/B-equivalence",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "A/B-extraction",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "A/B-validated",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "A/B-validated",
+          "declared_in": "docs/superpowers/README.md::Specs",
+          "owners": []
+        },
+        {
+          "pattern": "A/B-validated",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "AGENTS.md",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "AGENTS.md",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "ARCHITECTURE.md",
+          "declared_in": "skills/assess/scripts/lib/README.md::Ownership and structure drift",
+          "owners": []
+        },
+        {
+          "pattern": "Atom/RSS",
+          "declared_in": "README.md::Staying notified of new versions",
+          "owners": []
+        },
+        {
+          "pattern": "C/C",
+          "declared_in": "README.md::The same lens, three real public repos",
+          "owners": []
+        },
+        {
+          "pattern": "CodeRabbit/claude",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "DESIGN.md",
+          "declared_in": "skills/assess/scripts/lib/README.md::Ownership and structure drift",
+          "owners": []
+        },
+        {
+          "pattern": "JVM/Maven",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "LLM/Phase-2",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "SHA/timestamp",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "TODO/FIXME",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "[text](relative/path",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "ab-equivalence/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "agent/human",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "agent/human",
+          "declared_in": "skills/assess/scripts/lib/README.md::Signal integration",
+          "owners": []
+        },
+        {
+          "pattern": "assess-findings/SKILL.md",
+          "declared_in": "skills/README.md::Assessment helpers",
+          "owners": []
+        },
+        {
+          "pattern": "assess-pr/SKILL.md",
+          "declared_in": "skills/README.md::Assessment helpers",
+          "owners": []
+        },
+        {
+          "pattern": "assess-report.md",
+          "declared_in": "README.md::Why this matters for an AI-driven codebase",
+          "owners": []
+        },
+        {
+          "pattern": "assess/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "audit/edit",
+          "declared_in": "README.md::Why this exists",
+          "owners": []
+        },
+        {
+          "pattern": "build",
+          "declared_in": "README.md::Build artifacts and generated code are filtered by default",
+          "owners": []
+        },
+        {
+          "pattern": "chars/4",
+          "declared_in": "README.md::What `/assess` produces",
+          "owners": []
+        },
+        {
+          "pattern": "de-slop/audit",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "deslop/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "discovery/excludes",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "dist",
+          "declared_in": "README.md::Build artifacts and generated code are filtered by default",
+          "owners": []
+        },
+        {
+          "pattern": "doc/code",
+          "declared_in": "skills/assess/scripts/lib/README.md::Configuration",
+          "owners": []
+        },
+        {
+          "pattern": "generated",
+          "declared_in": "skills/assess/scripts/lib/README.md::Configuration",
+          "owners": []
+        },
+        {
+          "pattern": "generated",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "ghsync/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "hotspots/*.md",
+          "declared_in": "skills/assess/scripts/lib/README.md::Output and formatting",
+          "owners": []
+        },
+        {
+          "pattern": "hotspots/*.md",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "huddle/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "human/agent/mixed/unknown",
+          "declared_in": "skills/assess/scripts/lib/README.md::Data collection",
+          "owners": []
+        },
+        {
+          "pattern": "internal/import/parser.go",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "issue/ticket/URL/date",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "lib/__init__.py",
+          "declared_in": "skills/assess/tests/README.md::Infrastructure suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/agent_instructions_grader.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/change_coupling.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/ci_workflow.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/coupling_analysis.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/doc_complexity_join.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/doc_graph.py",
+          "declared_in": "skills/assess/tests/README.md::Test/source co-change seam",
+          "owners": []
+        },
+        {
+          "pattern": "lib/doc_graph.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/doc_staleness.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/git_churn.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/keyhole_signals.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/liveness_scan.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/stats_diff.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/structure_graph.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/test_pressure",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/understanding_analysis.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lib/wiki_writer.py",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "lizard/scc",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "log.md",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "log.md",
+          "declared_in": "skills/assess/scripts/lib/README.md::Output and formatting",
+          "owners": []
+        },
+        {
+          "pattern": "log.md",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "logs/metrics/traces",
+          "declared_in": "README.md::The intent: keep codebases comprehensible as AI accelerates them",
+          "owners": []
+        },
+        {
+          "pattern": "marathon/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "markdown/JSON/YAML",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "node_modules",
+          "declared_in": "README.md::Build artifacts and generated code are filtered by default",
+          "owners": []
+        },
+        {
+          "pattern": "ownership/seam",
+          "declared_in": "skills/assess/scripts/lib/README.md::Ownership and structure drift",
+          "owners": []
+        },
+        {
+          "pattern": "pr-review-merge/SKILL.md",
+          "declared_in": "skills/README.md::Team-orchestration library skills",
+          "owners": []
+        },
+        {
+          "pattern": "red-team/blue-team",
+          "declared_in": "README.md::Verify the auto-trigger works",
+          "owners": []
+        },
+        {
+          "pattern": "references/full-checklist.md",
+          "declared_in": "README.md::Skills (auto-discovered by Claude Code)",
+          "owners": []
+        },
+        {
+          "pattern": "references/full-checklist.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "repo/notes/.obsidian",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "run/installed",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/assess_core.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/assess_emit_workflow.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/assess_finalize.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/assess_gate.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/assess_report.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/complexity-treemap.py",
+          "declared_in": "skills/assess/tests/README.md::Orchestrator suites",
+          "owners": []
+        },
+        {
+          "pattern": "scripts/lib",
+          "declared_in": "skills/assess/scripts/lib/README.md::The wider co-change seams (cohesion, not entanglement)",
+          "owners": []
+        },
+        {
+          "pattern": "semantic-compress/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "skill-forge/SKILL.md",
+          "declared_in": "skills/README.md::Portable",
+          "owners": []
+        },
+        {
+          "pattern": "skills/assess/tests/fixtures",
+          "declared_in": "skills/assess/scripts/lib/README.md::The wider co-change seams (cohesion, not entanglement)",
+          "owners": []
+        },
+        {
+          "pattern": "spec/doc",
+          "declared_in": "skills/assess/scripts/lib/README.md::Signal integration",
+          "owners": []
+        },
+        {
+          "pattern": "splits/fuses",
+          "declared_in": "skills/assess/scripts/lib/README.md::Ownership and structure drift",
+          "owners": []
+        },
+        {
+          "pattern": "templates/assess-gate.yml.template",
+          "declared_in": "skills/assess/scripts/lib/README.md::Output and formatting",
+          "owners": []
+        },
+        {
+          "pattern": "test/source",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "test/source",
+          "declared_in": "skills/assess/tests/README.md::lib/ suites",
+          "owners": []
+        },
+        {
+          "pattern": "test_pressure",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "tests/golden.py",
+          "declared_in": "skills/assess/tests/README.md::Infrastructure suites",
+          "owners": []
+        },
+        {
+          "pattern": "tests/test_accretion_ratchet.py",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "tests/test_doc_provenance.py",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "tests/test_promissory_markers.py",
+          "declared_in": "skills/assess/scripts/lib/README.md::Scoring",
+          "owners": []
+        },
+        {
+          "pattern": "tests/test_structure_drift.py",
+          "declared_in": "skills/assess/scripts/lib/README.md::Ownership and structure drift",
+          "owners": []
+        },
+        {
+          "pattern": "wikilinks",
+          "declared_in": "skills/assess/scripts/lib/README.md::Document analysis",
+          "owners": []
+        },
+        {
+          "pattern": "worktree",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        },
+        {
+          "pattern": "worktree",
+          "declared_in": "README.md::Use as a GitHub Action",
+          "owners": []
+        },
+        {
+          "pattern": "~/.claude",
+          "declared_in": "README.md::Install",
+          "owners": []
+        },
+        {
+          "pattern": "~/dev/github.com/<org>/<repo>/<repo>-main",
+          "declared_in": "README.md::Adapting for your workflow",
+          "owners": []
+        }
+      ],
+      "total_patterns": 400,
+      "matched_patterns": 115
+    },
+    "tier_1": {
+      "available": true,
+      "human_grouped_static_splits_count": 6582,
+      "human_split_static_fuses_count": 0,
+      "human_grouped_never_cochange_count": 6636,
+      "human_split_but_cochange_count": 6,
+      "human_static_agree_count": 56,
+      "human_cochange_agree_count": 2,
+      "seam_allowlist_applied": true,
+      "allowlist_pairs_count": 2
+    }
+  }
 }

--- a/skills/assess/tests/test_assess_core.py
+++ b/skills/assess/tests/test_assess_core.py
@@ -1373,3 +1373,86 @@ def test_accretion_ratchet_files_sorted_worst_first(git_repo) -> None:
     nets = [f["net_additions"] for f in files]
     assert nets == sorted(nets, reverse=True)  # worst (largest growth) first
     assert files[0]["path"] == "src/big.py"
+
+
+# --- structure_drift block (Tier 0 + Tier 1 orchestration) -------------------
+
+def test_structure_drift_block_omitted_without_ownership_map(git_repo) -> None:
+    """A repo with no CODEOWNERS / boundary doc emits no structure_drift block.
+
+    Tier 0 degrades to "no ownership map", so the orchestrator omits the block
+    entirely rather than emitting a half-block - the contract that absence means
+    "nothing to drift against", never "no drift".
+    """
+    repo, commit = git_repo
+    _seed_assess(repo)
+    (repo / "a.py").write_text("x = 1\n")
+    commit("init")
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-28")
+    assert "structure_drift" not in ctx
+
+
+def test_structure_drift_block_present_with_codeowners(git_repo) -> None:
+    """A repo with a CODEOWNERS map emits a Tier 0 block.
+
+    Tier 1 is present-or-absent depending on whether the static import graph is
+    available in the test env; either way the block carries a tier_0 with the
+    documented aggregate fields and a tier_1 with an explicit availability flag.
+    """
+    repo, commit = git_repo
+    _seed_assess(repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "a.py").write_text("x = 1\n")
+    (repo / "CODEOWNERS").write_text("src/** @team\nghost/** @nobody\n")
+    commit("init")
+
+    ctx = build_run_context(repo_root=repo, run_date="2026-05-28")
+    assert "structure_drift" in ctx
+    sd = ctx["structure_drift"]
+    assert sd["tier_0"]["available"] is True
+    assert sd["tier_0"]["total_patterns"] == 2
+    assert sd["tier_0"]["matched_patterns"] == 1
+    # The stale glob is the single empty pattern.
+    patterns = [e["pattern"] for e in sd["tier_0"]["empty_ownership_patterns"]]
+    assert patterns == ["ghost/**"]
+    # tier_1 always carries an availability flag (true or a graceful false).
+    assert "available" in sd["tier_1"]
+
+
+def test_structure_drift_block_builder_tier1_available() -> None:
+    """_structure_drift_block surfaces the six Tier 1 counts when available.
+
+    Pure builder test: a Tier 1 result with counts is rendered into the tier_1
+    sub-block with the seam-allowlist metadata, independent of any git/grimp.
+    """
+    repo = Path(__file__).resolve().parents[3]  # has an ownership map (lib README)
+    tier_1 = {
+        "available": True,
+        "human_grouped_static_splits_count": 3,
+        "human_split_static_fuses_count": 0,
+        "human_grouped_never_cochange_count": 4,
+        "human_split_but_cochange_count": 1,
+        "human_static_agree_count": 2,
+        "human_cochange_agree_count": 1,
+    }
+    block = assess_core._structure_drift_block(repo, tier_1)
+    assert block is not None
+    assert block["tier_1"]["available"] is True
+    assert block["tier_1"]["human_grouped_static_splits_count"] == 3
+    assert block["tier_1"]["human_split_but_cochange_count"] == 1
+    assert block["tier_1"]["seam_allowlist_applied"] is True
+    assert block["tier_1"]["allowlist_pairs_count"] >= 1
+
+
+def test_structure_drift_block_builder_tier1_unavailable() -> None:
+    """When Tier 1 is unavailable, tier_1 degrades to a bare available:False.
+
+    The static lens being out (no import graph) yields an unavailable Tier 1;
+    the block still carries the cheap Tier 0 data and a half-block-free tier_1.
+    """
+    repo = Path(__file__).resolve().parents[3]
+    block = assess_core._structure_drift_block(repo, {"available": False})
+    assert block is not None
+    assert block["tier_0"]["available"] is True
+    assert block["tier_1"] == {"available": False}

--- a/skills/assess/tests/test_golden_baseline.py
+++ b/skills/assess/tests/test_golden_baseline.py
@@ -161,6 +161,57 @@ def test_opening_summary_is_bespoke_not_boilerplate() -> None:
     assert boilerplate in folded, "the non-verdict framing should remain in the 'How to read' fold"
 
 
+def test_golden_has_structure_drift_block_with_both_tiers() -> None:
+    """The captured baseline carries the structure_drift block (Tier 0 + Tier 1).
+
+    This repo declares an ownership map (the lib README seam doc + the README
+    cross-links), so Tier 0 is available; the static import graph exists, so
+    Tier 1 is available too. The block's shape is pinned here so a future
+    pipeline change that drops or reshapes it fails loudly.
+    """
+    ctx = golden.load_golden_run_context()
+    assert "structure_drift" in ctx, "golden run-context missing structure_drift"
+    sd = ctx["structure_drift"]
+
+    t0 = sd["tier_0"]
+    assert t0["available"] is True
+    assert isinstance(t0["empty_ownership_patterns"], list)
+    assert isinstance(t0["total_patterns"], int)
+    assert isinstance(t0["matched_patterns"], int)
+    # Every empty-pattern row has the documented {pattern, declared_in, owners}.
+    for row in t0["empty_ownership_patterns"]:
+        assert set(row) == {"pattern", "declared_in", "owners"}
+
+    t1 = sd["tier_1"]
+    assert t1["available"] is True
+    for key in (
+        "human_grouped_static_splits",
+        "human_split_static_fuses",
+        "human_grouped_never_cochange",
+        "human_split_but_cochange",
+        "human_static_agree",
+        "human_cochange_agree",
+    ):
+        assert isinstance(t1[f"{key}_count"], int)
+    assert t1["seam_allowlist_applied"] is True
+    assert isinstance(t1["allowlist_pairs_count"], int)
+
+
+def test_golden_structure_drift_tier1_has_no_false_positive_seam() -> None:
+    """After the seam allowlist this repo surfaces no hidden-coupling seam.
+
+    The documented seams (lib<->tests, build<->skills) are absorbed by the
+    allowlist, and the version hot-file's repo-wide couplings don't recur as a
+    directory pair - so the drift-derived hidden_coupling contribution is empty.
+    The captured derived hidden_coupling finding therefore carries only the
+    pre-existing containment-derived directories, never a drift false positive.
+    """
+    ctx = golden.load_golden_run_context()
+    hc = next(f for f in ctx["derived_findings"] if f["name"] == "hidden_coupling")
+    # The version-hot-file directory must never appear as a hidden-coupling seam.
+    assert ".claude-plugin" not in hc["paths"]
+
+
 def test_agent_assess_block_is_not_duplicated() -> None:
     """The 'read the .assess/ directory' block is for agents and belongs only in
     the Machine-readable fold - it used to also appear in the Strengths fold.

--- a/skills/assess/tests/test_keyhole_signals.py
+++ b/skills/assess/tests/test_keyhole_signals.py
@@ -737,3 +737,105 @@ def test_integrate_accretion_ratchet_absent_is_silent() -> None:
         commit_sets=_BLEEDING_COMMIT_SETS,
     )
     assert _finding_paths(result, "accretion_ratchet") == []
+
+
+# --- structure drift (Tier 1) folded into hidden_coupling --------------------
+
+def _drift_tier1(pairs: list[tuple[str, str]]) -> dict:
+    """A minimal available Tier 1 result carrying only the hidden-seam list."""
+    return {
+        "available": True,
+        "human_split_but_cochange": [
+            {"file_a": a, "file_b": b} for a, b in pairs
+        ],
+    }
+
+
+def test_drift_hidden_coupling_unavailable_is_empty() -> None:
+    """An unavailable Tier 1 result yields no hidden-coupling dirs."""
+    assert ks.structure_drift_hidden_coupling_dirs({"available": False}) == []
+    assert ks.structure_drift_hidden_coupling_dirs({}) == []
+
+
+def test_drift_hidden_coupling_recurring_dir_pair_surfaces() -> None:
+    """Two trees straddled by >= min_pairs distinct file pairs both surface.
+
+    Two distinct file pairs link src/ and lib/; the pair recurs, so both
+    directories read as a genuine hidden seam.
+    """
+    tier1 = _drift_tier1([
+        ("src/a.py", "lib/x.py"),
+        ("src/b.py", "lib/y.py"),
+    ])
+    assert ks.structure_drift_hidden_coupling_dirs(tier1) == ["lib", "src"]
+
+
+def test_drift_hidden_coupling_hub_file_is_not_a_seam() -> None:
+    """A single hub file coupling with every tree manufactures no seam.
+
+    The version hot-file shape: one file in cfg/ co-changes with a different
+    directory on each pair. Each directory *pair* occurs exactly once, so none
+    recurs and no directory surfaces - the version-bump ritual is not drift.
+    """
+    tier1 = _drift_tier1([
+        ("cfg/v.json", "src/a.py"),
+        ("cfg/v.json", "lib/b.py"),
+        ("cfg/v.json", "docs/c.md"),
+    ])
+    assert ks.structure_drift_hidden_coupling_dirs(tier1) == []
+
+
+def test_drift_hidden_coupling_ignores_root_and_intra_dir() -> None:
+    """Pairs touching the repo root, or within one directory, are ignored.
+
+    A root-level file (dir ``.``) has vacuous containment; an intra-directory
+    pair is cohesion, not a cross-tree seam. Neither contributes a finding even
+    when repeated.
+    """
+    tier1 = _drift_tier1([
+        ("README.md", "src/a.py"),   # root side -> ignored
+        ("README.md", "src/b.py"),   # root side -> ignored
+        ("src/c.py", "src/d.py"),    # intra-dir -> ignored
+        ("src/e.py", "src/f.py"),    # intra-dir -> ignored
+    ])
+    assert ks.structure_drift_hidden_coupling_dirs(tier1) == []
+
+
+def test_drift_hidden_coupling_single_pair_below_threshold() -> None:
+    """One file pair straddling two trees is below the recurrence threshold."""
+    tier1 = _drift_tier1([("src/a.py", "lib/x.py")])
+    assert ks.structure_drift_hidden_coupling_dirs(tier1) == []
+
+
+def test_drift_tier1_silent_without_static_graph() -> None:
+    """_structure_drift_tier1 returns unavailable when the static graph is out.
+
+    With no import graph there is nothing to disagree with, so Tier 1 is not
+    even attempted - the detector is never called.
+    """
+    out = ks._structure_drift_tier1(
+        Path("/nonexistent"),
+        {"available": False},
+        {"available": True, "change_coupling_pairs": []},
+    )
+    assert out == {"available": False}
+
+
+def test_integrate_returns_structure_drift_tier1() -> None:
+    """integrate() exposes the Tier 1 result for the orchestrator to serialise.
+
+    With a /nonexistent repo there is no ownership map, so the detector degrades
+    to available:False - but the key is present, proving the wiring exists.
+    """
+    result = ks.integrate(
+        repo_root=Path("/nonexistent"),
+        complexity_stats=_COMPLEXITY_STATS,
+        doc_staleness=_stale_doc_staleness(churn_degenerate=False),
+        dead_code={"available": False, "candidate_count": 0,
+                   "candidates": [], "tools": []},
+        observability={"rung": None, "reachable": {"present": False}},
+        structure=_MODULAR_STRUCTURE,
+        commit_sets=_BLEEDING_COMMIT_SETS,
+    )
+    assert "structure_drift_tier1" in result
+    assert result["structure_drift_tier1"].get("available") in (True, False)


### PR DESCRIPTION
## Summary

Wires the structure-drift signal (Tier 0 path-existence + Tier 1 grouping disagreement) into the deterministic `/assess` core, emits a new top-level `structure_drift` run-context block, and surfaces the Tier 1 hidden-seam direction through the existing B3 `hidden_coupling` finding. This completes the integration of the third write-side tendency (ownership-map drift) alongside accretion (task 2/3), mirroring that proven pattern exactly.

## Changes Made

- **`assess_core.py`** — `_structure_drift_block` serialises Tier 0 (`detect_path_existence_drift`) plus the Tier 1 result that `keyhole_signals` already computed, into a `{tier_0, tier_1}` block. Attached via `_attach_structure_drift`; the block is omitted entirely (graceful, half-block-free) when no ownership map exists or a scan fails.
- **`keyhole_signals.py`** — `integrate()` now runs Tier 1 once (fed the behaviour block's already-parsed co-change pairs, so no second `git log` parse), folds its `human_split_but_cochange` direction into the existing `hidden_coupling` finding (no new finding type), and returns the Tier 1 result for the orchestrator to serialise. The fold uses a recurring *directory pair* test so the version hot-file's repo-wide couplings never read as a seam.
- **Golden baseline** — `run-context-baseline.json` now carries the real `structure_drift` block for this repo. After the seam allowlist, Tier 1 yields zero false-positive hidden-coupling seams (the version-bump couplings don't recur as a directory pair).
- **`lib/README.md`** — the `structure_drift.py` and `keyhole_signals.py` entries reflect the new orchestration/serialisation relationship.
- **Version** — `1.44.3` → `1.44.4`.

## Technical Details

- **Tier 1 conditional logic**: runs only when the static import graph is available (no graph → `available: False`, nothing to disagree with) AND an ownership map exists.
- **Seam allowlist** applied inside the frozen detector; counts in the block are post-allowlist.
- **No new finding key** — structure drift IS a B3 signal, so it reuses `hidden_coupling`; `GATE_CONCERN_FINDINGS` and the plugin contract need no change.

## Testing

- New tests: `structure_drift` block schema + Tier 1 no-false-positive (golden); `structure_drift_hidden_coupling_dirs` hub-filtering / recurrence / degradation and the `integrate` wiring (keyhole); block-builder Tier 1 available/unavailable and end-to-end omission/presence (assess_core).
- Full `skills/assess` suite (742 passed, 2 pre-existing skips), `plugin contract` (182), `scripts/` (106) all green; `ruff` + `mypy` gates green.
- Determinism verified: two `build_run_context` runs produce a byte-identical `structure_drift` block and run-context.

## Risk Assessment

Additive, read-side only — degrades to block omission on any failure and never gates the assessment. The report's B3 *rendering* of structure drift is deferred to a follow-up task and is out of scope here.