### PR TITLE
fix: Correct huddle teammate->chair address from main to team-lead

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -180,7 +180,7 @@ You are a [ROLE] with deep expertise in [DOMAIN]. This identity persists across 
 
 ## Your Teammates
 
-[ROSTER — the chair lists every other member's name slug here, e.g. "security-eng, product-mgr, sre".] You share findings by sending one `SendMessage` per teammate name; there is no broadcast. If this roster is missing, message the chair (`SendMessage(to: "main", ...)`) and ask for the peer list.
+[ROSTER — the chair lists every other member's name slug here, e.g. "security-eng, product-mgr, sre".] You share findings by sending one `SendMessage` per teammate name; there is no broadcast. If this roster is missing, do NOT address the chair as `"main"` — for a background teammate `"main"` resolves to your own sub-session and is rejected ("you are the main conversation"), which can make you silently give up on reporting. Reach the chair as `SendMessage(to: "team-lead", ...)` — the `teammate_id` under which your spawn instructions arrived — and ask for the peer list. If you would rather self-discover, read the team config at `~/.claude/teams/<session-team>/config.json` and take the other `members[].name` entries.
 
 ## IMMEDIATE FIRST TASK
 


### PR DESCRIPTION
## Summary
The `/huddle` team-mode roster section told a teammate with a missing roster to reach the chair via `SendMessage(to: "main", ...)`. Empirical probing on Claude Code 2.1.181 (the `huddle-comms-probe` run) showed that for a background teammate `"main"` resolves to its own sub-session and is **rejected** ("you are the main conversation"). One probe teammate, on hitting that rejection, wrongly concluded it had no lead and **silently dropped its report up** - the exact failure this line could cause in a real huddle.

## Changes Made
- `skills/huddle/SKILL.md` - the `## Your Teammates` missing-roster fallback now directs teammates to:
  - reach the chair as `SendMessage(to: "team-lead", ...)` (the `teammate_id` their spawn instructions arrive under), and
  - optionally self-discover peers from `members[].name` in `~/.claude/teams/<session-team>/config.json`.
- `.claude-plugin/plugin.json` - version 1.45.1 -> 1.45.2 (patch).

## Technical Details
Verified on CC 2.1.181, macOS, iTerm2: roster-in-prompt cross-talk and `config.json` self-discovery both deliver verbatim; the chair is reachable only as `team-lead`, not `"main"`. The fix is doc/behaviour-only inside the skill body.

## Testing
No code paths changed; the deterministic-core pytest + lint gates and the plugin-contract internal-link check apply unchanged. CI on this PR covers them.

## Risk Assessment
Low. Single-paragraph correction in one skill plus a patch version bump. No script, schema, or build-pipeline changes.

## Notes
Out of scope here: the team-mode **shutdown** wording (merged separately via #212) is being revisited under the #211 / upstream #68721 track - this PR deliberately does not touch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated team roster request instructions for background teammates to use the correct communication channel.

* **Chores**
  * Version bump to 1.45.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->