### PR TITLE
docs: Link the modernization design subtree from the Map of Content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ The Six Thinking Hats team, indexed in [`agents/README.md`](../agents/README.md)
 
 - [Testing a branch locally](./testing-a-branch-locally.md) - run an unmerged branch's `SKILL.md` and scripts as a real plugin against a target repo.
 - [Design history](./superpowers/README.md) - the plans and specs behind the skills as they were built.
+- [Modernization programme (2026-09)](./design/2026-09-modernization/README.md) - intent, recorded probes, and the eleven workstream specs behind the multi-plugin split.
 - [Code review instructions](../.github/claude-review-instructions.md) - the guidelines the automated reviewer follows on pull requests.
 - [How to build a narrated skill explainer](./huddle-explainer/README.md) - the repeatable Claude Code + Claude Design + ElevenLabs pipeline, worked through end to end on `/huddle`.
 


### PR DESCRIPTION
## Summary

PR #290 merged `docs/design/2026-09-modernization/` (intent, README index, recorded probes, and eleven workstream spec placeholders) but the repo's Map of Content (`docs/index.md`) never linked to it, leaving the subtree an orphan island that the doc-graph review flagged. This PR adds the single inbound link.

## Changes Made

- Added one bullet to `docs/index.md`, directly after the existing "Design history" bullet, linking to `./design/2026-09-modernization/README.md`.

## Testing

- `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` - 355 passed.
- `git diff main --stat` confirms only `docs/index.md` changed.

## Risk Assessment

Docs-only change; no code, config, or CI behavior affected.

https://claude.ai/code/session_014p5xLvR5MEucTcDc66yzHe