### PR TITLE
fix: Exclude non-navigational URI schemes from broken-link counter

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.46.7",
+  "version": "1.46.8",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/assess/scripts/lib/doc_graph.py
+++ b/skills/assess/scripts/lib/doc_graph.py
@@ -124,8 +124,14 @@ HUB_MIN_OUTDEGREE = 3
 _WIKILINK_RE = re.compile(r"\[\[([^\[\]]+?)\]\]")
 # Markdown inline links: [text](target). Excludes images handled below.
 _MDLINK_RE = re.compile(r"(?<!\!)\[(?:[^\]]*)\]\(([^)]+)\)")
-# Schemes / forms that are not intra-repo file links.
-_EXTERNAL_RE = re.compile(r"^[a-z][a-z0-9+.-]*://|^mailto:|^tel:", re.IGNORECASE)
+# Schemes / forms that are not intra-repo file links.  Any token matching
+# the RFC 3986 URI-scheme pattern (`[a-z][a-z0-9+.-]*:`) is non-navigational:
+# `http://`, `https://`, `ftp://` (the scheme-plus-`://` form), but also bare
+# schemes such as `tel:`, `mailto:`, `sms:`, `callto:`, `javascript:`, etc.
+# Using the generic scheme pattern rather than an allowlist keeps the regex
+# stable as new schemes appear and avoids the specific-scheme gap that caused
+# `sms:` and `skype:` to be misclassified as broken file references (issue #227).
+_EXTERNAL_RE = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
 _FENCE_RE = re.compile(r"```.*?\n.*?```", re.DOTALL)  # fenced code blocks
 # Inline-code spans: backtick-delimited segments on a single logical line. A
 # link target inside `[[foo]]` or `[text](./foo.md)` is documentation syntax
@@ -595,13 +601,20 @@ def build_doc_graph(  # noqa: C901  # graph assembly + link resolution; ccn 19, 
         link_text = _strip_code_spans(text)
         # Wikilinks resolve by note name across the vault.
         for m in _WIKILINK_RE.finditer(link_text):
+            # Strip alias/anchor first so the scheme check sees the bare target
+            # (e.g. `tel:+1-555-1234` from `[[tel:+1-555-1234|Call us]]`).
+            wikilink_target = _strip_anchor_and_alias(m.group(1))
+            if _EXTERNAL_RE.match(wikilink_target):
+                # Non-navigational URI (`tel:`, `mailto:`, etc.) -- not a note
+                # reference; skip without counting as a broken link (issue #227).
+                continue
             tgt, amb = _resolve_wikilink(
                 m.group(1), d, repo_root, by_relpath, by_name, by_stem,
             )
             if amb:
                 ambiguous += 1
             if tgt is None:
-                _add_broken(d, _strip_anchor_and_alias(m.group(1)), "wikilink")
+                _add_broken(d, wikilink_target, "wikilink")
                 continue
             if tgt in doc_set and tgt != d:
                 graph.add_edge(rel(d), rel(tgt))

--- a/skills/assess/tests/test_doc_graph.py
+++ b/skills/assess/tests/test_doc_graph.py
@@ -504,3 +504,88 @@ def test_dataview_tag_hub_uses_frontmatter(tmp_path: Path) -> None:
     # hub -> p1 (tagged project) only; p2 is not tagged so stays an orphan.
     assert "p1.md" not in r.orphans
     assert "p2.md" in r.orphans
+
+
+# ---- non-navigational URI scheme exclusions (issue #227) -------------------
+
+def test_tel_mdlink_not_counted_broken(tmp_path: Path) -> None:
+    """[text](tel:+1-555-1234) is a phone-dialer link. It is not a broken
+    navigation edge -- the file `tel:+1-555-1234` does not exist, and that
+    is expected. The broken-link counter must not count it."""
+    _write(tmp_path, "contact.md", "Call us at [phone](tel:+1-555-1234)")
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("tel:" in t for t in targets)
+
+
+def test_mailto_mdlink_not_counted_broken(tmp_path: Path) -> None:
+    """[text](mailto:hello@example.com) is an email link, not a broken file
+    reference. The broken-link counter must not count it."""
+    _write(tmp_path, "contact.md", "Email us at [email](mailto:hello@example.com)")
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("mailto:" in t for t in targets)
+
+
+def test_other_non_http_scheme_mdlink_not_counted_broken(tmp_path: Path) -> None:
+    """Non-navigational URI schemes beyond tel:/mailto: (sms:, callto:, etc.)
+    are not file references and must not contribute broken links."""
+    _write(
+        tmp_path,
+        "contact.md",
+        "Text us at [sms](sms:+1-555-1234) or via [Skype](skype:username)",
+    )
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("sms:" in t or "skype:" in t for t in targets)
+
+
+def test_tel_wikilink_not_counted_broken(tmp_path: Path) -> None:
+    """[[tel:+1-555-1234]] is a non-navigational URI in wikilink form. It
+    must not be counted as a broken wikilink to a missing note."""
+    _write(tmp_path, "contact.md", "Dial [[tel:+1-555-1234]] for support")
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("tel:" in t for t in targets)
+
+
+def test_mailto_wikilink_not_counted_broken(tmp_path: Path) -> None:
+    """[[mailto:user@example.com]] in wikilink form must not count as a broken
+    note reference."""
+    _write(tmp_path, "contact.md", "Write to [[mailto:user@example.com]]")
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("mailto:" in t for t in targets)
+
+
+def test_uri_scheme_inside_code_fence_not_counted(tmp_path: Path) -> None:
+    """A tel: or mailto: link shown as an example inside a fenced code block
+    (e.g. in a FORMAT spec or tutorial) must not count -- it is documentation
+    syntax, not a navigation edge."""
+    _write(
+        tmp_path,
+        "guide.md",
+        "Contact links look like:\n\n```markdown\n"
+        "[phone](tel:+1-555-1234)\n"
+        "[email](mailto:hello@example.com)\n"
+        "```\n",
+    )
+    r = build_doc_graph(tmp_path)
+    assert r.dangling_links == 0
+    targets = {bl["target"] for bl in r.broken_links}
+    assert not any("tel:" in t or "mailto:" in t for t in targets)
+
+
+def test_real_file_links_still_flagged_after_scheme_exclusions(tmp_path: Path) -> None:
+    """URI-scheme exclusions must not accidentally suppress genuine broken
+    relative-path links. A link to a missing file must still be flagged."""
+    _write(tmp_path, "a.md", "[gone](missing-file.md) and [phone](tel:555-1234)")
+    r = build_doc_graph(tmp_path)
+    targets = {bl["target"] for bl in r.broken_links}
+    assert "missing-file.md" in targets
+    assert not any("tel:" in t for t in targets)


### PR DESCRIPTION
## Summary

- `_EXTERNAL_RE` matched `tel:` and `mailto:` specifically, but any other bare URI scheme (`sms:`, `skype:`, `callto:`, `javascript:`, etc.) was treated as a missing relative-path reference and counted as a broken link. Replaced the scheme allowlist with the generic RFC 3986 pattern (`^[a-z][a-z0-9+.-]*:`) to exclude every URI scheme generically.
- The wikilink extraction path had no scheme guard at all. A `[[tel:+1-555-1234]]` wikilink was resolved as a missing note and logged as broken. Added a pre-screen against `_EXTERNAL_RE` before attempting wikilink resolution.

## Changes

- `skills/assess/scripts/lib/doc_graph.py`: broaden `_EXTERNAL_RE` to match any RFC 3986 scheme; add scheme guard to the wikilink path in `build_doc_graph`.
- `skills/assess/tests/test_doc_graph.py`: 7 new tests covering `tel:`/`mailto:`/`sms:`/`skype:` markdown links, `tel:`/`mailto:` wikilinks, tel/mailto inside code fences, and a regression guard that genuine broken relative paths are still flagged.

## Test plan

- [ ] `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -v` from `skills/assess/` - 46 doc_graph tests pass, 817 total pass, 0 failures.

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broken-link detection so non-web links like email, phone, and other URI schemes are no longer flagged as broken.
  * Wikilinks now handle aliases and anchors more accurately when checking link targets.
  * Links shown inside code blocks are ignored during broken-link checks.

* **Chores**
  * Updated the plugin manifest version to `1.46.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->