### PR TITLE
feat: Parse existing coverage reports into test-pressure scan

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.46.3",
+  "version": "1.46.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -52,6 +52,7 @@ from lib.badge import (
     write_badge,
 )
 from lib.assess_config import load_excludes, load_structure_config
+from lib.coverage_report import detect_coverage_report, load_coverage_data
 from lib.doc_graph import build_doc_graph, is_repo_file
 from lib.doc_staleness import analyze_doc_staleness
 from lib.git_churn import git_commit_info, tracked_files
@@ -988,9 +989,27 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
     # mutation survivor density with the complexity hotspots.
     hot_files = [h.get("path") for h in current.get("top_hotspots", [])
                  if h.get("path")]
+    # Pull line-coverage truth from a report the project already generated (CI or
+    # local) - /assess never runs the suite, so an existing coverage.xml / lcov.info
+    # is the only honest source. Absent or malformed -> None, and the scan reports
+    # "not assessed" rather than guessing. Provenance is recorded separately so the
+    # report can distinguish a real read from "none found".
+    cov_detect = detect_coverage_report(repo_root)
+    coverage_data = load_coverage_data(repo_root)
+    ctx["coverage_report"] = (
+        {
+            "available": True,
+            "source": cov_detect["source"],
+            "format": cov_detect["format"],
+            "parsed": coverage_data is not None,
+        }
+        if cov_detect
+        else {"available": False, "source": "none found"}
+    )
     test_pressure = _safe(
         "test_pressure",
-        lambda: scan_test_pressure(repo_root, hot_files=hot_files, opt_in=False),
+        lambda: scan_test_pressure(repo_root, hot_files=hot_files, opt_in=False,
+                                   coverage_data=coverage_data),
     )
     # A failed (or malformed) scan must not read as "no mutation setup": that
     # would mis-score Layer 1 just as a failed liveness scan would mis-score

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -350,6 +350,22 @@ Inspects a run-context dict for suspicious results (e.g. zero files scored, impl
 CCN) and returns typed `Anomaly` records. Detail strings are sanitised (counts and
 grades only, no paths or code) so they are safe to include in self-feedback issues.
 
+**`coverage_report.py`**
+Parses an *existing* coverage report into the shape the `test_pressure` scan's
+`coverage_data=` param consumes (`{_overall, per_file: {relpath: line_rate}}`).
+Two formats: Cobertura `coverage.xml` (`_overall` from the root `line-rate`,
+per-file from each `<class>` element's `filename`/`line-rate`; one `iter("class")`
+walk handles both the flat and nested `<packages>` schemas) and `lcov.info`
+(per-file `LH/LF`, overall `sum(LH)/sum(LF)`). `/assess` never runs the suite, so a
+report the project already generated is the only honest line-coverage source - the
+parser reads it without taking a coverage.py runtime dependency. `detect_coverage_report`
+searches the repo root, `./coverage/`, and `./.coverage/` (a `.coverage` SQLite *file*
+is out of scope - reading it needs the coverage.py lib). Honest-degrade is the hard
+contract: a missing or malformed report returns `None`, never raises, never blocks the
+assessment; `assess_core.py` records provenance ("none found" vs. the file/format read)
+separately. Stdlib only, imports no orchestrator. Add fixtures + cases in
+`tests/test_coverage_report.py` alongside any change to a parse rule.
+
 **`test_pressure/`**
 Layer 1 write-side truth pressure. Two tiers:
 - Mutation tier: runs a mutation-testing tool (mutmut for Python) over a sample of the

--- a/skills/assess/scripts/lib/coverage_report.py
+++ b/skills/assess/scripts/lib/coverage_report.py
@@ -1,0 +1,171 @@
+"""Parse an *existing* coverage report into the shape ``scan_test_pressure``
+already consumes - no coverage run, no third-party library, read-only.
+
+`/assess` never runs the test suite (it stays read-only and fast), so the only
+honest source of line-coverage truth is a report the project already generated
+in CI or locally. This module reads two ubiquitous formats - Cobertura
+``coverage.xml`` and ``lcov.info`` - and reduces each to the documented shape the
+test-pressure scan's ``coverage_data=`` param expects:
+
+    {"_overall": float, "per_file": {relpath: line_rate}}
+
+``_overall`` feeds the Layer 1 coverage-vs-mutation gap signal; ``per_file`` is
+the per-file line ratio. Both are *informational* truth pulled from the
+project's own tooling, never a gate.
+
+Honest degradation is the hard contract here: a missing report, a malformed one,
+or an unreadable file degrades to ``None`` - never an exception, never a block to
+the assessment. The provenance distinction (a real read vs. "none found") is
+recorded by the orchestrator from ``detect_coverage_report`` so the report can
+state which it was.
+
+A bare ``.coverage`` SQLite *file* is deliberately out of scope: reading it needs
+the ``coverage.py`` library (a runtime dependency the deterministic core does not
+take), so it degrades as if absent.
+
+Inward-only imports: this module imports stdlib only and is imported by the
+orchestrator (`assess_core.py`); it never imports an orchestrator itself.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+# Cobertura first, then lcov; repo root, then the common report sub-directories.
+# A ``.coverage`` directory is searched for nested reports; a ``.coverage`` SQLite
+# *file* never matches (``is_file`` on a path inside it fails) - out of scope by
+# construction, no special-case needed.
+_CANDIDATES: tuple[tuple[str, str], ...] = (
+    ("coverage.xml", "cobertura"),
+    ("coverage/coverage.xml", "cobertura"),
+    (".coverage/coverage.xml", "cobertura"),
+    ("lcov.info", "lcov"),
+    ("coverage/lcov.info", "lcov"),
+    (".coverage/lcov.info", "lcov"),
+)
+
+
+def _parse_cobertura(path: Path) -> dict[str, Any] | None:
+    """Parse a Cobertura ``coverage.xml`` into ``{_overall, per_file}``.
+
+    ``_overall`` is the root ``line-rate``; ``per_file`` maps each ``<class>``
+    element's ``filename`` to its ``line-rate``. ``root.iter("class")`` walks the
+    whole tree, so both the flat (``<coverage><classes><class>``) and nested
+    (``<coverage><packages><package><classes><class>``) schemas are handled by
+    the same pass. Returns ``None`` on any parse/read error or empty report.
+    """
+    try:
+        root = ET.parse(str(path)).getroot()
+    except (ET.ParseError, OSError, ValueError):
+        return None
+    try:
+        rate = root.get("line-rate")
+        overall: float | None = float(rate) if rate is not None else None
+
+        per_file: dict[str, float] = {}
+        for cls in root.iter("class"):
+            filename = cls.get("filename")
+            cls_rate = cls.get("line-rate")
+            if filename is None or cls_rate is None:
+                continue
+            try:
+                per_file[filename] = float(cls_rate)
+            except (TypeError, ValueError):
+                continue
+
+        if overall is None and not per_file:
+            return None
+        return {"_overall": overall, "per_file": per_file}
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def _parse_lcov(path: Path) -> dict[str, Any] | None:
+    """Parse an ``lcov.info`` tracefile into ``{_overall, per_file}``.
+
+    Line-by-line: ``SF:`` opens a record (the source file), ``LF:`` is lines
+    found, ``LH:`` is lines hit. Per-file ``line_rate = LH / LF``; overall is
+    ``sum(LH) / sum(LF)`` across all records. A record is flushed on
+    ``end_of_record``, on the next ``SF:``, or at end-of-file, so a tracefile
+    that omits the terminator still parses. Returns ``None`` on read error or an
+    empty / zero-line report.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+    per_file: dict[str, float] = {}
+    total_lf = 0
+    total_lh = 0
+    current: str | None = None
+    lf = 0
+    lh = 0
+
+    def flush() -> None:
+        nonlocal total_lf, total_lh
+        if current is not None and lf > 0:
+            per_file[current] = lh / lf
+            total_lf += lf
+            total_lh += lh
+
+    try:
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line.startswith("SF:"):
+                flush()
+                current = line[3:].strip()
+                lf = lh = 0
+            elif line.startswith("LF:"):
+                lf = int(line[3:].strip())
+            elif line.startswith("LH:"):
+                lh = int(line[3:].strip())
+            elif line == "end_of_record":
+                flush()
+                current = None
+                lf = lh = 0
+        flush()
+    except (TypeError, ValueError):
+        return None
+
+    if not per_file or total_lf == 0:
+        return None
+    return {"_overall": total_lh / total_lf, "per_file": per_file}
+
+
+def detect_coverage_report(repo_root: Path | str) -> dict[str, str] | None:
+    """Locate a coverage report at the repo root or a common sub-directory.
+
+    Searches ``coverage.xml`` (Cobertura) and ``lcov.info`` at the repo root,
+    ``./coverage/``, and ``./.coverage/`` (as a directory). Returns
+    ``{"source": <relpath>, "format": "cobertura"|"lcov"}`` for the first match,
+    or ``None`` if none is found. A ``.coverage`` SQLite file is never matched -
+    it is out of scope (see module docstring).
+    """
+    root = Path(repo_root)
+    for rel, fmt in _CANDIDATES:
+        if (root / rel).is_file():
+            return {"source": rel, "format": fmt}
+    return None
+
+
+def load_coverage_data(repo_root: Path | str) -> dict[str, Any] | None:
+    """Detect, then parse, a coverage report under ``repo_root``.
+
+    Returns the documented ``{_overall, per_file}`` shape, or ``None`` when no
+    report is found or the report cannot be parsed. Never raises - this is the
+    read-only entry point the orchestrator wires before ``scan_test_pressure``.
+    """
+    try:
+        detected = detect_coverage_report(repo_root)
+        if detected is None:
+            return None
+        path = Path(repo_root) / detected["source"]
+        if detected["format"] == "cobertura":
+            return _parse_cobertura(path)
+        if detected["format"] == "lcov":
+            return _parse_lcov(path)
+        return None
+    except Exception:  # noqa: BLE001 - never raise into the assessment
+        return None

--- a/skills/assess/tests/fixtures/coverage.xml
+++ b/skills/assess/tests/fixtures/coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<coverage line-rate="0.75" branch-rate="0.5" lines-covered="15" lines-valid="20" version="6.5.0" timestamp="1700000000000">
+  <sources>
+    <source>.</source>
+  </sources>
+  <packages>
+    <package name="src" line-rate="0.75" branch-rate="0.5" complexity="0">
+      <classes>
+        <class name="a" filename="src/a.py" line-rate="0.8" branch-rate="0.5" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="1"/>
+            <line number="2" hits="0"/>
+          </lines>
+        </class>
+        <class name="b" filename="src/b.py" line-rate="0.5" branch-rate="0.5" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="1"/>
+            <line number="2" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/skills/assess/tests/fixtures/lcov.info
+++ b/skills/assess/tests/fixtures/lcov.info
@@ -1,0 +1,14 @@
+TN:
+SF:src/a.py
+DA:1,1
+DA:2,1
+DA:3,0
+LF:10
+LH:8
+end_of_record
+SF:src/b.py
+DA:1,1
+DA:2,0
+LF:10
+LH:2
+end_of_record

--- a/skills/assess/tests/test_coverage_report.py
+++ b/skills/assess/tests/test_coverage_report.py
@@ -1,0 +1,143 @@
+"""Contract suite for the coverage-report parser.
+
+The parser reads an *existing* coverage report (Cobertura ``coverage.xml`` or
+``lcov.info``) into the shape ``scan_test_pressure`` consumes:
+``{"_overall": float, "per_file": {relpath: line_rate}}``. These tests pin the
+two parse formats, the detection search order, and the hard contract that any
+absent or malformed input degrades to ``None`` rather than raising.
+
+Expected ratios are hand-computed in the fixtures so the contract is auditable:
+- ``fixtures/coverage.xml`` - root line-rate 0.75; src/a.py 0.8, src/b.py 0.5.
+- ``fixtures/lcov.info`` - a: LH 8/LF 10 = 0.8; b: 2/10 = 0.2;
+  overall (8+2)/(10+10) = 0.5.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.coverage_report import (
+    _parse_cobertura,
+    _parse_lcov,
+    detect_coverage_report,
+    load_coverage_data,
+)
+
+
+# --- Cobertura ------------------------------------------------------------
+
+def test_parse_cobertura_nested_schema(fixtures_dir: Path) -> None:
+    result = _parse_cobertura(fixtures_dir / "coverage.xml")
+    assert result is not None
+    assert result["_overall"] == 0.75
+    assert result["per_file"] == {"src/a.py": 0.8, "src/b.py": 0.5}
+
+
+def test_parse_cobertura_flat_schema(tmp_path: Path) -> None:
+    """A flat ``<coverage><classes><class>`` report (no ``<packages>``) parses
+    via the same tree walk."""
+    xml = (
+        '<?xml version="1.0" ?>\n'
+        '<coverage line-rate="0.6">\n'
+        '  <classes>\n'
+        '    <class filename="x.py" line-rate="0.6"/>\n'
+        '  </classes>\n'
+        '</coverage>\n'
+    )
+    path = tmp_path / "coverage.xml"
+    path.write_text(xml)
+    result = _parse_cobertura(path)
+    assert result == {"_overall": 0.6, "per_file": {"x.py": 0.6}}
+
+
+def test_parse_cobertura_malformed_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "coverage.xml"
+    path.write_text("<coverage line-rate=\"0.5\"><classes><not-closed")
+    assert _parse_cobertura(path) is None
+
+
+def test_parse_cobertura_absent_returns_none(tmp_path: Path) -> None:
+    assert _parse_cobertura(tmp_path / "nope.xml") is None
+
+
+# --- lcov -----------------------------------------------------------------
+
+def test_parse_lcov(fixtures_dir: Path) -> None:
+    result = _parse_lcov(fixtures_dir / "lcov.info")
+    assert result is not None
+    assert result["per_file"] == {"src/a.py": 0.8, "src/b.py": 0.2}
+    assert result["_overall"] == 0.5
+
+
+def test_parse_lcov_no_terminator_still_flushes(tmp_path: Path) -> None:
+    """A record without ``end_of_record`` is flushed at EOF."""
+    path = tmp_path / "lcov.info"
+    path.write_text("SF:a.py\nLF:4\nLH:2\n")
+    result = _parse_lcov(path)
+    assert result == {"_overall": 0.5, "per_file": {"a.py": 0.5}}
+
+
+def test_parse_lcov_zero_lines_returns_none(tmp_path: Path) -> None:
+    """A record with LF:0 contributes nothing; an all-zero report degrades."""
+    path = tmp_path / "lcov.info"
+    path.write_text("SF:a.py\nLF:0\nLH:0\nend_of_record\n")
+    assert _parse_lcov(path) is None
+
+
+def test_parse_lcov_absent_returns_none(tmp_path: Path) -> None:
+    assert _parse_lcov(tmp_path / "nope.info") is None
+
+
+# --- detection ------------------------------------------------------------
+
+def test_detect_prefers_cobertura_at_root(tmp_path: Path) -> None:
+    (tmp_path / "coverage.xml").write_text("<coverage line-rate=\"0.5\"/>")
+    (tmp_path / "lcov.info").write_text("SF:a\nLF:1\nLH:1\nend_of_record\n")
+    assert detect_coverage_report(tmp_path) == {
+        "source": "coverage.xml", "format": "cobertura"}
+
+
+def test_detect_lcov_in_coverage_subdir(tmp_path: Path) -> None:
+    (tmp_path / "coverage").mkdir()
+    (tmp_path / "coverage" / "lcov.info").write_text(
+        "SF:a\nLF:1\nLH:1\nend_of_record\n")
+    assert detect_coverage_report(tmp_path) == {
+        "source": "coverage/lcov.info", "format": "lcov"}
+
+
+def test_detect_dot_coverage_directory(tmp_path: Path) -> None:
+    (tmp_path / ".coverage").mkdir()
+    (tmp_path / ".coverage" / "coverage.xml").write_text(
+        "<coverage line-rate=\"0.5\"/>")
+    assert detect_coverage_report(tmp_path) == {
+        "source": ".coverage/coverage.xml", "format": "cobertura"}
+
+
+def test_detect_dot_coverage_sqlite_file_out_of_scope(tmp_path: Path) -> None:
+    """A bare ``.coverage`` SQLite *file* (not a directory) is never matched -
+    reading it needs the coverage.py library, which is out of scope."""
+    (tmp_path / ".coverage").write_text("SQLite format 3\x00binary junk")
+    assert detect_coverage_report(tmp_path) is None
+
+
+def test_detect_none_when_absent(tmp_path: Path) -> None:
+    assert detect_coverage_report(tmp_path) is None
+
+
+# --- load (end to end) ----------------------------------------------------
+
+def test_load_cobertura_end_to_end(tmp_path: Path) -> None:
+    (tmp_path / "coverage.xml").write_text(
+        '<coverage line-rate="0.9"><classes>'
+        '<class filename="m.py" line-rate="0.9"/></classes></coverage>')
+    assert load_coverage_data(tmp_path) == {
+        "_overall": 0.9, "per_file": {"m.py": 0.9}}
+
+
+def test_load_returns_none_when_no_report(tmp_path: Path) -> None:
+    assert load_coverage_data(tmp_path) is None
+
+
+def test_load_malformed_report_degrades_to_none(tmp_path: Path) -> None:
+    """Detected but unparseable -> None, never an exception."""
+    (tmp_path / "coverage.xml").write_text("not xml at all <<<")
+    assert load_coverage_data(tmp_path) is None


### PR DESCRIPTION
## Summary

Implements `assess-test-focus-funnel.1`: a read-only coverage-report parser that feeds the Layer 1 test-pressure scan real line-coverage truth.

`/assess` never runs the test suite (it stays read-only and fast), so the only honest source of line coverage is a report the project already generated in CI or locally. This adds `skills/assess/scripts/lib/coverage_report.py`, which reads an existing Cobertura `coverage.xml` or `lcov.info` into the `{_overall, per_file: {relpath: line_rate}}` shape `scan_test_pressure`'s `coverage_data=` param already expects - without taking a `coverage.py` runtime dependency.

## Changes Made

- **`lib/coverage_report.py`** (new, stdlib-only, never raises):
  - `_parse_cobertura` - `_overall` from root `line-rate`, per-file from each `<class>` element's `filename`/`line-rate`. A single `iter("class")` walk handles both the flat (`<coverage><classes>`) and nested (`<packages><package><classes>`) schemas.
  - `_parse_lcov` - tracks the current file via `SF:`, per-file `line_rate = LH/LF`, overall `sum(LH)/sum(LF)`. Flushes a record on `end_of_record`, the next `SF:`, or EOF.
  - `detect_coverage_report` - searches the repo root, `./coverage/`, and `./.coverage/` (as a directory). A bare `.coverage` SQLite *file* is out of scope (reading it needs the `coverage.py` lib) and degrades as if absent.
  - `load_coverage_data` - detect-then-parse entry point; returns the documented shape or `None`.
- **`assess_core.py`** - calls `load_coverage_data(repo_root)` before `scan_test_pressure(...)` and passes it as `coverage_data=`. Adds a `coverage_report` provenance block to `run-context.json` distinguishing `"none found"` from the file/format actually read.
- **`lib/README.md`** - per-module entry added (co-change seam map kept current).
- **`.claude-plugin/plugin.json`** - version bumped to `1.46.4` (MINOR: new feature on an existing skill).

## Technical Details

- **Inward-only imports**: the parser imports stdlib only and is imported *by* `assess_core.py`; it never imports an orchestrator. Enforced by `test_self_architecture.py` (passing).
- **Honest-degrade everywhere**: a missing or malformed report yields `None`, never an exception, never a block to the assessment. Provenance is recorded so the report can state which case occurred.

## Testing

- `tests/test_coverage_report.py` (16 cases): Cobertura nested + flat parse, lcov parse, no-terminator flush, detection search order + precedence, `.coverage` SQLite-file out-of-scope, and absent/malformed degrade-to-`None` for both formats and the `load` entry point.
- Fixtures `tests/fixtures/coverage.xml` and `tests/fixtures/lcov.info` with hand-computed ratios.
- Full `skills/assess` suite: 784 passed, 2 skipped. `ruff check .` and `mypy` gates pass.

## Risk Assessment

Low. Additive, read-only signal; the failure path degrades to the existing "not assessed" behaviour, so a broken or absent report leaves the assessment unchanged.