### PR TITLE
docs: Add WS10 sunset spec for the modernization programme

### DIFF
--- a/docs/design/2026-09-modernization/sunset/spec.md
+++ b/docs/design/2026-09-modernization/sunset/spec.md
@@ -1,3 +1,110 @@
 # WS10 spec: Sunset
 
-Placeholder. Replaced by the WS10 (`modernization-sunset`) spec PR of the programme indexed in [README.md](../README.md). Intent: [intent.md](../intent.md).
+## Intent
+
+Satisfies brief **R18** (removal half) of [../intent.md](../intent.md); tag `modernization-sunset` holds exactly one task, status `deferred` until the next MAJOR (3.0.0) is scheduled.
+
+## Current state
+
+Measured at `44bddbf`.
+
+Deprecation Path rows in `../intent.md` whose "Removed in" column is `3.0.0`:
+
+```
+$ awk '/^## Deprecation Path/,/^## Programme sequence/' docs/design/2026-09-modernization/intent.md | rg -c '3\.0\.0'
+5
+$ awk '/^## Deprecation Path/,/^## Programme sequence/' docs/design/2026-09-modernization/intent.md | rg '3\.0\.0'
+| Single plugin split (R1) | Symlink meta-plugin `ai-native-toolkit` keeping id, namespace, and every name; once-only notice | 3.0.0 (`renames -> null`) |
+| `6hats` folded into `huddle` (R12) | Stub skill under the old name, forwards with the size argument | 3.0.0 |
+| `docs/superpowers/` renamed (R13) | Redirect stub | 3.0.0 |
+| `.github/claude-review-instructions.md` replaced (R8) | Three-line pointer | 3.0.0 |
+| Assess helpers not folded (Out of scope) | Listed on the 3.0 list in the guide | 3.0.0 |
+```
+
+Whether a `remove-in:` marker exists in the tree today (the marker is planted by WS1/WS2/WS5, which have not merged yet, so it should not exist):
+
+```
+$ rg -n 'remove-in' --glob '!docs/design/**' .
+[no output, exit 1]
+```
+
+Current plugin version:
+
+```
+$ jq -r '.version' .claude-plugin/plugin.json
+1.56.0
+```
+
+Whether `renames` appears in `.claude-plugin/marketplace.json` today:
+
+```
+$ rg -n 'renames' .claude-plugin/marketplace.json
+[no output, exit 1]
+```
+
+Two of the five items already exist on disk and will be live shims by the time this task runs: `.github/claude-review-instructions.md` (10,836 bytes today, replaced by `REVIEW.md` under R8/WS5) and `docs/superpowers/` (holds `README.md`, `plans/`, `specs/` today; WS5 renames it to `docs/design/` and leaves `docs/superpowers/README.md` as the redirect stub under R13).
+
+## Design
+
+This task is the deferred half of R18; the guide half (D3, `docs/migration-2.0.md`) ships with WS1. Nothing here executes before the next MAJOR - the task sits `deferred` in Task Master until then.
+
+One removal action per Deprecation Path row measured above:
+
+| Breadcrumb | Created by | Removal action |
+|---|---|---|
+| Symlink meta-plugin `ai-native-toolkit` (D5, R1/WS1) | WS1 | Add `renames: {"ai-native-toolkit": null}` to `.claude-plugin/marketplace.json`; delete `plugins/ai-native-toolkit/` (its `plugin.json` and every symlink) |
+| `6hats` stub (D4, R12/WS2) | WS2 | Delete `plugins/huddle/skills/6hats/`; remove the `6hats` allow-list entry from the `^[a-z][a-z-]*$` naming contract test |
+| `docs/superpowers/` redirect stub (R13/WS5) | WS5 | Delete `docs/superpowers/README.md`; remove `docs/superpowers/` entirely once nothing else references it |
+| `.github/claude-review-instructions.md` pointer (R8/WS5) | WS5 | Delete `.github/claude-review-instructions.md`; `REVIEW.md` is by then the sole review-policy source |
+| Assess helpers fold (Out of scope, listed on the 3.0 list) | Not workstream-owned; deferred at programme design time because no runner-consumable transfer set exists for assess | Fold `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` into `plugins/assess/skills/assess/references/` |
+
+The marketplace edit for the first row:
+
+```json
+{
+  "renames": {
+    "ai-native-toolkit": null
+  }
+}
+```
+
+None of the five removal actions touches a path marked by the floor today (`skills/marathon/SKILL.md`, `skills/pr-review-merge/SKILL.md`, `commands/tm.md`, `commands/issues.md`); by 3.0.0 the marked set is token-discovered per WS0 (R0), so this task carries no floor edit regardless.
+
+Every plugin bumps in the same PR: the six family plugins (D2's per-plugin semver) and, until its own removal in this task, the meta-plugin. The assess-helpers fold is a behaviour change, not a pure move, so it is a MAJOR bump for `assess` specifically, consistent with a 3.0.0 boundary where breaking changes are expected.
+
+The guide's shim section - the part of `docs/migration-2.0.md` that lists active shims and their `remove-in` status - is deleted once every listed shim is gone; the guide's historical 1.x-to-2.0 mapping is untouched.
+
+## Requirements
+
+1. `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' .` returns 0 (or no match) after the task; `docs/design/2026-09-modernization/intent.md` and this spec keep the term as a historical record and are excluded from the count, same as the Current state command above.
+2. `plugins/ai-native-toolkit/` does not exist: `test -d plugins/ai-native-toolkit && echo present || echo absent` prints `absent`.
+3. `.claude-plugin/marketplace.json` carries `renames: {"ai-native-toolkit": null}` and no entry with `source: "./plugins/ai-native-toolkit"`: `jq '.renames, [.plugins[] | select(.source == "./plugins/ai-native-toolkit")]' .claude-plugin/marketplace.json` prints the rename and an empty array.
+4. `plugins/huddle/skills/6hats/` does not exist, and no naming-contract allow-list entry names it: `test -d plugins/huddle/skills/6hats && echo present || echo absent` prints `absent`.
+5. `docs/superpowers/` does not exist: `test -d docs/superpowers && echo present || echo absent` prints `absent`.
+6. `.github/claude-review-instructions.md` does not exist: `test -f .github/claude-review-instructions.md && echo present || echo absent` prints `absent`.
+7. `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` do not exist; their content is reachable under `plugins/assess/skills/assess/references/`.
+8. Every plugin touched by this task has a version bump recorded in its `CHANGELOG.md` in the same PR (the same-PR-bump-requires-changelog contract test from WS7/R10 is green for this PR's diff).
+9. The shim section is gone from `docs/migration-2.0.md`: a grep for its heading returns no match, while the guide's historical 1.x-to-2.0 rows remain.
+10. `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` is green.
+
+## Verification
+
+- `tests/test_plugin_contract.py::test_internal_links_resolve` and `::test_marketplace_entries_exist` (`plugin contract pytest` job) catch any dangling link left by the deletions and any marketplace entry whose `source` no longer resolves.
+- `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' .` (Requirement 1) is the mechanical proof the enumeration is complete.
+- `claude plugin validate .` zero warnings; `claude plugin validate plugins/<name> --strict` for each of the six remaining family plugins (the meta-plugin is gone, so it drops out of this loop).
+- The WS7-introduced same-PR-bump contract test (fetches the base ref) is green for every plugin this PR touches.
+- The assess-helpers fold is not gated by `ab-equivalence`: the Out of scope entry in `../intent.md`'s programme source records that no runner-consumable transfer set exists for assess, so this fold ships as a plain, expected-breaking change at the MAJOR boundary rather than a frozen move.
+
+## Breadcrumbs
+
+This workstream removes breadcrumbs and adds none: it deletes the five shims enumerated in Design (the meta-plugin, the `6hats` stub, the `docs/superpowers/` redirect, the `.github/claude-review-instructions.md` pointer, and the assess-helpers gap) and leaves no new pointer, stub, or `remove-in` marker in their place.
+
+## Rollback
+
+This PR is a pure deletion plus a version bump, docs and plugin trees only, no floor edit. `git revert` of the single commit restores every deleted file and the pre-bump versions, returning `main` to green. The programme cuts a version tag only after the post-merge self-test is green (the same pattern used for `v1.57.0`), so if the revert happens before that tag exists there is no immutable artefact to reconcile. If the tag has already been cut, the fix is a new forward PR that restores the shim content and bumps again - the tag itself cannot be un-cut.
+
+## Sequencing
+
+One PR, opened only after WS3, WS5, WS6, WS7, and WS9 have all merged (the programme dependency graph's `WS3, WS5, WS6, WS7, WS9 -> WS10`; WS1, WS2, WS4, and WS8 are satisfied transitively, since each of those five depends on one or more of them). The task stays `deferred` in Task Master until the next MAJOR is scheduled - it is the last task in the programme to leave that status.
+
+It may not touch anything outside the five removal actions in Design, the version bumps they require, and the migration guide's shim-section deletion. It must not rename anything (WS2's territory, already merged), add a new component, touch `FLOOR.md`, `floor_check.py`, `floor_anchor.py`, or `floor.yml` (none of the five actions intersects a floor-marked path, per Design), or touch `action.yml` or a CI job `name:` (D7).

--- a/docs/design/2026-09-modernization/sunset/spec.md
+++ b/docs/design/2026-09-modernization/sunset/spec.md
@@ -42,7 +42,7 @@ $ rg -n 'renames' .claude-plugin/marketplace.json
 [no output, exit 1]
 ```
 
-Two of the five items already exist on disk and will be live shims by the time this task runs: `.github/claude-review-instructions.md` (10,836 bytes today, replaced by `REVIEW.md` under R8/WS5) and `docs/superpowers/` (holds `README.md`, `plans/`, `specs/` today; WS5 renames it to `docs/design/` and leaves `docs/superpowers/README.md` as the redirect stub under R13).
+Two of the five items already exist on disk and will be live shims by the time this task runs: `.github/claude-review-instructions.md` (10,836 bytes today, replaced by `REVIEW.md` under R8/WS5) and `docs/superpowers/` (holds `README.md`, `plans/`, `specs/` today; WS5 merges those contents into the already-existing `docs/design/` - the directory this programme itself lives in - and leaves `docs/superpowers/README.md` as the redirect stub under R13).
 
 ## Design
 
@@ -52,9 +52,9 @@ One removal action per Deprecation Path row measured above:
 
 | Breadcrumb | Created by | Removal action |
 |---|---|---|
-| Symlink meta-plugin `ai-native-toolkit` (D5, R1/WS1) | WS1 | Add `renames: {"ai-native-toolkit": null}` to `.claude-plugin/marketplace.json`; delete `plugins/ai-native-toolkit/` (its `plugin.json` and every symlink) |
+| Symlink meta-plugin `ai-native-toolkit` (D5, R1/WS1) | WS1 | Add `renames: {"ai-native-toolkit": null}` to `.claude-plugin/marketplace.json`; delete `plugins/ai-native-toolkit/` (its `plugin.json` and every symlink); remove the `family-bump-requires-umbrella-bump` contract test, which has no umbrella version left to compare against once the meta-plugin is gone (`bump-requires-changelog` stays in force) |
 | `6hats` stub (D4, R12/WS2) | WS2 | Delete `plugins/huddle/skills/6hats/`; remove the `6hats` allow-list entry from the `^[a-z][a-z-]*$` naming contract test |
-| `docs/superpowers/` redirect stub (R13/WS5) | WS5 | Delete `docs/superpowers/README.md`; remove `docs/superpowers/` entirely once nothing else references it |
+| `docs/superpowers/` redirect stub (R13/WS5) | WS5 | Delete `docs/superpowers/README.md` - after WS5's merge into `docs/design/` that stub is all `docs/superpowers/` still holds - then remove the emptied directory once nothing else references it |
 | `.github/claude-review-instructions.md` pointer (R8/WS5) | WS5 | Delete `.github/claude-review-instructions.md`; `REVIEW.md` is by then the sole review-policy source |
 | Assess helpers fold (Out of scope, listed on the 3.0 list) | Not workstream-owned; deferred at programme design time because no runner-consumable transfer set exists for assess | Fold `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` into `plugins/assess/skills/assess/references/` |
 
@@ -70,7 +70,11 @@ The marketplace edit for the first row:
 
 None of the five removal actions touches a path marked by the floor today (`skills/marathon/SKILL.md`, `skills/pr-review-merge/SKILL.md`, `commands/tm.md`, `commands/issues.md`); by 3.0.0 the marked set is token-discovered per WS0 (R0), so this task carries no floor edit regardless.
 
-Every plugin bumps in the same PR: the six family plugins (D2's per-plugin semver) and, until its own removal in this task, the meta-plugin. The assess-helpers fold is a behaviour change, not a pure move, so it is a MAJOR bump for `assess` specifically, consistent with a 3.0.0 boundary where breaking changes are expected.
+Every surviving plugin bumps in the same PR, but not all onto the same line. The five non-`assess` family plugins go to `3.0.0`. `assess` takes a MINOR bump on its own 1.x line - from whatever `1.x` version it carries when this task runs (D2 puts it at `1.57.0` once the split lands; the Current state measurement above is the pre-split `1.56.0`). The programme's `3.0.0` is the other five families' line and never applies to `assess`.
+
+A MAJOR bump for `assess` is rejected, per D2. D2 defines MAJOR by what the code keys off: `assess_core.py:388-390` treats a MAJOR change as a breaking change to the deterministic core, and `assess_gate.py:140` returns early from the regression compare when the diff is unreliable. So shipping `assess` as `2.0.0` would disarm `fail_on_regression` for every adopter on the version this ships and reset their trend history. Folding `assess-findings` and `assess-pr` into `references/` changes no code under `assess`'s `lib/` and no stats schema, so it cannot regress an adopter's metrics and is not MAJOR by that definition; a 3.0.0 calendar boundary is not the definition the gate reads.
+
+The meta-plugin takes no bump. This task deletes `plugins/ai-native-toolkit/`, its `plugin.json`, and its `CHANGELOG.md`, so there is no manifest left to record a version in and no changelog entry to demand.
 
 The guide's shim section - the part of `docs/migration-2.0.md` that lists active shims and their `remove-in` status - is deleted once every listed shim is gone; the guide's historical 1.x-to-2.0 mapping is untouched.
 
@@ -83,17 +87,18 @@ The guide's shim section - the part of `docs/migration-2.0.md` that lists active
 5. `docs/superpowers/` does not exist: `test -d docs/superpowers && echo present || echo absent` prints `absent`.
 6. `.github/claude-review-instructions.md` does not exist: `test -f .github/claude-review-instructions.md && echo present || echo absent` prints `absent`.
 7. `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` do not exist; their content is reachable under `plugins/assess/skills/assess/references/`.
-8. Every plugin touched by this task has a version bump recorded in its `CHANGELOG.md` in the same PR (the same-PR-bump-requires-changelog contract test from WS7/R10 is green for this PR's diff).
-9. The shim section is gone from `docs/migration-2.0.md`: a grep for its heading returns no match, while the guide's historical 1.x-to-2.0 rows remain.
-10. `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` is green.
+8. Every plugin that survives this task has a version bump recorded in its `CHANGELOG.md` in the same PR (the `bump-requires-changelog` contract test from WS7/R10 is green for this PR's diff). The deleted meta-plugin is exempt: its `plugin.json` and `CHANGELOG.md` go with it, so it has neither a version to bump nor a changelog to record it in.
+9. The `family-bump-requires-umbrella-bump` contract test is gone: a grep of `tests/` for its name returns no match. This PR bumps all six family plugins while deleting the umbrella they were compared against, so the test cannot hold and is removed in the same diff; `bump-requires-changelog` (Requirement 8) is untouched.
+10. The shim section is gone from `docs/migration-2.0.md`: a grep for its heading returns no match, while the guide's historical 1.x-to-2.0 rows remain.
+11. `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` is green.
 
 ## Verification
 
 - `tests/test_plugin_contract.py::test_internal_links_resolve` and `::test_marketplace_entries_exist` (`plugin contract pytest` job) catch any dangling link left by the deletions and any marketplace entry whose `source` no longer resolves.
 - `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' .` (Requirement 1) is the mechanical proof the enumeration is complete.
 - `claude plugin validate .` zero warnings; `claude plugin validate plugins/<name> --strict` for each of the six remaining family plugins (the meta-plugin is gone, so it drops out of this loop).
-- The WS7-introduced same-PR-bump contract test (fetches the base ref) is green for every plugin this PR touches.
-- The assess-helpers fold is not gated by `ab-equivalence`: the Out of scope entry in `../intent.md`'s programme source records that no runner-consumable transfer set exists for assess, so this fold ships as a plain, expected-breaking change at the MAJOR boundary rather than a frozen move.
+- The WS7-introduced `bump-requires-changelog` contract test (fetches the base ref) is green for every plugin this PR touches. Its sibling `family-bump-requires-umbrella-bump` is deleted by this PR rather than kept green, per Requirement 9.
+- The assess-helpers fold is not gated by `ab-equivalence`: the Out of scope entry in `../intent.md`'s programme source records that no runner-consumable transfer set exists for assess, so this fold ships as a plain move rather than a frozen one. It reaches no code under `assess`'s `lib/` and no stats schema, which is why it rides a MINOR (Design, citing D2) and not a MAJOR.
 
 ## Breadcrumbs
 
@@ -107,4 +112,4 @@ This PR is a pure deletion plus a version bump, docs and plugin trees only, no f
 
 One PR, opened only after WS3, WS5, WS6, WS7, and WS9 have all merged (the programme dependency graph's `WS3, WS5, WS6, WS7, WS9 -> WS10`; WS1, WS2, WS4, and WS8 are satisfied transitively, since each of those five depends on one or more of them). The task stays `deferred` in Task Master until the next MAJOR is scheduled - it is the last task in the programme to leave that status.
 
-It may not touch anything outside the five removal actions in Design, the version bumps they require, and the migration guide's shim-section deletion. It must not rename anything (WS2's territory, already merged), add a new component, touch `FLOOR.md`, `floor_check.py`, `floor_anchor.py`, or `floor.yml` (none of the five actions intersects a floor-marked path, per Design), or touch `action.yml` or a CI job `name:` (D7).
+It may not touch anything outside the five removal actions in Design, the version bumps they require, the `family-bump-requires-umbrella-bump` test removal named in that table's meta-plugin row, and the migration guide's shim-section deletion. It must not rename anything (WS2's territory, already merged), add a new component, touch `FLOOR.md`, `floor_check.py`, `floor_anchor.py`, or `floor.yml` (none of the five actions intersects a floor-marked path, per Design), or touch `action.yml` or a CI job `name:` (D7).

--- a/docs/design/2026-09-modernization/sunset/spec.md
+++ b/docs/design/2026-09-modernization/sunset/spec.md
@@ -6,7 +6,7 @@ Satisfies brief **R18** (removal half) of [../intent.md](../intent.md); tag `mod
 
 ## Current state
 
-Measured at `44bddbf`.
+Measured at `2027a23`.
 
 Deprecation Path rows in `../intent.md` whose "Removed in" column is `3.0.0`:
 
@@ -42,6 +42,29 @@ $ rg -n 'renames' .claude-plugin/marketplace.json
 [no output, exit 1]
 ```
 
+Files that reference `assess-findings` or `assess-pr` today, excluding this programme's own docs, the generated `.assess/` artefacts, and `docs/superpowers/` (which WS5 merges into `docs/design/`):
+
+```
+$ rg -c 'assess-findings|assess-pr' --glob '!docs/design/**' --glob '!.assess/**' --glob '!docs/superpowers/**' . | sort
+./agents/assess-layer-scorer.md:3
+./docs/index.md:2
+./scripts/standalone_skill_config.py:4
+./skills/assess-findings/SKILL.md:2
+./skills/assess-pr/SKILL.md:1
+./skills/assess/references/consent-lifecycle.md:3
+./skills/assess/references/uninstall.md:1
+./skills/assess/scripts/lib/archetype.py:1
+./skills/assess/scripts/lib/README.md:1
+./skills/assess/SKILL.md:5
+./skills/assess/tests/fixtures/golden/run-context-baseline.json:4
+./skills/assess/tests/test_decomposition_parity.py:3
+./skills/assess/tests/test_uninstall.py:1
+./skills/README.md:2
+./skills/skill-forge/SKILL.md:1
+```
+
+Thirteen files besides the two skills themselves. WS1's move relocates all of them under `plugins/<family>/`; the paths cited in Design are today's, and the edit each consumer needs is unchanged by the move.
+
 Two of the five items already exist on disk and will be live shims by the time this task runs: `.github/claude-review-instructions.md` (10,836 bytes today, replaced by `REVIEW.md` under R8/WS5) and `docs/superpowers/` (holds `README.md`, `plans/`, `specs/` today; WS5 merges those contents into the already-existing `docs/design/` - the directory this programme itself lives in - and leaves `docs/superpowers/README.md` as the redirect stub under R13).
 
 ## Design
@@ -56,9 +79,9 @@ One removal action per Deprecation Path row measured above:
 | `6hats` stub (D4, R12/WS2) | WS2 | Delete `plugins/huddle/skills/6hats/`; remove the `6hats` allow-list entry from the `^[a-z][a-z-]*$` naming contract test |
 | `docs/superpowers/` redirect stub (R13/WS5) | WS5 | Delete `docs/superpowers/README.md` - after WS5's merge into `docs/design/` that stub is all `docs/superpowers/` still holds - then remove the emptied directory once nothing else references it |
 | `.github/claude-review-instructions.md` pointer (R8/WS5) | WS5 | Delete `.github/claude-review-instructions.md`; `REVIEW.md` is by then the sole review-policy source |
-| Assess helpers fold (Out of scope, listed on the 3.0 list) | Not workstream-owned; deferred at programme design time because no runner-consumable transfer set exists for assess | Fold `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` into `plugins/assess/skills/assess/references/` |
+| Assess helpers fold (Out of scope, listed on the 3.0 list) | Not workstream-owned; deferred at programme design time because no runner-consumable transfer set exists for assess | Fold `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` into `plugins/assess/skills/assess/references/`, and rewire every consumer measured in Current state: **(a)** `skills/assess/SKILL.md:417,498` - replace "Use the assess-findings skill" and "Use the assess-pr skill" with read-the-reference instructions, since `USE_SKILL_RE` (`tests/test_plugin_contract.py:30`) makes `test_use_the_skill_references_resolve` assert each such name is an installed skill; **(b)** `skills/assess/tests/test_decomposition_parity.py:86` (`test_findings_and_pr_subskills_exist`) and `:93` (`test_orchestrator_delegates_to_each_unit`) - both hard-code the two `SKILL.md` paths and the two delegation names, so both are re-pointed at `references/`, not deleted (Requirement 12); **(c)** `skills/assess/tests/test_uninstall.py:12` - `ASSESS_PR_SKILL` resolves a sibling `assess-pr/SKILL.md`, re-point at the reference file; **(d)** `scripts/standalone_skill_config.py:138-139` - the `bundle_files` map reads the two `SKILL.md` files as ZIP sources, with the matching delegate prose at `:119,125`; **(e)** `skills/skill-forge/SKILL.md:171` - a live relative link to `../assess-pr/SKILL.md` that `test_internal_links_resolve` follows, and that crosses a plugin boundary after WS1's move; **(f)** `skills/README.md:24-25` and `docs/index.md:36-37` - rows linking both files, covered by no gate (`shipped_md()`, `tests/test_plugin_contract.py:79`, is skill `SKILL.md` plus command files), so they rot silently unless edited here; **(g)** prose naming the two units as skills in `agents/assess-layer-scorer.md:12,24,31`, `skills/assess/references/consent-lifecycle.md:3,54,65`, `skills/assess/references/uninstall.md:3`, `skills/assess/scripts/lib/README.md:401`, and `skills/assess/scripts/lib/archetype.py:62`, each re-worded to name the bundled reference rather than a skill. `skills/assess/tests/fixtures/golden/run-context-baseline.json:2639,2644,3589,3594` needs no edit: it is a captured snapshot the tests compare against itself (`skills/assess/tests/test_golden_baseline.py`), not a value re-derived from the tree |
 
-The marketplace edit for the first row:
+The marketplace edit for the first row. The key itself comes from D5's rejected-option note in [../intent.md](../intent.md) (`renames -> null` as a tombstone); the marketplace schema's keys are defined on the plugin-marketplaces documentation page, the same page D1 cites for `metadata.pluginRoot`. This spec has not verified against that page whether `renames` is a top-level key or nested (under `metadata`, say), and nothing in-repo settles it - the Current state `rg -n 'renames' .claude-plugin/marketplace.json` is empty. The placement in the snippet below is therefore unverified, and Requirement 3 carries the verification step: a `claude plugin validate .` run on the edited file, with the snippet corrected to whatever placement that page and that run establish.
 
 ```json
 {
@@ -80,22 +103,23 @@ The guide's shim section - the part of `docs/migration-2.0.md` that lists active
 
 ## Requirements
 
-1. `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' .` returns 0 (or no match) after the task; `docs/design/2026-09-modernization/intent.md` and this spec keep the term as a historical record and are excluded from the count, same as the Current state command above.
+1. `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' --glob '!docs/migration-2.0.md' .` returns 0 (or no match) after the task. Two exclusions, each for its own reason. `docs/design/**` covers `intent.md` and this spec, which keep the term as programme record - same as the Current state command above. `docs/migration-2.0.md` is excluded because its historical mapping table keeps a row that carries a `remove-in: 3.0.0` field: the `commands/6hats.md` row the merged [../naming/spec.md](../naming/spec.md) (Breadcrumbs, line 122) specifies, which Requirement 10 preserves. The boundary is the section, not the field - a `remove-in:` field on a mapping row records when the shim went, and does not make the row a live shim. The guide's shim section, which is the live list of shims and their remove-in status, is deleted under Requirement 10, so nothing outside the historical table still claims a shim exists.
 2. `plugins/ai-native-toolkit/` does not exist: `test -d plugins/ai-native-toolkit && echo present || echo absent` prints `absent`.
-3. `.claude-plugin/marketplace.json` carries `renames: {"ai-native-toolkit": null}` and no entry with `source: "./plugins/ai-native-toolkit"`: `jq '.renames, [.plugins[] | select(.source == "./plugins/ai-native-toolkit")]' .claude-plugin/marketplace.json` prints the rename and an empty array.
+3. `.claude-plugin/marketplace.json` carries a `renames` entry mapping `ai-native-toolkit` to null and no entry with `source: "./plugins/ai-native-toolkit"`: `jq '.renames, [.plugins[] | select(.source == "./plugins/ai-native-toolkit")]' .claude-plugin/marketplace.json` prints the rename and an empty array. The `jq` path assumes the top-level placement shown in Design, which is unverified; `claude plugin validate .` on the edited file, exiting zero with no warnings, is what establishes the key's real placement, and both the snippet and this `jq` filter are corrected to match it before the PR opens.
 4. `plugins/huddle/skills/6hats/` does not exist, and no naming-contract allow-list entry names it: `test -d plugins/huddle/skills/6hats && echo present || echo absent` prints `absent`.
 5. `docs/superpowers/` does not exist: `test -d docs/superpowers && echo present || echo absent` prints `absent`.
 6. `.github/claude-review-instructions.md` does not exist: `test -f .github/claude-review-instructions.md && echo present || echo absent` prints `absent`.
-7. `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` do not exist; their content is reachable under `plugins/assess/skills/assess/references/`.
+7. `plugins/assess/skills/assess-findings/` and `plugins/assess/skills/assess-pr/` do not exist; their content is reachable under `plugins/assess/skills/assess/references/`; and the rewire is green, not merely reachable. The `skills/assess pytest`, `plugin contract pytest`, and `scripts/ pytest` jobs all pass; `rg -c 'Use the assess-(findings|pr) skill' plugins/assess/skills/assess/SKILL.md` returns 0, so the orchestrator routes to neither removed name; and `claude plugin details assess` lists neither skill.
 8. Every plugin that survives this task has a version bump recorded in its `CHANGELOG.md` in the same PR (the `bump-requires-changelog` contract test from WS7/R10 is green for this PR's diff). The deleted meta-plugin is exempt: its `plugin.json` and `CHANGELOG.md` go with it, so it has neither a version to bump nor a changelog to record it in.
 9. The `family-bump-requires-umbrella-bump` contract test is gone: a grep of `tests/` for its name returns no match. This PR bumps all six family plugins while deleting the umbrella they were compared against, so the test cannot hold and is removed in the same diff; `bump-requires-changelog` (Requirement 8) is untouched.
-10. The shim section is gone from `docs/migration-2.0.md`: a grep for its heading returns no match, while the guide's historical 1.x-to-2.0 rows remain.
+10. The shim section is gone from `docs/migration-2.0.md`: a grep for its heading returns no match, while the guide's historical 1.x-to-2.0 rows remain - including the `commands/6hats.md` row that carries a `remove-in: 3.0.0` field, which is why Requirement 1's grep excludes this file.
 11. `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` is green.
+12. The two decomposition-parity assertions that name the folded units survive the fold as assertions, not as deletions: `test_findings_and_pr_subskills_exist` asserts the two files under `references/`, and `test_orchestrator_delegates_to_each_unit` asserts the orchestrator's read-the-reference lines. Same disclosure Requirement 9 gives the umbrella test, opposite outcome: the umbrella test loses the thing it compares against and goes, while these two keep theirs under a new path and stay. A diff that deletes either assertion instead of re-pointing it fails this requirement.
 
 ## Verification
 
 - `tests/test_plugin_contract.py::test_internal_links_resolve` and `::test_marketplace_entries_exist` (`plugin contract pytest` job) catch any dangling link left by the deletions and any marketplace entry whose `source` no longer resolves.
-- `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' .` (Requirement 1) is the mechanical proof the enumeration is complete.
+- `rg -c 'remove-in: 3.0.0' --glob '!docs/design/**' --glob '!docs/migration-2.0.md' .` (Requirement 1) is the mechanical proof the enumeration is complete; the guide is read separately against Requirement 10, which keeps its historical rows and deletes its shim section.
 - `claude plugin validate .` zero warnings; `claude plugin validate plugins/<name> --strict` for each of the six remaining family plugins (the meta-plugin is gone, so it drops out of this loop).
 - The WS7-introduced `bump-requires-changelog` contract test (fetches the base ref) is green for every plugin this PR touches. Its sibling `family-bump-requires-umbrella-bump` is deleted by this PR rather than kept green, per Requirement 9.
 - The assess-helpers fold is not gated by `ab-equivalence`: the Out of scope entry in `../intent.md`'s programme source records that no runner-consumable transfer set exists for assess, so this fold ships as a plain move rather than a frozen one. It reaches no code under `assess`'s `lib/` and no stats schema, which is why it rides a MINOR (Design, citing D2) and not a MAJOR.
@@ -112,4 +136,4 @@ This PR is a pure deletion plus a version bump, docs and plugin trees only, no f
 
 One PR, opened only after WS3, WS5, WS6, WS7, and WS9 have all merged (the programme dependency graph's `WS3, WS5, WS6, WS7, WS9 -> WS10`; WS1, WS2, WS4, and WS8 are satisfied transitively, since each of those five depends on one or more of them). The task stays `deferred` in Task Master until the next MAJOR is scheduled - it is the last task in the programme to leave that status.
 
-It may not touch anything outside the five removal actions in Design, the version bumps they require, the `family-bump-requires-umbrella-bump` test removal named in that table's meta-plugin row, and the migration guide's shim-section deletion. It must not rename anything (WS2's territory, already merged), add a new component, touch `FLOOR.md`, `floor_check.py`, `floor_anchor.py`, or `floor.yml` (none of the five actions intersects a floor-marked path, per Design), or touch `action.yml` or a CI job `name:` (D7).
+It may not touch anything outside the five removal actions in Design, the consumer edits (a) to (g) enumerated in that table's assess-helpers row, the version bumps they require, the `family-bump-requires-umbrella-bump` test removal named in that table's meta-plugin row, and the migration guide's shim-section deletion. It must not rename anything (WS2's territory, already merged), add a new component, touch `FLOOR.md`, `floor_check.py`, `floor_anchor.py`, or `floor.yml` (none of the five actions intersects a floor-marked path, per Design), or touch `action.yml` or a CI job `name:` (D7).


### PR DESCRIPTION
## Summary
- Adds `docs/design/2026-09-modernization/sunset/spec.md` for WS10 (tag `modernization-sunset`), the deferred R18 removal task that sunsets every `remove-in: 3.0.0` breadcrumb at the programme's next MAJOR.
- Overwrites the placeholder with the full eight-section spec: Intent, Current state, Design, Requirements, Verification, Breadcrumbs, Rollback, Sequencing.

## Changes Made
- Current state measures, against this checkout, the five Deprecation Path rows in `../intent.md` marked `3.0.0`, confirms no `remove-in:` marker exists in the tree yet, and records today's plugin version and marketplace state - each with the real command and output.
- Design enumerates one removal action per breadcrumb (meta-plugin via `renames: {"ai-native-toolkit": null}`, the `6hats` stub, the `docs/superpowers/` redirect, the `.github/claude-review-instructions.md` pointer, the assess-helpers fold), the every-plugin bump, and the guide's shim-section deletion.
- Requirements and Verification are each tied to a command, test, or grep a cold verifier can re-run.

## Testing
- `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_plugin_contract.py -q` - 355 passed.
- `rg -c '^## ' docs/design/2026-09-modernization/sunset/spec.md` - 8.
- Re-ran three of the spec's own measurement commands against this checkout; outputs match what's recorded in the spec.
- `git diff main --stat` - only the spec file changed.

## Risk Assessment
Docs-only change under `docs/design/`; no floor-protected path, no plugin manifest, no CI job touched.

https://claude.ai/code/session_01AKcLe4iTwyxHWqk1HMSqBb