### PR TITLE
feat: Rank risky files needing test work into a focus block

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.46.4",
+  "version": "1.46.6",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/assess_core.py
+++ b/skills/assess/scripts/assess_core.py
@@ -65,6 +65,7 @@ from lib.structure_drift import (
     SEAM_ALLOWLIST,
     detect_path_existence_drift,
 )
+from lib.test_focus import compute_test_focus
 from lib.test_pressure import scan_test_pressure
 from lib.wiki_writer import (
     UNFINALIZED_ACTIONS_POINTER,
@@ -1033,6 +1034,18 @@ def build_run_context(*, repo_root: Path, run_date: str) -> dict:
             "duplicate_truth": [],
         },
     }
+
+    # Cross-join the three already-collected signals - hotspot risk band, parsed
+    # coverage, hollow-test heuristics - into one ranked focus list answering
+    # "which risky files most need test work, and which kind?". Pure composition
+    # of values already in hand (the top hotspots, the coverage_data loaded above,
+    # and this block's cheap_heuristics), so it cannot fail the scan. This block is
+    # the single source the report table and the mutation offer both consume.
+    ctx["test_focus"] = compute_test_focus(
+        current.get("top_hotspots", []),
+        coverage_data,
+        ctx["test_pressure"].get("cheap_heuristics"),
+    )
 
     # Promissory markers (stale TODO/FIXME, suppressions, disabled tests):
     # the write-side erosion instrument. Family totals + stale counts feed the

--- a/skills/assess/scripts/lib/README.md
+++ b/skills/assess/scripts/lib/README.md
@@ -366,6 +366,21 @@ assessment; `assess_core.py` records provenance ("none found" vs. the file/forma
 separately. Stdlib only, imports no orchestrator. Add fixtures + cases in
 `tests/test_coverage_report.py` alongside any change to a parse rule.
 
+**`test_focus.py`**
+Cross-joins three already-collected signals - the hotspot risk band (position in
+`complexity_stats.top_hotspots`), the parsed coverage report, and the
+`test_pressure` cheap heuristics - into one ranked focus list. `compute_test_focus`
+classifies each top-10 hot file (`no_covering_test` / `covered_but_hollow` /
+`covered_clean` / `unknown_no_coverage`), filters out `covered_clean`, and ranks by
+risk band then signal severity. Honest-degrade is the contract: `coverage_data is
+None` makes every file `unknown_no_coverage` (never `covered_clean`) and records
+`coverage_present: False`; it never raises. Pure data - inputs are passed in
+(`hot_files`, `coverage_data`, `cheap_heuristics`), no file I/O, stdlib only,
+imports no orchestrator. This block is the SINGLE source both the report focus
+table and the mutation offer consume - it is the contract, not duplicated
+downstream. Add cases in `tests/test_test_focus.py` alongside any change to a
+classification or ranking rule.
+
 **`test_pressure/`**
 Layer 1 write-side truth pressure. Two tiers:
 - Mutation tier: runs a mutation-testing tool (mutmut for Python) over a sample of the

--- a/skills/assess/scripts/lib/test_focus.py
+++ b/skills/assess/scripts/lib/test_focus.py
@@ -1,0 +1,226 @@
+"""Compose existing signals into a single ranked test-focus block.
+
+`/assess` already surfaces three independent truths about a file: how risky it is
+(complexity x churn -> the hotspot band), whether a test covers it (the parsed
+coverage report), and whether the test that covers it looks hollow (the cheap
+heuristics). On their own each is a separate list the reader has to cross-join in
+their head. This module does that cross-join deterministically and emits one
+ranked list answering the only question that matters for write-side safety:
+*which risky files most need test work, and which kind?*
+
+`compute_test_focus` is the SINGLE source the report table (the focus block) and
+the mutation offer both read - the contract is here, not duplicated downstream.
+It is a pure function: it takes its three inputs as parameters and returns a
+plain dict. No file I/O, no orchestrator import, never raises.
+
+Signal per file (most to least actionable):
+  - ``no_covering_test``      - covered report exists but this file is absent or
+                                its line rate is 0: a risky file with no test.
+  - ``covered_but_hollow``    - a test covers it, but it trips a hollow-test
+                                heuristic (asserts internals, untested boundary,
+                                duplicate truth).
+  - ``unknown_no_coverage``   - no coverage report at all: we *cannot* say it is
+                                covered, so we do not pretend it is clean.
+  - ``covered_clean``         - covered, no hollow hit. Not a focus target;
+                                filtered out of the output.
+
+Honest degradation is the hard contract: ``coverage_data is None`` makes every
+file ``unknown_no_coverage`` (never ``covered_clean``) and records
+``coverage_present: False``. A risky file we know nothing about is surfaced for
+test work, not silently blessed as clean.
+
+Inward-only imports: stdlib only; imported by the orchestrator (`assess_core.py`),
+never importing one itself.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Risk bands by position in the ranked top_hotspots list. Index 0-2 are the
+# sharpest hotspots, 3-6 the next tier, 7-9 the tail; anything past the top 10 is
+# not a hotspot and is excluded entirely.
+_HIGH_MAX = 2
+_MEDIUM_MAX = 6
+_LOW_MAX = 9
+
+# Ranking weights. Risk band dominates; signal severity breaks ties within a band.
+_BAND_RANK = {"high": 3, "medium": 2, "low": 1}
+_SIGNAL_SEVERITY = {
+    "no_covering_test": 3,
+    "covered_but_hollow": 2,
+    "unknown_no_coverage": 1,
+    "covered_clean": 0,
+}
+
+# Which suggested action each signal implies.
+_ACTION_BY_SIGNAL = {
+    "no_covering_test": "add_tests",
+    "unknown_no_coverage": "add_tests",
+    "covered_but_hollow": "strengthen_assertions",
+    "covered_clean": "none",
+}
+
+# The three hollow-test heuristic buckets, in report order. Each bucket entry
+# names the file it flags under either ``file`` (boundary / duplicate-truth, a
+# source file) or ``test_file`` (assertion-on-internal, a test file); we read
+# whichever is present so a source hot file matches against any of them.
+_HEURISTIC_BUCKETS = (
+    "assertion_on_internal",
+    "untested_boundaries",
+    "duplicate_truth",
+)
+
+
+@dataclass
+class TestFocusEntry:
+    """One ranked focus target: a hot file, its risk, its test signal, the
+    hollow-heuristic kinds it tripped, and the suggested remediation."""
+
+    path: str
+    risk_band: str  # 'high' | 'medium' | 'low'
+    test_signal: str  # 'no_covering_test'|'covered_but_hollow'|'covered_clean'|'unknown_no_coverage'
+    hollow_heuristic_kinds: list[str] = field(default_factory=list)
+    suggested_action: str = "none"  # 'add_tests' | 'strengthen_assertions' | 'none'
+
+
+def _entry_path(entry: Any) -> str | None:
+    """Path of a top_hotspots entry, whether it is a dict (``{"path": ...}``) or a
+    bare string. Anything else has no usable path."""
+    if isinstance(entry, str):
+        return entry or None
+    if isinstance(entry, dict):
+        path = entry.get("path")
+        return path if isinstance(path, str) and path else None
+    return None
+
+
+def _risk_band(index: int) -> str | None:
+    """Band for a file's position in the ranked hotspot list, or ``None`` if it
+    falls outside the top 10 (not a hotspot)."""
+    if index <= _HIGH_MAX:
+        return "high"
+    if index <= _MEDIUM_MAX:
+        return "medium"
+    if index <= _LOW_MAX:
+        return "low"
+    return None
+
+
+def _is_covered(path: str, coverage_data: dict[str, Any]) -> bool:
+    """True when the parsed coverage report carries a non-zero line rate for the
+    file. Absent from the report, or a 0.0 rate, means no covering test."""
+    per_file = coverage_data.get("per_file")
+    if not isinstance(per_file, dict):
+        return False
+    rate = per_file.get(path)
+    try:
+        return rate is not None and float(rate) > 0.0
+    except (TypeError, ValueError):
+        return False
+
+
+def _hollow_kinds(path: str, cheap_heuristics: dict[str, Any]) -> list[str]:
+    """Heuristic buckets in which this file appears, in report order. Reads both
+    the ``file`` and ``test_file`` keys so a source hot file matches whichever a
+    bucket uses."""
+    if not isinstance(cheap_heuristics, dict):
+        return []
+    kinds: list[str] = []
+    for bucket in _HEURISTIC_BUCKETS:
+        findings = cheap_heuristics.get(bucket)
+        if not isinstance(findings, list):
+            continue
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            if finding.get("file") == path or finding.get("test_file") == path:
+                kinds.append(bucket)
+                break
+    return kinds
+
+
+def _classify(
+    path: str,
+    coverage_present: bool,
+    coverage_data: dict[str, Any] | None,
+    cheap_heuristics: dict[str, Any],
+) -> tuple[str, list[str]]:
+    """Resolve a file's test signal and the hollow kinds it tripped.
+
+    No coverage report at all -> ``unknown_no_coverage`` (we never claim clean).
+    Covered + a hollow hit -> ``covered_but_hollow``. Covered + clean ->
+    ``covered_clean``. Present report but file absent / zero rate ->
+    ``no_covering_test``.
+    """
+    if not coverage_present or coverage_data is None:
+        return "unknown_no_coverage", []
+    if not _is_covered(path, coverage_data):
+        return "no_covering_test", []
+    kinds = _hollow_kinds(path, cheap_heuristics)
+    if kinds:
+        return "covered_but_hollow", kinds
+    return "covered_clean", []
+
+
+def compute_test_focus(
+    hot_files: Any,
+    coverage_data: dict[str, Any] | None,
+    cheap_heuristics: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Cross-join the hotspot, coverage, and hollow-test signals into one ranked
+    focus block.
+
+    Args:
+        hot_files: the ranked ``complexity_stats.top_hotspots`` list (entries are
+            dicts with a ``path``, or bare path strings). Position sets the risk
+            band; only the top 10 are considered, the rest are not hotspots.
+        coverage_data: the parsed ``{_overall, per_file}`` report from
+            ``load_coverage_data``, or ``None`` when no report was found.
+        cheap_heuristics: the ``test_pressure`` block's ``cheap_heuristics`` dict
+            (``assertion_on_internal`` / ``untested_boundaries`` /
+            ``duplicate_truth`` buckets).
+
+    Returns:
+        ``{available, coverage_present, entries, total_focus_targets}`` where
+        ``entries`` is the ranked list of focus targets (``covered_clean``
+        filtered out), each a ``TestFocusEntry`` as a dict.
+    """
+    coverage_present = coverage_data is not None
+    heuristics = cheap_heuristics if isinstance(cheap_heuristics, dict) else {}
+    entries: list[TestFocusEntry] = []
+
+    items = hot_files if isinstance(hot_files, list) else []
+    for index, item in enumerate(items):
+        band = _risk_band(index)
+        if band is None:
+            break  # past the top 10 - no longer a hotspot
+        path = _entry_path(item)
+        if path is None:
+            continue
+        signal, kinds = _classify(path, coverage_present, coverage_data, heuristics)
+        if signal == "covered_clean":
+            continue  # not a focus target
+        entries.append(
+            TestFocusEntry(
+                path=path,
+                risk_band=band,
+                test_signal=signal,
+                hollow_heuristic_kinds=kinds,
+                suggested_action=_ACTION_BY_SIGNAL[signal],
+            )
+        )
+
+    # Rank by risk band first, then signal severity within a band. Python's sort
+    # is stable, so files tied on both keys keep their original hotspot order.
+    entries.sort(
+        key=lambda e: (_BAND_RANK[e.risk_band], _SIGNAL_SEVERITY[e.test_signal]),
+        reverse=True,
+    )
+
+    return {
+        "available": True,
+        "coverage_present": coverage_present,
+        "entries": [asdict(e) for e in entries],
+        "total_focus_targets": len(entries),
+    }

--- a/skills/assess/tests/test_test_focus.py
+++ b/skills/assess/tests/test_test_focus.py
@@ -1,0 +1,192 @@
+"""Contract tests for ``lib/test_focus.compute_test_focus``.
+
+Cover each signal classification, the risk-band assignment by hotspot position,
+the ranking order, the ``covered_clean`` filter, and the honest no-coverage
+degrade (``coverage_data=None`` -> every entry ``unknown_no_coverage`` and
+``coverage_present: False``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# scripts/ on the path so ``lib`` imports resolve the same way the orchestrator does.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from lib.test_focus import compute_test_focus  # noqa: E402
+
+
+def _hot(*paths: str) -> list[dict]:
+    """Build a top_hotspots-shaped list (ranked, each entry a dict with a path)."""
+    return [{"path": p} for p in paths]
+
+
+def _coverage(per_file: dict[str, float], overall: float = 0.5) -> dict:
+    return {"_overall": overall, "per_file": per_file}
+
+
+def _empty_heuristics() -> dict:
+    return {
+        "assertion_on_internal": [],
+        "untested_boundaries": [],
+        "duplicate_truth": [],
+    }
+
+
+def _entry(block: dict, path: str) -> dict:
+    return next(e for e in block["entries"] if e["path"] == path)
+
+
+# ── signal classification ─────────────────────────────────────────────────────
+
+def test_no_covering_test_when_file_absent_from_report() -> None:
+    block = compute_test_focus(_hot("a.py"), _coverage({"other.py": 0.8}),
+                               _empty_heuristics())
+    entry = _entry(block, "a.py")
+    assert entry["test_signal"] == "no_covering_test"
+    assert entry["suggested_action"] == "add_tests"
+    assert entry["hollow_heuristic_kinds"] == []
+
+
+def test_no_covering_test_when_line_rate_zero() -> None:
+    block = compute_test_focus(_hot("a.py"), _coverage({"a.py": 0.0}),
+                               _empty_heuristics())
+    assert _entry(block, "a.py")["test_signal"] == "no_covering_test"
+
+
+def test_covered_but_hollow_when_in_a_heuristic_bucket() -> None:
+    heuristics = {
+        "assertion_on_internal": [],
+        "untested_boundaries": [{"file": "a.py", "line": 3, "operator": "<="}],
+        "duplicate_truth": [],
+    }
+    block = compute_test_focus(_hot("a.py"), _coverage({"a.py": 0.9}), heuristics)
+    entry = _entry(block, "a.py")
+    assert entry["test_signal"] == "covered_but_hollow"
+    assert entry["suggested_action"] == "strengthen_assertions"
+    assert entry["hollow_heuristic_kinds"] == ["untested_boundaries"]
+
+
+def test_covered_but_hollow_matches_test_file_key() -> None:
+    """assertion_on_internal entries name the file under ``test_file``; a hot file
+    matching that key still counts as hollow."""
+    heuristics = {
+        "assertion_on_internal": [
+            {"test_file": "a.py", "subject_function": "test_x:obj",
+             "internal_field": "_y", "confidence": "medium"}
+        ],
+        "untested_boundaries": [],
+        "duplicate_truth": [],
+    }
+    block = compute_test_focus(_hot("a.py"), _coverage({"a.py": 0.9}), heuristics)
+    assert _entry(block, "a.py")["hollow_heuristic_kinds"] == ["assertion_on_internal"]
+
+
+def test_multiple_hollow_kinds_collected_in_report_order() -> None:
+    heuristics = {
+        "assertion_on_internal": [{"test_file": "a.py", "internal_field": "_y"}],
+        "untested_boundaries": [{"file": "a.py", "line": 1, "operator": "<"}],
+        "duplicate_truth": [{"file": "a.py", "field_name": "x", "derives_from": "y"}],
+    }
+    block = compute_test_focus(_hot("a.py"), _coverage({"a.py": 0.9}), heuristics)
+    assert _entry(block, "a.py")["hollow_heuristic_kinds"] == [
+        "assertion_on_internal", "untested_boundaries", "duplicate_truth",
+    ]
+
+
+def test_covered_clean_is_filtered_out() -> None:
+    block = compute_test_focus(_hot("a.py"), _coverage({"a.py": 0.95}),
+                               _empty_heuristics())
+    assert block["entries"] == []
+    assert block["total_focus_targets"] == 0
+    assert block["coverage_present"] is True
+
+
+# ── risk bands ────────────────────────────────────────────────────────────────
+
+def test_risk_band_by_hotspot_position() -> None:
+    paths = [f"f{i}.py" for i in range(10)]
+    # No coverage report -> every file is a focus target, so all 10 appear.
+    block = compute_test_focus(_hot(*paths), None, _empty_heuristics())
+    band = {e["path"]: e["risk_band"] for e in block["entries"]}
+    assert [band[f"f{i}.py"] for i in range(3)] == ["high", "high", "high"]
+    assert [band[f"f{i}.py"] for i in range(3, 7)] == ["medium"] * 4
+    assert [band[f"f{i}.py"] for i in range(7, 10)] == ["low"] * 3
+
+
+def test_files_beyond_top_ten_are_excluded() -> None:
+    paths = [f"f{i}.py" for i in range(13)]
+    block = compute_test_focus(_hot(*paths), None, _empty_heuristics())
+    assert block["total_focus_targets"] == 10
+    assert all(int(e["path"][1:-3]) < 10 for e in block["entries"])
+
+
+# ── ranking ───────────────────────────────────────────────────────────────────
+
+def test_ranking_risk_band_dominates_then_signal_severity() -> None:
+    # low-risk file with the most severe signal vs high-risk with a milder one:
+    # the high-risk file must still rank first (band dominates).
+    hot = _hot(*[f"f{i}.py" for i in range(8)])  # f0-f2 high, f3-f6 medium, f7 low
+    coverage = _coverage({
+        "f0.py": 0.95,  # high, covered_clean -> filtered
+        "f7.py": 0.0,   # low, no_covering_test (severe)
+    })
+    # f0 filtered; f1,f2 high no_covering_test; f3-f6 medium; f7 low severe.
+    block = compute_test_focus(hot, coverage, _empty_heuristics())
+    ranked = [e["path"] for e in block["entries"]]
+    # First entries are the high-band files, low-band f7 is last despite severity.
+    assert ranked[0] in {"f1.py", "f2.py"}
+    assert ranked[-1] == "f7.py"
+    assert block["entries"][0]["risk_band"] == "high"
+
+
+def test_signal_severity_orders_within_a_band() -> None:
+    # Two high-risk files: one with no test (severe), one covered-but-hollow.
+    hot = _hot("a.py", "b.py")
+    coverage = _coverage({"b.py": 0.9})  # a.py absent -> no_covering_test
+    heuristics = {
+        "assertion_on_internal": [],
+        "untested_boundaries": [{"file": "b.py", "line": 1, "operator": "<"}],
+        "duplicate_truth": [],
+    }
+    block = compute_test_focus(hot, coverage, heuristics)
+    ranked = [e["path"] for e in block["entries"]]
+    assert ranked == ["a.py", "b.py"]  # no_covering_test outranks covered_but_hollow
+
+
+# ── honest degrade ────────────────────────────────────────────────────────────
+
+def test_no_coverage_degrades_to_unknown_not_clean() -> None:
+    paths = [f"f{i}.py" for i in range(3)]
+    block = compute_test_focus(_hot(*paths), None, _empty_heuristics())
+    assert block["coverage_present"] is False
+    assert block["available"] is True
+    assert block["total_focus_targets"] == 3
+    for entry in block["entries"]:
+        assert entry["test_signal"] == "unknown_no_coverage"
+        assert entry["suggested_action"] == "add_tests"
+        assert entry["hollow_heuristic_kinds"] == []
+
+
+def test_empty_inputs_produce_empty_block() -> None:
+    block = compute_test_focus([], None, None)
+    assert block == {
+        "available": True,
+        "coverage_present": False,
+        "entries": [],
+        "total_focus_targets": 0,
+    }
+
+
+def test_bare_string_hotspot_entries_supported() -> None:
+    block = compute_test_focus(["a.py", "b.py"], None, _empty_heuristics())
+    assert {e["path"] for e in block["entries"]} == {"a.py", "b.py"}
+
+
+def test_malformed_hotspot_entries_are_skipped() -> None:
+    block = compute_test_focus(
+        [{"path": "a.py"}, {"no_path": 1}, None, 42],
+        _coverage({"a.py": 0.0}),
+        _empty_heuristics(),
+    )
+    assert [e["path"] for e in block["entries"]] == ["a.py"]


### PR DESCRIPTION
## Summary

Adds `lib/test_focus.py` - a pure-data module that cross-joins three signals `/assess` already collects (hotspot risk band, parsed coverage, hollow-test heuristics) into one ranked focus list answering "which risky files most need test work, and which kind?". Wires the resulting `test_focus` block into `run-context.json`. Implements `assess-test-focus-funnel.3`.

This block is the single source the report table (task 5) and the mutation offer (task 4) will both consume - the contract lives here, not duplicated downstream.

## Changes Made

- **`skills/assess/scripts/lib/test_focus.py`** (new) - `compute_test_focus(hot_files, coverage_data, cheap_heuristics) -> dict` and the `TestFocusEntry` dataclass. Pure: inputs passed in, no file I/O, stdlib only, imports no orchestrator.
- **`skills/assess/scripts/assess_core.py`** - call `compute_test_focus(...)` after the `test_pressure` block, feeding it the current `top_hotspots`, the `coverage_data` already loaded for the coverage report, and `test_pressure.cheap_heuristics`. Adds `ctx["test_focus"]`.
- **`skills/assess/tests/test_test_focus.py`** (new) - 14 cases: each signal classification, risk-band assignment, ranking order, the `covered_clean` filter, and the no-coverage degrade.
- **`skills/assess/scripts/lib/README.md`** - seam-map entry for the new module.
- **`.claude-plugin/plugin.json`** - version bump to `1.46.6`.

## Technical Details

- **Signal classification** per top-10 hot file: `unknown_no_coverage` (no report), `no_covering_test` (report present, file absent or line-rate 0), `covered_but_hollow` (covered + appears in a cheap-heuristics bucket), `covered_clean` (covered, no hollow hit - filtered out).
- **Risk band** from hotspot position: index 0-2 high, 3-6 medium, 7-9 low; files beyond the top 10 excluded.
- **Suggested action**: `add_tests` for no/unknown coverage, `strengthen_assertions` for hollow, `none` for clean (filtered).
- **Ranking**: risk band dominates, signal severity breaks ties; stable sort preserves original hotspot order within a tie.
- **Honest degrade**: `coverage_data is None` -> every file `unknown_no_coverage` (never `covered_clean`), `coverage_present: False`. Never raises.

## Testing

- `skills/assess` pytest: 798 passed, 2 skipped (incl. 14 new `test_test_focus` cases)
- `scripts/` pytest: 106 passed
- `plugin contract` pytest: 278 passed
- ruff + mypy: clean

## Risk Assessment

Low. Additive pure-data module; the wire-in composes values already in hand and cannot fail the scan. Honest-degrade path covered by a test.
