### PR TITLE
feat: Render structure drift findings in assess report

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.44.4",
+  "version": "1.45.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_report.py
+++ b/skills/assess/scripts/assess_report.py
@@ -49,6 +49,37 @@ DIFF_CATEGORIES = [
     ("persistent", "Persistent", "still in the hotspot list"),
 ]
 
+# Caps on listed empty-ownership patterns so a pathologically broken ownership
+# map can't bloat the frozen report. The full list stays in run-context.json.
+MAX_EMPTY_PATTERNS_RENDERED = 20
+
+# Tier 1 grouping-disagreement metrics, in render order. Each row is the
+# run-context key stem (the ``_count`` suffix is added at read time), a
+# human label, and the one-line interpretation - the disagreement (or
+# agreement) the metric measures between the declared boundary, the static
+# import graph, and the co-change history. The objective count is rendered
+# first, the interpretation second (SKILL.md deterministic-findings rule).
+TIER1_METRICS = [
+    ("human_grouped_static_splits",
+     "declared together, import graph splits them",
+     "a boundary the dependency structure no longer backs"),
+    ("human_split_static_fuses",
+     "import graph fuses them, no declared boundary does",
+     "cohesion the ownership map misses"),
+    ("human_grouped_never_cochange",
+     "declared together, commit log never couples them",
+     "a boundary history does not exercise as a unit"),
+    ("human_split_but_cochange",
+     "keep co-changing, no declared boundary groups them",
+     "a hidden seam the map omits (folded into hidden_coupling above)"),
+    ("human_static_agree",
+     "declared and dependency lenses agree",
+     "boundary backed by the import graph"),
+    ("human_cochange_agree",
+     "declared and historical lenses agree",
+     "boundary exercised as a unit by history"),
+]
+
 REPORT_TEMPLATE = Template("""# Deterministic Assessment Snapshot: $repo_name
 
 _Generated $run_date by `/assess` v$plugin_version.${commit_note}_
@@ -69,7 +100,7 @@ $hotspots_table
 $keyhole_summary
 
 $findings_section
-
+$structure_drift_section
 ## Changes Since Last Run
 
 $diff_section
@@ -124,6 +155,121 @@ def render_findings_section(ctx: dict) -> str:
     if not markdown or not markdown.strip():
         return "_No cross-layer findings recorded._"
     return markdown.strip()
+
+
+def _render_tier0_drift(tier_0: dict) -> list[str]:
+    """Tier 0 ownership-map drift: declared globs matching zero tracked files.
+
+    Each empty pattern is a slice of the tree the ownership map *claims* to
+    cover but no file satisfies, so any edit there silently skips the declared
+    owner's review. Lists the pattern, where it was declared, and the owners it
+    would have routed to. Returns ``[]`` (caller omits the section) when Tier 0
+    is unavailable or no pattern is empty - absence reads as "nothing stale",
+    never a broken half-section.
+    """
+    if not tier_0.get("available"):
+        return []
+    patterns = tier_0.get("empty_ownership_patterns") or []
+    if not patterns:
+        return []
+    ordered = sorted(
+        patterns,
+        key=lambda p: (p.get("pattern", ""), p.get("declared_in", "")),
+    )
+    lines = [
+        "### Tier 0 - Ownership Map Drift",
+        "",
+        (f"{len(patterns)} declared ownership pattern"
+         f"{'' if len(patterns) == 1 else 's'} match zero tracked files. "
+         "Stale ownership silently drops review coverage: an edit under one of "
+         "these patterns routes to no declared owner."),
+        "",
+    ]
+    for p in ordered[:MAX_EMPTY_PATTERNS_RENDERED]:
+        owners = p.get("owners") or []
+        owners_text = ", ".join(owners) if owners else "_no owners declared_"
+        lines.append(
+            f"- `{p.get('pattern', '?')}` "
+            f"(declared in {p.get('declared_in', '?')}; owners: {owners_text})"
+        )
+    overflow = len(ordered) - MAX_EMPTY_PATTERNS_RENDERED
+    if overflow > 0:
+        lines.append(f"- ...and {overflow} more")
+    lines.append("")
+    return lines
+
+
+def _render_tier1_disagreement(tier_1: dict, repo_name: str) -> list[str]:
+    """Tier 1 grouping disagreement: six set-algebra counts over the declared,
+    static-import, and co-change groupings, plus the seam-allowlist note.
+
+    The objective counts lead; the interpretation follows each (SKILL.md
+    deterministic-findings rule). The hidden-seam direction
+    (``human_split_but_cochange``) already folds into the ``hidden_coupling``
+    finding above, so this block surfaces the explicit magnitudes and the
+    allowlist transparency line rather than re-rendering that finding. Returns
+    ``[]`` (caller omits) when the static lens was unavailable.
+    """
+    if not tier_1.get("available"):
+        return []
+    lines = [
+        "### Tier 1 - Grouping Disagreement",
+        "",
+        ("Set-algebra over three groupings - the declared boundary, the static "
+         "import graph, and the co-change history - counting the file pairs each "
+         "lens pair agrees or disagrees on:"),
+        "",
+    ]
+    for key, label, interpretation in TIER1_METRICS:
+        count = tier_1.get(f"{key}_count", 0)
+        lines.append(f"- **{count}** `{key}` - {label}: {interpretation}")
+    lines.append("")
+    if tier_1.get("seam_allowlist_applied"):
+        n = tier_1.get("allowlist_pairs_count", 0)
+        note = (
+            f"Seam allowlist applied: {n} owned seam pair"
+            f"{'' if n == 1 else 's'} excluded from the disagreement counts "
+            "before they were reported."
+        )
+        if _is_self_assessment(repo_name):
+            note += " See `lib/README.md` for the owned seams."
+        lines.append(note)
+        lines.append("")
+    return lines
+
+
+def _is_self_assessment(repo_name: str) -> bool:
+    """True when /assess is assessing its own repo - the only case where the
+    ``lib/README.md`` owned-seams footnote points at a file that exists."""
+    return repo_name == "ai-native-toolkit"
+
+
+def format_structure_drift_findings(
+    structure_drift: dict | None, repo_name: str = "",
+) -> str:
+    """Render the run-context ``structure_drift`` block as a Markdown section.
+
+    Two tiers, each independently omitted when it has nothing to say:
+    - **Tier 0** lists declared ownership patterns matching no tracked file.
+    - **Tier 1** surfaces the six grouping-disagreement counts and the
+      seam-allowlist transparency line.
+
+    Counts lead, interpretation follows; the harness never auto-prescribes
+    regenerating the ownership map - that is a human decision, stated here only
+    so the human can make it. Returns ``""`` (caller omits the heading) when the
+    block is absent or both tiers are empty - graceful degrade, no broken
+    markdown.
+    """
+    if not structure_drift:
+        return ""
+    body: list[str] = []
+    body += _render_tier0_drift(structure_drift.get("tier_0") or {})
+    body += _render_tier1_disagreement(
+        structure_drift.get("tier_1") or {}, repo_name,
+    )
+    if not body:
+        return ""
+    return "## Structure Drift\n\n" + "\n".join(body).rstrip() + "\n"
 
 
 def _format_transition(category: str, entry: dict) -> str:
@@ -238,9 +384,18 @@ def render_report(ctx: dict, repo_name: str) -> str:
         hotspots_table=render_hotspots_table(ctx),
         keyhole_summary=render_keyhole_summary(ctx),
         findings_section=render_findings_section(ctx),
+        structure_drift_section=_structure_drift_section(ctx, repo_name),
         diff_section=render_diff_section(ctx),
     )
     return report.rstrip() + "\n"
+
+
+def _structure_drift_section(ctx: dict, repo_name: str) -> str:
+    """Template-ready structure-drift block: the rendered section followed by a
+    blank line, or ``""`` when there's nothing to render (the surrounding blank
+    line in the template then collapses on the final ``rstrip``)."""
+    section = format_structure_drift_findings(ctx.get("structure_drift"), repo_name)
+    return f"\n{section.rstrip()}\n" if section else ""
 
 
 def load_context(repo_root: Path) -> dict:

--- a/skills/assess/tests/test_assess_report.py
+++ b/skills/assess/tests/test_assess_report.py
@@ -15,6 +15,7 @@ import pytest
 from assess_report import (
     _fmt,
     _render_commit_note,
+    format_structure_drift_findings,
     load_context,
     main,
     render_diff_section,
@@ -74,6 +75,37 @@ def _full_ctx() -> dict:
             {"path": "scripts", "action": "investigate the seam",
              "findings": ["hidden_coupling"], "rank": 1},
         ],
+        "structure_drift": _structure_drift_block(),
+    }
+
+
+def _structure_drift_block() -> dict:
+    """A populated structure_drift block: Tier 0 empty globs + Tier 1 counts."""
+    return {
+        "tier_0": {
+            "available": True,
+            "total_patterns": 30,
+            "matched_patterns": 8,
+            "empty_ownership_patterns": [
+                {"pattern": "../skills/marathon/SKILL.md",
+                 "declared_in": "commands/README.md::Workflow",
+                 "owners": []},
+                {"pattern": "./assess/SKILL.md",
+                 "declared_in": "skills/README.md::Portable",
+                 "owners": ["@platform-team"]},
+            ],
+        },
+        "tier_1": {
+            "available": True,
+            "human_grouped_static_splits_count": 6582,
+            "human_split_static_fuses_count": 0,
+            "human_grouped_never_cochange_count": 6636,
+            "human_split_but_cochange_count": 6,
+            "human_static_agree_count": 56,
+            "human_cochange_agree_count": 2,
+            "seam_allowlist_applied": True,
+            "allowlist_pairs_count": 2,
+        },
     }
 
 
@@ -312,6 +344,101 @@ def test_commit_note_dirty_and_behind() -> None:
 def test_commit_note_unavailable_is_empty() -> None:
     assert _render_commit_note({"measured_commit": {"available": False}}) == ""
     assert _render_commit_note({}) == ""
+
+
+# --------------------------------------------------------------------------
+# Structure drift (Tier 0 ownership-map drift + Tier 1 grouping disagreement)
+# --------------------------------------------------------------------------
+
+def test_structure_drift_tier0_lists_empty_patterns() -> None:
+    """Tier 0 surfaces each empty ownership pattern with its declared_in source
+    and owners, framed as stale ownership dropping review coverage."""
+    out = format_structure_drift_findings(_structure_drift_block())
+    assert "Tier 0" in out
+    assert "Ownership Map Drift" in out
+    assert "`../skills/marathon/SKILL.md`" in out
+    assert "commands/README.md::Workflow" in out
+    assert "@platform-team" in out
+    # The interpretation is review-coverage loss, not a blame.
+    assert "review coverage" in out
+
+
+def test_structure_drift_tier0_omitted_when_no_empty_patterns() -> None:
+    block = _structure_drift_block()
+    block["tier_0"]["empty_ownership_patterns"] = []
+    out = format_structure_drift_findings(block)
+    assert "Tier 0" not in out
+
+
+def test_structure_drift_tier0_omitted_when_unavailable() -> None:
+    block = _structure_drift_block()
+    block["tier_0"] = {"available": False}
+    out = format_structure_drift_findings(block)
+    assert "Tier 0" not in out
+
+
+def test_structure_drift_tier1_renders_six_counts() -> None:
+    """Tier 1 surfaces the six disagreement/agreement counts, objective first."""
+    out = format_structure_drift_findings(_structure_drift_block())
+    assert "Tier 1" in out
+    assert "Grouping Disagreement" in out
+    # All six magnitudes are present.
+    assert "6582" in out
+    assert "6636" in out
+    assert "56" in out
+    assert "2" in out
+    # Zero counts are shown explicitly, not dropped.
+    assert "human_split_static_fuses" in out
+    assert "human_split_but_cochange" in out
+
+
+def test_structure_drift_tier1_omitted_when_unavailable() -> None:
+    block = _structure_drift_block()
+    block["tier_1"] = {"available": False}
+    out = format_structure_drift_findings(block)
+    assert "Grouping Disagreement" not in out
+
+
+def test_structure_drift_seam_allowlist_transparency() -> None:
+    """When the allowlist fired, the report says so and how many pairs it cut."""
+    out = format_structure_drift_findings(_structure_drift_block())
+    assert "allowlist" in out
+    assert "2" in out  # allowlist_pairs_count
+
+
+def test_structure_drift_never_auto_recommends_regenerate_codeowners() -> None:
+    """The deterministic harness states counts; regenerating the ownership map is
+    a human decision, never an auto-prescribed action."""
+    out = format_structure_drift_findings(_structure_drift_block()).lower()
+    assert "regenerate codeowners" not in out
+    assert "regenerate the ownership map" not in out
+
+
+def test_structure_drift_empty_block_omitted() -> None:
+    assert format_structure_drift_findings(None) == ""
+    assert format_structure_drift_findings({}) == ""
+
+
+def test_structure_drift_deterministic() -> None:
+    block = _structure_drift_block()
+    assert format_structure_drift_findings(block) == \
+        format_structure_drift_findings(block)
+
+
+def test_structure_drift_in_full_report() -> None:
+    report = render_report(_full_ctx(), "demo")
+    assert "Structure Drift" in report
+    assert "Tier 0" in report
+    assert "Tier 1" in report
+    assert "$" not in report
+
+
+def test_structure_drift_absent_block_leaves_valid_report() -> None:
+    ctx = _full_ctx()
+    del ctx["structure_drift"]
+    report = render_report(ctx, "demo")
+    assert "Structure Drift" not in report
+    assert "$" not in report
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Renders the run-context `structure_drift` block in the deterministic `/assess` report (`assess_report.py`), completing the structure_drift signal end to end: the Tier 0 path-existence cut and the Tier 1 grouping-disagreement counts are now surfaced in the frozen report, not just serialised into `run-context.json`.

## Changes Made

- `skills/assess/scripts/assess_report.py`
  - `format_structure_drift_findings(structure_drift, repo_name)` renders a new `## Structure Drift` section with two independently-omitted tiers.
  - **Tier 0 - Ownership Map Drift**: lists each declared ownership pattern that matches zero tracked files, with its `declared_in` source and owners, framed as "stale ownership silently drops review coverage." Rendered only when `tier_0.available` and at least one pattern is empty; capped at 20 listed patterns with an overflow line; patterns sorted for determinism.
  - **Tier 1 - Grouping Disagreement**: surfaces the six set-algebra counts (objective magnitude first, interpretation second), in a fixed render order. The hidden-seam direction (`human_split_but_cochange`) already folds into the existing `hidden_coupling` finding; this section references that rather than re-deriving it, and adds the explicit counts the finding does not carry.
  - **Seam-allowlist transparency**: when the allowlist fired, notes how many owned-seam pairs it excluded before reporting; for `/assess`'s own repo, footnotes "See `lib/README.md` for the owned seams."
  - Wired into the report template; the section self-omits (no broken markdown, blank-line spacing preserved) when the block is absent or both tiers are empty.

- `skills/assess/tests/test_assess_report.py`: Tier 0 listing + omission paths, Tier 1 six-count rendering + omission, allowlist transparency, the "never auto-recommend regenerate CODEOWNERS" guard, determinism, full-report integration, and absent-block graceful degrade.

- `.claude-plugin/plugin.json`: version `1.44.4` -> `1.45.0` (MINOR - the structure_drift signal, Tier 0 + Tier 1, is now fully shipped and surfaced in the report).

## Technical Details

The renderer consumes the deterministic core's `structure_drift` block verbatim - counts lead, interpretation follows (the deterministic-findings framing rule), and the harness never auto-prescribes regenerating the ownership map; that is a human decision, stated so the human can make it. Same `run-context.json` in -> byte-identical section out (sorted patterns, fixed metric order, no set/dict-order leakage).

## Testing

- `skills/assess` pytest: 753 passed, 2 skipped (43 in the report suite).
- `scripts/` pytest: 106 passed.
- `plugin contract` pytest: 182 passed.
- `ruff check .` (skills/assess + complexity ratchet) and `mypy` gate: clean.

## Risk Assessment

Low. Additive report section behind availability flags; absent/empty input omits the section cleanly. No change to the deterministic core, the run-context schema, or any other orchestrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assessment reports now include a Structure Drift section that identifies unmatched code ownership patterns and consistency metrics.

* **Tests**
  * Added comprehensive test coverage for Structure Drift reporting.

* **Chores**
  * Bumped plugin version to 1.45.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->