### PR TITLE
feat: Add --porcelain flag to ghsync for machine-readable repo lists

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.47.2",
+  "version": "1.47.3",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-native-toolkit",
   "description": "Skills for AI-native development. /assess scores a codebase's readiness for AI agent contributors (0-8 layered contract model) and generates a Codecov-style complexity hotspot SVG plus a colour-blind-safe doc-navigability graph. /huddle runs structured multi-perspective deliberation using Six Thinking Hats with Fibonacci team sizing. /deslop detects and removes the telltale signs of AI writing from prose. /ghsync bulk-clones and keeps in sync every GitHub repo you can access across an org or personal account, for onboarding into a new enterprise. /skill-forge hardens a skill through judge-panel refinement rounds until it clears a 3-tier promotion gate - a prove-and-promote quality gate that ran on itself. /semantic-compress optimizes an LLM-directed document while preserving what it does, with two transforms gated on the ab-equivalence A/B harness: compress (a local core->pointer pass and an A/B-validated distill loop that produces the smallest behaviourally-equivalent version of a whole document or skill) and directive-clarity (rewrites latent-action instructions - bare negations, facts-not-actions, vague pointers - into directives that name the action, validated by a measured directness gain at zero regression). Also bundles personal workflow commands: /tm (Task Master orchestration), /issues (GitHub-issue marathon - triage open issues then run agent-ready ones to merge with Agent Teams), /fix-pr and /fix-develop (autonomous PR/branch fix loops). /tm, /issues, /fix-pr, and /fix-develop share the marathon and pr-review-merge skills for team orchestration and PR review/merge.",
-  "version": "1.47.3",
+  "version": "1.48.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Ben Coombs"

--- a/skills/ghsync/SKILL.md
+++ b/skills/ghsync/SKILL.md
@@ -68,6 +68,7 @@ bash "$SKILL_DIR/scripts/ghsync.sh" --org meridianhub --root ~/dev/github.com/me
 | `--root DIR` | Directory to clone into (default: current directory) |
 | `--list-teams` | List your teams in the org (with repo counts) and exit; orgs only |
 | `--list-repos` | List the deduplicated accessible repos and exit |
+| `--porcelain` | Machine-readable repo list: one name per line to stdout, all chatter to stderr; implies `--list-repos`. Consumed by downstream tooling such as `/ghreport`. |
 | `--dry-run` | Show what would be cloned/updated without making changes |
 | `--limit N` | Process only the first N repos (useful for a quick test) |
 | `--quiet` | Suppress per-repository chatter; keep the final summary |

--- a/skills/ghsync/scripts/ghsync.sh
+++ b/skills/ghsync/scripts/ghsync.sh
@@ -111,7 +111,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     -h|--help)
-      sed -n '4,45p' "$0"
+      sed -n '4,44p' "$0"
       exit 0
       ;;
     *)

--- a/skills/ghsync/scripts/ghsync.sh
+++ b/skills/ghsync/scripts/ghsync.sh
@@ -32,7 +32,7 @@ set -euo pipefail
 # --hostname github.example.com` first.
 #
 # Usage: ./ghsync.sh [--org NAME] [--root DIR] [--quiet] [--limit N]
-#                    [--dry-run] [--list-teams] [--list-repos]
+#                    [--dry-run] [--list-teams] [--list-repos] [--porcelain]
 #   --org NAME     Org to sync (default: basename of --root / cwd)
 #   --root DIR     Directory to clone into (default: current directory)
 #   --quiet        Suppress per-repository messages during sync
@@ -40,6 +40,8 @@ set -euo pipefail
 #   --dry-run      Show what would be done without making changes
 #   --list-teams   List your teams in the org and exit (orgs only)
 #   --list-repos   List the deduplicated accessible repos and exit
+#   --porcelain    Machine-readable repo list: one name per line to stdout,
+#                  all progress/status chatter to stderr; implies --list-repos
 # ===================================================================
 
 # Process command line args
@@ -50,6 +52,7 @@ REPO_LIMIT=0
 DRY_RUN=false
 LIST_TEAMS=false
 LIST_REPOS=false
+PORCELAIN_MODE=false
 
 # Repositories to never sync (oversized, checkout issues, etc.).
 # Override per-machine by exporting GHSYNC_BLACKLIST as a space-separated
@@ -98,17 +101,36 @@ while [[ $# -gt 0 ]]; do
       LIST_REPOS=true
       shift
       ;;
+    --porcelain)
+      # Machine-readable repo list for downstream tooling (e.g. ghreport).
+      # Implies the --list-repos early exit, but with a clean stdout: only
+      # repo names reach stdout; every progress/status message is routed to
+      # stderr by the fd swap below.
+      PORCELAIN_MODE=true
+      LIST_REPOS=true
+      shift
+      ;;
     -h|--help)
-      sed -n '4,41p' "$0"
+      sed -n '4,45p' "$0"
       exit 0
       ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--org NAME] [--root DIR] [--quiet] [--limit N] [--dry-run] [--list-teams] [--list-repos]"
+      echo "Usage: $0 [--org NAME] [--root DIR] [--quiet] [--limit N] [--dry-run] [--list-teams] [--list-repos] [--porcelain]"
       exit 1
       ;;
   esac
 done
+
+# Porcelain mode: keep stdout clean for machine consumers. Save the real
+# stdout on fd 3 and redirect fd 1 to stderr, so every informational echo,
+# warning, and progress line in the rest of the script lands on stderr
+# without having to touch each call site. Only the repo-name list is then
+# explicitly written to fd 3 (real stdout) in the --list-repos block below.
+# Without --porcelain this is a no-op and behaviour is unchanged.
+if [ "$PORCELAIN_MODE" = true ]; then
+    exec 3>&1 1>&2
+fi
 
 # Derive root and org. Root is where repos land (default: cwd). Org defaults
 # to the basename of root, so dropping into ~/dev/github.com/<org> just works.
@@ -315,11 +337,19 @@ else
 fi
 
 if [ "$LIST_REPOS" = true ]; then
-    echo ""
-    echo "Repositories accessible to you:"
-    for repo in "${github_repos[@]}"; do
-        echo "  - $repo"
-    done
+    if [ "$PORCELAIN_MODE" = true ]; then
+        # Machine-readable: one repo name per line to real stdout (fd 3),
+        # no prefix, no surrounding chatter.
+        for repo in "${github_repos[@]}"; do
+            echo "$repo" >&3
+        done
+    else
+        echo ""
+        echo "Repositories accessible to you:"
+        for repo in "${github_repos[@]}"; do
+            echo "  - $repo"
+        done
+    fi
     exit 0
 fi
 

--- a/tests/test_ghsync_porcelain.py
+++ b/tests/test_ghsync_porcelain.py
@@ -1,0 +1,101 @@
+"""Behavioural contract for `ghsync.sh --porcelain`.
+
+The `--porcelain` flag exists so downstream tooling (e.g. /ghreport) can parse
+the discovered repo list off stdout. The contract that matters: with
+`--porcelain`, stdout carries ONLY repo names (one per line, no prefix, no
+progress chatter); every informational line goes to stderr. Without it, the
+existing `--list-repos` output (header + `  - name` lines) is unchanged.
+
+This runs the real script offline: `gh` is stubbed on PATH to return canned
+discovery data, and the script's own `jq` filtering does the rest (jq ships on
+the CI runner). No network, no auth, deterministic.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+GHSYNC = REPO / "skills" / "ghsync" / "scripts" / "ghsync.sh"
+
+# Stub `gh` covering exactly the calls the discovery path makes: auth check,
+# account-type probe (Organization), no team memberships, and an org repo
+# list with an archived repo and an empty (no default branch) repo that must
+# both be filtered out.
+GH_STUB = """\
+#!/usr/bin/env bash
+case "$1" in
+  auth) exit 0 ;;
+  api)
+    case "$2" in
+      users/*) echo "Organization" ;;
+      user/teams) echo "" ;;
+      *) echo "" ;;
+    esac ;;
+  repo)
+    cat <<'JSON'
+[{"name":"zebra","isArchived":false,"defaultBranchRef":{"name":"main"}},
+ {"name":"alpha","isArchived":false,"defaultBranchRef":{"name":"main"}},
+ {"name":"arch-one","isArchived":true,"defaultBranchRef":{"name":"main"}},
+ {"name":"empty-one","isArchived":false,"defaultBranchRef":null}]
+JSON
+    ;;
+  *) exit 0 ;;
+esac
+"""
+
+# After dedupe/sort and dropping the archived + empty repos.
+EXPECTED_REPOS = ["alpha", "zebra"]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="requires bash and jq on PATH",
+)
+
+
+def _run(tmp_path, *args):
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir(exist_ok=True)
+    gh = stub_dir / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+    root = tmp_path / "root"
+    root.mkdir(exist_ok=True)
+    env = {"PATH": f"{stub_dir}:{shutil.os.environ['PATH']}"}
+    return subprocess.run(
+        ["bash", str(GHSYNC), "--org", "testorg", "--root", str(root), *args],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+def test_porcelain_stdout_is_only_repo_names(tmp_path):
+    res = _run(tmp_path, "--porcelain")
+    assert res.returncode == 0, res.stderr
+    lines = res.stdout.splitlines()
+    assert lines == EXPECTED_REPOS, f"stdout not clean repo list: {res.stdout!r}"
+
+
+def test_porcelain_routes_chatter_to_stderr(tmp_path):
+    res = _run(tmp_path, "--porcelain")
+    # Progress/status lines must not contaminate stdout...
+    assert "Org:" not in res.stdout
+    assert "Fetching" not in res.stdout
+    assert "  - " not in res.stdout
+    # ...they belong on stderr.
+    assert "Org:" in res.stderr
+
+
+def test_list_repos_without_porcelain_unchanged(tmp_path):
+    res = _run(tmp_path, "--list-repos")
+    assert res.returncode == 0, res.stderr
+    # Human format: a header plus `  - name` bullet lines, chatter on stdout.
+    assert "Repositories accessible to you:" in res.stdout
+    assert "  - alpha" in res.stdout
+    assert "  - zebra" in res.stdout
+
+
+def test_porcelain_documented_in_help(tmp_path):
+    res = _run(tmp_path, "--help")
+    assert res.returncode == 0
+    assert "--porcelain" in res.stdout


### PR DESCRIPTION
## Summary

Adds a `--porcelain` flag to `ghsync.sh` that prints the deduplicated repo list one name per line to stdout, routing all progress/status chatter to stderr. Implies `--list-repos`.

This is the foundation for `/ghreport` (PR #2, follow-up): it lets the report tool reuse `ghsync`'s exact team-union / org-repo-list discovery instead of re-implementing it, parsing repo names off a clean stdout.

## Changes Made

- `skills/ghsync/scripts/ghsync.sh`: new `--porcelain` flag. Implemented with an fd swap (`exec 3>&1 1>&2`) right after arg parsing, so every existing informational `echo` lands on stderr without touching each call site; only the repo-name list is written to the saved real stdout (fd 3). The non-porcelain path is byte-for-byte unchanged (Chesterton's fence).
- `skills/ghsync/SKILL.md`: documents the flag in the flags table.
- `tests/test_ghsync_porcelain.py`: offline behavioural contract - stubs `gh` on `PATH`, lets the real `jq` filtering run (jq is on the runner), and asserts (a) porcelain stdout is only repo names, (b) chatter goes to stderr, (c) `--list-repos` output is unchanged, (d) `--porcelain` is documented in `--help`.
- `.claude-plugin/plugin.json`: version bump `1.47.2 -> 1.47.3`.

## Testing

- `pytest tests/` -> 292 passed (incl. 4 new porcelain tests).
- Manual: stubbed-`gh` run confirms porcelain stdout = bare names, stderr = chatter; `--list-repos` still prints the `  - name` human format.

## Risk Assessment

Low. Additive flag; default behaviour untouched and asserted by the unchanged-output test. No network/auth in tests.