### PR TITLE
feat: Add chair-facilitated deliberation loop to huddle phases

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.45.2",
+  "version": "1.46.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/huddle/SKILL.md
+++ b/skills/huddle/SKILL.md
@@ -200,7 +200,7 @@ Blue Hat (the team lead) will announce each new phase. When announced:
 
 1. **Spawn the hat agent** with a prompt shaped by YOUR professional lens
 2. **Share findings** with each teammate individually — one `SendMessage` per name on your roster (no broadcast)
-3. **Discuss with peers** — 2-3 substantive messages max per phase
+3. **Engage the tension Blue raises** — Blue will name a specific disagreement and ask you to respond to a specific peer. Answer it *from your lens*: rebut, qualify, or build on their point with NEW reasoning your discipline supplies. 2-3 substantive messages max per phase.
 4. **Follow Blue's direction** — when Blue says move on, move on
 
 ## Communication Style
@@ -209,6 +209,7 @@ Blue Hat (the team lead) will announce each new phase. When announced:
 - Reference specific findings from your hat agent investigation.
 - Challenge other members respectfully when your expertise says otherwise.
 - Build on others' observations — "Adding to what [member] said..."
+- **Stay in your lens — don't merge into the group voice.** Argue *from* your named profession. When you agree, say *why* from your expertise, or what your discipline would still flag; never collapse into a generic "I agree." The friction your specialty adds is your entire value here.
 - Keep exchanges focused — 2-3 substantive messages per phase, not endless back-and-forth.
 - **Never re-broadcast findings you already shared.** If Blue or a peer asks you to elaborate, add NEW detail or nuance.
 - When Blue announces a new phase, commit fully to the new hat. Don't continue cross-discussing the prior phase.
@@ -249,31 +250,31 @@ SendMessage(
 
 **Include specific questions and prior-phase context in every announcement.** Vague prompts like "share your gut reactions" produce idle members. Concrete prompts like "the dunning race condition and the demo conflict are the two biggest risks - what else?" produce immediate action.
 
-**4b. Monitor the discussion**
+**4b. Run the deliberation loop**
 
-As messages come in from team members:
-- Let them discuss peer-to-peer - don't relay messages
-- Intervene if someone drifts off the current hat's focus
-- If a member goes idle without sharing findings, send ONE direct nudge with an explicit agent spawn prompt. If they don't respond after the nudge, move on - don't block the meeting on one member.
-- Note consensus and dissent internally
-- Extend the phase if dialogue is producing genuine insight
+A phase is a facilitated discussion, not a round of parallel reports. Run this loop before you advance - it is what makes sequential hats worth the cost:
 
-**4c. Move to next phase**
+1. **Collect first findings.** Wait for findings from at least N-1 members (e.g., 2 of 3); don't block on one idle member. If a member goes idle without sharing, send ONE direct nudge with an explicit agent spawn prompt, then proceed without them.
+2. **Seed an exchange - required before you may advance.** Reading the findings, pick the single sharpest disagreement between two lenses and prompt both members by name to respond to each other: "security-eng flagged X; product-mgr, your lens values Y, which conflicts - respond directly to security-eng." This forces a real rebuttal/build-on instead of parallel monologues. A phase must contain at least one such exchange before it closes.
+3. **Seed more while it pays.** If the discussion is producing genuine insight and other live disagreements remain, seed them too - your judgment. Stop seeding when no new substantive points surface.
+4. **Keep it on the hat, and keep the lenses apart.** Redirect anyone drifting off the current hat or rehashing a prior phase (one message; enforce each hat's "Not My Job" lane). Watch for **voice-collapse** - members agreeing without lens-specific reasoning - and re-anchor them: "That's a security framing - product-mgr, what does YOUR lens say?" Distinct professional voices held apart is the goal; homogenised consensus is a failure mode dressed as success. Don't relay messages - members talk directly.
 
-Move on when you have findings from at least N-1 members (e.g., 2 of 3). Do not wait indefinitely for every member. Announce the transition to each member individually - one `SendMessage` per member name (there is no all-recipients broadcast):
+**4c. Converge-or-cap, then advance**
+
+Close the phase when **either** the discussion has converged (no new substantive points; consensus and the specific dissent are both clear) **or** each engaged member has had ~2 exchange rounds (the 2-3-message cap). Whichever comes first - this bounds cost and can't deadlock on an over-talker. Then announce the transition to each member individually - one `SendMessage` per member name (there is no all-recipients broadcast) - leading with a synthesis of what just happened:
 
 ```
 for each <member-name> in your team:
 SendMessage(
   to: "<member-name>",
-  message: "[1-2 sentence summary of key takeaway from this phase]. Moving to [NEXT HAT] phase.
+  message: "[1-2 sentence synthesis: what the team converged on, and the specific dissent we carry forward]. Moving to [NEXT HAT] phase.
 
   [Specific framing questions informed by what was just surfaced]",
   summary: "Phase summary, moving to [next hat]"
 )
 ```
 
-Carry forward key tensions or open questions into the framing of the next phase.
+The synthesis is the artifact the pause produces - a running consensus/dissent ledger, not just elapsed time. Carry the live tensions into the framing of the next phase.
 <!-- chat-skip:end -->
 
 ### Step 5: Deliver the Verdict


### PR DESCRIPTION
## Summary
In team mode, a `/huddle` phase could advance the moment N-1 members reported findings - a **reporting** threshold, not a **deliberation** one. The chair could therefore skip the cross-member discussion that a Six Thinking Hats session exists for, while the run still read as "discussion happened." This makes each phase a real facilitated loop.

## Changes Made
`skills/huddle/SKILL.md` - Step 4 becomes an explicit per-phase deliberation loop:
- **4b. Run the deliberation loop**: collect findings (N-1, don't block on one idle member) -> **seed an exchange** (chair names the sharpest two-lens disagreement and requires a direct rebuttal/build-on; **at least one per phase**, seed more while it produces insight) -> keep it on the current hat and **keep the lenses apart** (re-anchor on voice-collapse) -> don't relay (switchboard rule preserved).
- **4c. Converge-or-cap, then advance**: close on convergence **or** a ~2-round cap (whichever first - bounds cost, can't deadlock on an over-talker), then transition with a **1-2 sentence synthesis** carried into the next phase.
- Member-facing instructions: engage the seeded tension *from your lens*; **stay in your lens, don't merge into the group voice**.

`.claude-plugin/plugin.json` - 1.45.2 -> 1.46.0.

## Technical Details
Stop condition is **converge-or-cap**: a required floor (>=1 real exchange) plus a ceiling (convergence or the existing 2-3-message cap). Seeding is adaptive - one minimum, more while it pays. The voice-collapse guardrail traces to a named failure mode (distinct professional voices homogenising into one), per the repo's feature test. Team mode only; phased/solo have no peers.

## Testing
All edits sit inside the existing `<!-- chat-skip -->` block. Verified locally: marker balance 11/11, `build-standalone-skills.sh huddle` succeeds, and the new plugin-only content is correctly absent from the standalone ZIP. CI runs the pytest + lint + plugin-contract gates.

## Risk Assessment
Low. Doc/behaviour change in one skill section, no scripts/schema/build-pipeline changes, no new build markers. Backward-compatible - no interface users must adapt to.

## Notes
Designed via brainstorming (converge-or-cap stop condition, adaptive seeding, lens-preservation) before implementation; this PR body is the design record. Out of scope: shutdown wording (the #211 / #68721 track).