### PR TITLE
fix: Derive real mutmut survivor density from junitxml

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.46.3",
+  "version": "1.46.5",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -353,6 +353,10 @@ grades only, no paths or code) so they are safe to include in self-feedback issu
 **`test_pressure/`**
 Layer 1 write-side truth pressure. Two tiers:
 - Mutation tier: runs a mutation-testing tool (mutmut for Python) over a sample of the
-  codebase to measure whether the test suite actually catches changes.
+  codebase to measure whether the test suite actually catches changes. For mutmut the
+  run is two-step - `mutmut run` then `mutmut junitxml` - because the run's stdout lists
+  only survivors (no totals); the junitxml report carries every mutant, so per-file
+  killed/survived/total (and a real survivor density) can be derived. Falls back to the
+  survivor-only stdout parse when junitxml is absent (e.g. mutmut 3.x) or empty.
 - Cheap heuristics: test/source ratio, assertion density, and the coverage gap signal -
   fast proxies that run without a mutation tool.

--- a/skills/assess/scripts/lib/test_pressure/__init__.py
+++ b/skills/assess/scripts/lib/test_pressure/__init__.py
@@ -53,6 +53,7 @@ from .mutation import (
     _parse_cargo_mutants,
     _parse_gremlins,
     _parse_mutmut,
+    _parse_mutmut_junitxml,
     _parse_stryker_json,
     compute_gap_signal,
     compute_survivor_density,

--- a/skills/assess/scripts/lib/test_pressure/mutation.py
+++ b/skills/assess/scripts/lib/test_pressure/mutation.py
@@ -10,9 +10,13 @@ mutates and *runs* code, so it is never part of a default read-only assessment.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
+import tempfile
+import time
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from .common import _iter_files, _read
@@ -150,6 +154,54 @@ def _parse_mutmut(stdout: str) -> list[dict]:
             for f, n in out.items()]
 
 
+def _testcase_file(testcase: ET.Element) -> str | None:
+    """Derive the source file path for a mutmut junitxml ``<testcase>``.
+
+    mutmut 2.x emits ``<testcase ... file="src/foo.py">`` - the file attribute
+    is the source path directly. Some versions/tools instead encode it in
+    ``classname`` as a dotted module path (``mutmut.src.foo`` -> ``src/foo.py``),
+    so we fall back to that. Returns None when neither yields a path."""
+    file_attr = testcase.get("file")
+    if file_attr:
+        return file_attr
+    classname = testcase.get("classname") or ""
+    if classname.startswith("mutmut."):
+        dotted = classname[len("mutmut."):]
+        if dotted:
+            return dotted.replace(".", "/") + ".py"
+    return None
+
+
+def _parse_mutmut_junitxml(xml_path: Path) -> list[dict]:
+    """Parse ``mutmut junitxml`` output into per-file killed/survived/total.
+
+    Unlike the survivor-only stdout listing, junitxml reports *every* mutant -
+    one ``<testcase>`` each - so we recover real totals. A testcase with a
+    ``<failure>`` child is a survivor (the suite did not catch the mutation);
+    otherwise it was killed. Returns ``list[{file, killed, survived, total}]``
+    with ``total = killed + survived``. Never raises - returns ``[]`` on any
+    error (missing file, malformed XML, unexpected shape) so the run degrades
+    gracefully to the stdout fallback."""
+    try:
+        root = ET.parse(xml_path).getroot()
+    except (ET.ParseError, OSError, ValueError):
+        return []
+    per_file: dict[str, dict[str, int]] = {}
+    try:
+        for testcase in root.iter("testcase"):
+            fname = _testcase_file(testcase)
+            if not fname:
+                continue
+            survived = testcase.find("failure") is not None
+            agg = per_file.setdefault(fname, {"killed": 0, "survived": 0})
+            agg["survived" if survived else "killed"] += 1
+    except Exception:  # pragma: no cover - defensive: never crash the run
+        return []
+    return [{"file": f, "killed": d["killed"], "survived": d["survived"],
+             "total": d["killed"] + d["survived"]}
+            for f, d in per_file.items()]
+
+
 def _parse_gremlins(stdout: str) -> list[dict]:
     """gremlins per-mutant lines: ``KILLED|LIVED|TIMED OUT|NOT COVERED ... <file>:<line>``.
     LIVED / NOT COVERED == survived."""
@@ -265,6 +317,7 @@ def run_bounded_mutation(repo_root: Path, hot_files: list | None = None,
                 "reason": "no supported mutation tool on PATH for languages present"}
 
     scope = [str(f) for f in (hot_files or [])][:MAX_FILES_TO_MUTATE]
+    started = time.monotonic()
     try:
         proc = subprocess.run(
             spec["cmd"](repo_root, scope), cwd=str(repo_root),
@@ -282,8 +335,53 @@ def run_bounded_mutation(repo_root: Path, hot_files: list | None = None,
         per_file = spec["parser"](proc.stdout)
     except Exception:  # pragma: no cover - parser must never crash the run
         per_file = []
+
+    # mutmut's stdout only lists survivors (no totals), so density can't be
+    # derived from it. A second `mutmut junitxml` call reports every mutant -
+    # giving real killed/survived/total per file. The two-step run shares the
+    # MUTATION_TIMEOUT budget; junitxml is best-effort and falls back to the
+    # survivor-only stdout parse on any failure or empty result.
+    if spec["tool"] == "mutmut":
+        remaining = MUTATION_TIMEOUT - (time.monotonic() - started)
+        if remaining > 0:
+            xml_per_file = _run_mutmut_junitxml(repo_root, remaining)
+            if xml_per_file:
+                per_file = xml_per_file
+
     return {"mutation_run": True, "available": True, "tool": spec["tool"],
             "scope": scope, "per_file": per_file}
+
+
+def _run_mutmut_junitxml(repo_root: Path, timeout: float) -> list[dict]:
+    """Run ``mutmut junitxml`` (after a completed ``mutmut run``) and parse it
+    into per-file totals. mutmut writes the XML report to stdout, so we capture
+    it to a temp file and hand that to ``_parse_mutmut_junitxml``. Best-effort:
+    returns ``[]`` on any failure (older mutmut without the subcommand, timeout,
+    crash, malformed output) so the caller falls back to the stdout parse."""
+    try:
+        proc = subprocess.run(
+            ["mutmut", "junitxml"], cwd=str(repo_root),
+            capture_output=True, text=True, timeout=max(1.0, timeout), check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):  # pragma: no cover - defensive
+        return []
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return []
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".xml", delete=False, encoding="utf-8") as fh:
+            fh.write(proc.stdout)
+            tmp_path = fh.name
+        return _parse_mutmut_junitxml(Path(tmp_path))
+    except OSError:  # pragma: no cover - defensive
+        return []
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:  # pragma: no cover - defensive
+                pass
 
 
 # ── aggregation over per-file mutation results ────────────────────────────────

--- a/skills/assess/tests/fixtures/mutmut-junitxml.xml
+++ b/skills/assess/tests/fixtures/mutmut-junitxml.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="2" tests="5" time="0.0">
+	<testsuite disabled="0" errors="0" failures="2" name="mutmut" skipped="0" tests="5" time="0">
+		<testcase name="Mutant #1" file="src/calc.py" line="2">
+			<system-out>    return a + b</system-out>
+		</testcase>
+		<testcase name="Mutant #2" file="src/calc.py" line="6">
+			<failure type="failure" message="bad_survived">--- src/calc.py
++++ src/calc.py
+@@ -3,7 +3,7 @@
+ def sub(a, b):
+-    return a - b
++    return a + b
+</failure>
+			<system-out>    return a - b</system-out>
+		</testcase>
+		<testcase name="Mutant #3" file="src/calc.py" line="10">
+			<failure type="failure" message="bad_survived">--- src/calc.py
++++ src/calc.py
+@@ -7,5 +7,5 @@
+ def mul(a, b):
+-    return a * b
++    return a / b
+</failure>
+			<system-out>    return a * b</system-out>
+		</testcase>
+		<testcase name="Mutant #4" file="src/util.py" line="3">
+			<system-out>    return x or y</system-out>
+		</testcase>
+		<testcase name="Mutant #5" file="src/util.py" line="7">
+			<system-out>    return not flag</system-out>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/skills/assess/tests/test_complexity_treemap.py
+++ b/skills/assess/tests/test_complexity_treemap.py
@@ -581,6 +581,29 @@ def test_load_survivor_density_from_per_file(treemap, tmp_path):
     assert (tmp_path / "src/c.py").resolve() not in density  # no total
 
 
+def test_mutmut_junitxml_drives_hatch_overlay(treemap, tmp_path, fixtures_dir):
+    """End to end: a real mutmut junitxml parse -> run-context per_file ->
+    load_survivor_density -> hatch overrides. Before the junitxml fix the mutmut
+    path carried no totals, so this overlay could never render on a Python repo."""
+    from lib.test_pressure import _parse_mutmut_junitxml
+
+    per_file = _parse_mutmut_junitxml(fixtures_dir / "mutmut-junitxml.xml")
+    ctx = {"test_pressure": {"per_file": per_file}}
+    j = tmp_path / "run-context.json"
+    j.write_text(json.dumps(ctx), encoding="utf-8")
+
+    density = treemap.load_survivor_density(j, tmp_path)
+    calc = (tmp_path / "src/calc.py").resolve()
+    util = (tmp_path / "src/util.py").resolve()
+    assert density[calc] == 2 / 3      # real density, not skipped
+    assert density[util] == 0.0         # all killed -> real 0 density (has a total)
+
+    files = [(calc, 100, 5.0, "lizard"), (util, 50, 3.0, "lizard")]
+    overrides = treemap._survivor_overrides(files, density)
+    assert overrides[calc] == {"hatch": "cross"}  # 0.67 > 0.5
+    assert util not in overrides                   # 0.0 below hatch threshold
+
+
 def test_load_survivor_density_absent_block_is_empty(treemap, tmp_path):
     j = tmp_path / "run-context.json"
     j.write_text(json.dumps({"doc_graph": {}}), encoding="utf-8")

--- a/skills/assess/tests/test_test_pressure.py
+++ b/skills/assess/tests/test_test_pressure.py
@@ -19,6 +19,7 @@ from lib.test_pressure import (
     _parse_cargo_mutants,
     _parse_gremlins,
     _parse_mutmut,
+    _parse_mutmut_junitxml,
     _parse_stryker_json,
 )
 
@@ -268,6 +269,104 @@ def test_compute_gap_signal_variants() -> None:
     assert compute_gap_signal(0.9, 0.8) == "no gap"
     assert compute_gap_signal(None, 0.3) == "not assessed"
     assert compute_gap_signal(0.9, None) == "not assessed"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# TASK 2 - mutmut junitxml parser (real totals, not survivor-only)
+# ════════════════════════════════════════════════════════════════════════════
+
+def test_parse_mutmut_junitxml_per_file_totals(fixtures_dir: Path) -> None:
+    """A real mutmut junitxml fixture yields per-file killed/survived/total.
+    A <testcase> with a <failure> child is a survivor; otherwise it was killed."""
+    parsed = {p["file"]: p for p in
+              _parse_mutmut_junitxml(fixtures_dir / "mutmut-junitxml.xml")}
+    assert parsed["src/calc.py"]["killed"] == 1
+    assert parsed["src/calc.py"]["survived"] == 2
+    assert parsed["src/calc.py"]["total"] == 3
+    assert parsed["src/util.py"]["killed"] == 2
+    assert parsed["src/util.py"]["survived"] == 0
+    assert parsed["src/util.py"]["total"] == 2
+
+
+def test_parse_mutmut_junitxml_classname_fallback(tmp_path: Path) -> None:
+    """Some versions encode the path in classname (mutmut.<dotted>) instead of
+    the file attribute - derive <path>.py from it when file= is absent."""
+    xml = (
+        '<?xml version="1.0" ?>\n'
+        '<testsuites><testsuite name="mutmut">'
+        '<testcase classname="mutmut.pkg.mod" name="m1"></testcase>'
+        '<testcase classname="mutmut.pkg.mod" name="m2">'
+        '<failure message="bad_survived">x</failure></testcase>'
+        '</testsuite></testsuites>'
+    )
+    p = tmp_path / "report.xml"
+    p.write_text(xml, encoding="utf-8")
+    parsed = {row["file"]: row for row in _parse_mutmut_junitxml(p)}
+    assert parsed["pkg/mod.py"] == {
+        "file": "pkg/mod.py", "killed": 1, "survived": 1, "total": 2}
+
+
+def test_parse_mutmut_junitxml_missing_file_degrades(tmp_path: Path) -> None:
+    assert _parse_mutmut_junitxml(tmp_path / "nope.xml") == []
+
+
+def test_parse_mutmut_junitxml_malformed_degrades(tmp_path: Path) -> None:
+    p = tmp_path / "bad.xml"
+    p.write_text("not xml at all <<<", encoding="utf-8")
+    assert _parse_mutmut_junitxml(p) == []
+
+
+def test_junitxml_to_density_overall_is_non_null(fixtures_dir: Path) -> None:
+    """The whole point of the fix: junitxml carries totals, so survivor density
+    has a real overall value (unlike the survivor-only stdout parse)."""
+    per_file = _parse_mutmut_junitxml(fixtures_dir / "mutmut-junitxml.xml")
+    d = compute_survivor_density(per_file)
+    assert d["overall"] is not None
+    assert d["total_mutants"] == 5
+    assert d["total_survived"] == 2
+    assert abs(d["overall"] - 0.4) < 1e-9
+
+
+def test_run_bounded_mutation_uses_junitxml(tmp_path: Path, monkeypatch,
+                                            fixtures_dir: Path) -> None:
+    """The two-step mutmut path: `mutmut run` then `mutmut junitxml`. The junitxml
+    parse wins, so per_file carries real totals."""
+    _write(tmp_path, "app.py", "def f(): pass")
+    monkeypatch.setattr(tp.shutil, "which", lambda t: "/usr/bin/" + t)
+    xml = (fixtures_dir / "mutmut-junitxml.xml").read_text(encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["mutmut", "junitxml"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=xml, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="app.py:3\n", stderr="")
+
+    monkeypatch.setattr(tp.subprocess, "run", fake_run)
+    r = run_bounded_mutation(tmp_path, hot_files=["app.py"], opt_in=True)
+    assert r["mutation_run"] is True
+    assert r["tool"] == "mutmut"
+    by_file = {p["file"]: p for p in r["per_file"]}
+    assert by_file["src/calc.py"]["total"] == 3
+    assert compute_survivor_density(r["per_file"])["overall"] is not None
+
+
+def test_run_bounded_mutation_junitxml_empty_falls_back_to_stdout(
+        tmp_path: Path, monkeypatch) -> None:
+    """When `mutmut junitxml` is absent/empty (e.g. mutmut 3.x dropped it), the
+    run degrades to the survivor-only stdout parse - exactly as before the fix."""
+    _write(tmp_path, "app.py", "def f(): pass")
+    monkeypatch.setattr(tp.shutil, "which", lambda t: "/usr/bin/" + t)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["mutmut", "junitxml"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no cmd")
+        return subprocess.CompletedProcess(cmd, 0, stdout="app.py:3\napp.py:9\n",
+                                           stderr="")
+
+    monkeypatch.setattr(tp.subprocess, "run", fake_run)
+    r = run_bounded_mutation(tmp_path, hot_files=["app.py"], opt_in=True)
+    assert r["mutation_run"] is True
+    assert r["per_file"][0]["survived"] == 2
+    assert r["per_file"][0]["total"] is None  # stdout parse: no totals
 
 
 # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

The mutmut path in `lib/test_pressure/mutation.py` parsed only survivor listings from `mutmut run` stdout, producing `{killed: None, survived: n, total: None}`. With `total` None, `compute_survivor_density` returned `overall: None`, and `complexity-treemap.py`'s `load_survivor_density` skipped every entry. Net effect: the survivor-density hatch overlay could **never** render on a Python repo, even after a full mutation run. This fixes `assess-test-focus-funnel.2`.

## Changes Made

- **`_parse_mutmut_junitxml(xml_path)`** - parses a `mutmut junitxml` report via `xml.etree.ElementTree`. Each `<testcase>` is classified `survived` if it has a `<failure>` child, else `killed`, and aggregated per file into `{file, killed, survived, total}` with `total = killed + survived`. Returns `[]` on any error (never raises).
- **Two-step mutmut run in `run_bounded_mutation`** - after `mutmut run`, invokes `mutmut junitxml`, parses it, and prefers its real totals. Falls back to the existing survivor-only stdout parse when junitxml is empty or absent. The second call shares the `MUTATION_TIMEOUT` budget (remaining time after the run); all existing degrade paths (opt-in, tool-absent, timeout, parse failure) are preserved, and the change is scoped to the mutmut path only.
- **Captured fixture + tests** - `tests/fixtures/mutmut-junitxml.xml` plus unit tests for the parser (per-file killed/survived/total, classname fallback, missing/malformed degrade), the junitxml->density integration (`overall` non-null), the two-step run wiring, the stdout fallback, and the treemap-hatching integration (`load_survivor_density` -> `_survivor_overrides` yields a hatch).
- Updated the `lib/README.md` co-change seam map for the two-step mutmut flow.
- Bumped `.claude-plugin/plugin.json` to `1.46.5`.

## Technical Details / Key Finding

The task spec assumed mutmut encodes the source path in `classname="mutmut.<dotted.path>"`. A real capture from mutmut **2.4.4 and 2.5.1** showed it actually uses the testcase **`file`** attribute (`<testcase name="Mutant #1" file="src/calc.py" line="2">`) with a `<failure>` child marking survivors - **no `classname` at all**. The parser reads `file` first and falls back to a dotted `classname`, so it works against real mutmut output (and the spec's hypothesized form). The locally-installed **mutmut 3.6.0 removed `junitxml` entirely** - that case is the documented fallback to the survivor-only stdout parse, degrading exactly as today.

## Testing

All four CI-equivalent gates pass locally:
- `skills/assess pytest`: 776 passed, 2 skipped
- `scripts/ pytest`: 106 passed
- `plugin contract pytest`: 278 passed
- `ruff check` + `mypy`: clean

## Risk Assessment

Low. Change is confined to the mutmut path; other tools (stryker/gremlins/cargo-mutants) and all degrade paths are untouched. The junitxml step is best-effort with full fallback.