### PR TITLE
chore: Probe the render assertion (throwaway, do not merge)

### DIFF
--- a/.github/workflows/assess-gate.yml
+++ b/.github/workflows/assess-gate.yml
@@ -27,6 +27,19 @@ jobs:
           persist-credentials: false  # nothing here pushes; don't leave a token in .git
 
       - name: Run the AI-readiness gate (this branch's action)
+        id: assess-action
         uses: ./
         with:
           config: .assess/config.toml
+
+      # The composite keeps `continue-on-error` on its render step so a
+      # consumer's PR never reddens on infrastructure. That degrade is right for
+      # consumers and wrong here: this workflow IS the action's self-test, and a
+      # render that fell over would otherwise ship as a notice nobody reads.
+      # Asserting on 'failure' rather than on 'success' keeps a render skipped
+      # for want of uv green - a skip is infrastructure, a failure is a defect.
+      - name: Assert render did not fail
+        if: steps.assess-action.outputs.rendered == 'failure'
+        run: |
+          echo "::error::The assess action's render step failed on this branch - the composite could not render the deterministic snapshot. See the 'Render the deterministic snapshot' step above."
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,19 @@ jobs:
     name: plugin contract pytest
     runs-on: ubuntu-latest
     steps:
+      # Full history: the contract tests reason about the diff against the PR
+      # base (a same-PR version bump, a changelog entry), which a shallow
+      # checkout cannot see. Read-only job, so the token is not persisted.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # fetch-depth: 0 deepens the merge ref, it does not create the base
+      # branch ref locally. Fetch it explicitly so `origin/<base>` resolves.
+      - name: Fetch the PR base ref
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
       continue-on-error: true
       if: steps.ensure-uv.outputs.ok == 'true'
       shell: bash
-      working-directory: ${{ github.action_path }}/skills/assess
+      working-directory: ${{ github.action_path }}/skills/nonexistent
       run: |
         mkdir -p "${GITHUB_WORKSPACE}/.assess"
         uv run scripts/complexity-treemap.py "${GITHUB_WORKSPACE}" \
@@ -121,7 +121,7 @@ runs:
       # failure, warn-only), never a red check.
       if: steps.ensure-uv.outputs.ok == 'true' && steps.render.outcome == 'success'
       shell: bash
-      working-directory: ${{ github.action_path }}/skills/assess
+      working-directory: ${{ github.action_path }}/skills/nonexistent
       # The single step whose exit code can fail the consumer's PR - and only
       # per their own config.toml opt-ins.
       run: |

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,17 @@ inputs:
     required: false
     default: '.assess/config.toml'
 
+outputs:
+  rendered:
+    description: >-
+      Outcome of the composite's snapshot render step: success, failure, or
+      skipped. A caller cannot address a step inside the composite, and this
+      action's own step outcome reports the gate verdict rather than whether
+      the snapshot rendered - so the render result has to be published to be
+      assertable. This repo's self-test asserts on it; consumers stay warn-only
+      because the assertion lives in the workflow, not here.
+    value: ${{ steps.render.outcome }}
+
 runs:
   using: 'composite'
   steps:

--- a/docs/floor-anchor-proof.md
+++ b/docs/floor-anchor-proof.md
@@ -175,7 +175,10 @@ gh api "repos/$REPO/rulesets" --method POST --input - <<'JSON'
 JSON
 
 # 3. Create the anchor read token secret (fine-grained PAT, Administration: read).
+#    Actions and Dependabot read separate secret stores, so the same PAT is set
+#    twice; setting only the first leaves every Dependabot PR red on the anchor.
 gh secret set FLOOR_ANCHOR_TOKEN --repo "$REPO"   # paste the PAT when prompted
+gh secret set FLOOR_ANCHOR_TOKEN --repo "$REPO" --app dependabot   # paste the same PAT again
 ```
 
 ## Honest-degrade note (E2)

--- a/scripts/floor_anchor.py
+++ b/scripts/floor_anchor.py
@@ -30,9 +30,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 API = "https://api.github.com"
 
@@ -44,6 +46,16 @@ FLOOR_CONTEXT = os.environ.get("FLOOR_CONTEXT", "floor enforcement")
 # anchor would go red without gating, and the floor would silently disarm (E2).
 ANCHOR_CONTEXT = os.environ.get("ANCHOR_CONTEXT", "floor self-anchor")
 FLOOR_PATH = ".github/workflows/floor.yml"
+
+# Where the workflow definitions live, relative to the repository root, and the
+# line shape a job ``name:`` takes in them. Jobs sit at two levels of two-space
+# indentation under ``jobs:``; steps sit deeper and behind a ``- ``, so a
+# four-space ``name:`` is unambiguously a job name. This is a regex over lines
+# rather than a YAML parse on purpose: the self-anchor job runs bare ``python``
+# with no dependency install, so PyYAML is not available to it.
+WORKFLOW_DIR = ".github/workflows"
+JOB_NAME_RE = re.compile(r"^\s{4}name: (.+)$")
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # --- E2 DESCOPE: floor.yml path lock (maintainer decision, 2026-07-10) --------
 # The path lock was a third hard requirement: an active push ruleset with a
@@ -104,6 +116,11 @@ Missing configuration (maintainer-only, run out-of-band -- see docs/floor-anchor
   2. Create the anchor read token so this check can query the settings above:
 
      gh secret set FLOOR_ANCHOR_TOKEN --repo "{repo}"   # paste a PAT: Administration: read
+     gh secret set FLOOR_ANCHOR_TOKEN --repo "{repo}" --app dependabot   # the same PAT again: Dependabot runs read a separate secret store
+
+     Both are needed. Actions secrets and Dependabot secrets are separate
+     stores, so a rotation that sets only the first leaves every
+     Dependabot-triggered run without a token and red on this check.
 
 Note: the floor.yml path lock (a push ruleset with file_path_restriction over
 {FLOOR_PATH}) is DESCOPED per the maintainer's PRD-E2 decision \
@@ -165,7 +182,7 @@ def _default_branch(repo: str, token: str) -> str:
     return data.get("default_branch", "main")
 
 
-def check_required_check(repo: str, branch: str, token: str) -> None:
+def check_required_check(repo: str, branch: str, token: str) -> set[str]:
     """Fail unless BOTH floor contexts are required status checks on ``branch``.
 
     The deterministic ``FLOOR_CONTEXT`` job *and* the ``ANCHOR_CONTEXT`` job (this
@@ -177,6 +194,8 @@ def check_required_check(repo: str, branch: str, token: str) -> None:
 
     Checks both classic branch protection and repo rulesets, since either can
     supply a required check. A permission error (admin:read missing) fails closed.
+    Returns every required context it saw, so the caller can check them against
+    the workflows on this branch.
     """
     contexts: set[str] = set()
 
@@ -217,6 +236,7 @@ def check_required_check(repo: str, branch: str, token: str) -> None:
         f"ok   both floor status checks ({FLOOR_CONTEXT!r}, {ANCHOR_CONTEXT!r}) "
         f"are required on {branch!r}."
     )
+    return contexts
 
 
 def _ruleset_required_contexts(repo: str, token: str) -> set[str]:
@@ -245,6 +265,55 @@ def _ruleset_required_contexts(repo: str, token: str) -> set[str]:
                     if chk.get("context"):
                         contexts.add(chk["context"])
     return contexts
+
+
+def _workflow_job_names(root: Path | None = None) -> set[str]:
+    """Every job ``name:`` literal declared by ``.github/workflows/*.yml``.
+
+    Read from the checked-out branch, so a rename is seen in the PR that makes
+    it rather than after merge. An unreadable or absent workflow directory
+    yields an empty set, which the caller turns into a fail-closed error.
+    """
+    base = REPO_ROOT if root is None else Path(root)
+    names: set[str] = set()
+    for workflow in sorted((base / WORKFLOW_DIR).glob("*.yml")):
+        try:
+            text = workflow.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            match = JOB_NAME_RE.match(line)
+            if match:
+                names.add(match.group(1).strip().strip("\"'"))
+    return names
+
+
+def check_contexts_have_workflows(contexts: set[str], root: Path | None = None) -> None:
+    """Fail unless every required context is produced by a job on this branch.
+
+    A required status check that no job emits is never reported, and GitHub
+    treats a context that never arrives as pending rather than failing -- so a
+    job rename orphans the context and the merge blocks on a check that can
+    never turn green, or (where the context is dropped instead) a floor layer
+    disarms with nothing red. Comparing the required set against the job
+    ``name:`` literals on the checked-out branch moves that discovery into the
+    PR that renames the job.
+    """
+    job_names = _workflow_job_names(root)
+    orphaned = sorted(ctx for ctx in contexts if ctx not in job_names)
+    if orphaned:
+        named = ", ".join(repr(ctx) for ctx in orphaned)
+        raise AnchorError(
+            f"required status check context(s) {named} are produced by no job "
+            f"name: in {WORKFLOW_DIR}/*.yml on this branch. A required context "
+            "no job emits never arrives, so the check it gates can never turn "
+            f"green. Job names seen: {sorted(job_names) or 'none'}. Rename the "
+            "job back, or update branch protection in the same change."
+        )
+    print(
+        f"ok   all {len(contexts)} required context(s) are produced by a job "
+        f"name: in {WORKFLOW_DIR}/*.yml."
+    )
 
 
 def _descope_warning() -> str:
@@ -327,7 +396,8 @@ def main() -> int:
         )
     try:
         branch = _default_branch(repo, token)
-        check_required_check(repo, branch, token)
+        contexts = check_required_check(repo, branch, token)
+        check_contexts_have_workflows(contexts)
     except AnchorError as exc:
         return _fail(str(exc), repo)
     # E2 descope: the floor.yml path lock is a documented capability gap on this

--- a/scripts/tests/test_floor_anchor.py
+++ b/scripts/tests/test_floor_anchor.py
@@ -251,3 +251,123 @@ def test_main_passes_and_warns_when_both_contexts_present(monkeypatch, capsys):
     assert "::warning::" in captured.err
     assert "DESCOPED" in captured.err
     assert "path lock is descoped" in captured.out
+
+
+# ── check_contexts_have_workflows: a required context no job emits (R19 g3) ───
+
+WORKFLOW_WITH_TWO_JOBS = """\
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  pytest:
+    name: scripts/ pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pytest
+        run: pytest
+
+  lint:
+    name: 'ruff + mypy gates'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ruff
+        run: ruff check .
+"""
+
+
+def _workflows(tmp_path, body=WORKFLOW_WITH_TWO_JOBS, filename="tests.yml"):
+    """Materialize a repo root whose .github/workflows holds one workflow."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    (wf_dir / filename).write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def test_workflow_job_names_reads_job_names_not_step_names(tmp_path):
+    names = floor_anchor._workflow_job_names(_workflows(tmp_path))
+    # Job names come from the four-space `name:` lines; step names sit deeper
+    # behind a `- `, and the workflow's own top-level name is at column zero.
+    assert names == {"scripts/ pytest", "ruff + mypy gates"}
+
+
+def test_workflow_job_names_reads_every_workflow_file(tmp_path):
+    root = _workflows(tmp_path)
+    _workflows(
+        root,
+        body="jobs:\n  floor:\n    name: floor enforcement\n    runs-on: ubuntu-latest\n",
+        filename="floor.yml",
+    )
+    assert "floor enforcement" in floor_anchor._workflow_job_names(root)
+
+
+def test_contexts_have_workflows_passes_when_every_context_is_a_job(tmp_path, capsys):
+    floor_anchor.check_contexts_have_workflows({"scripts/ pytest"}, _workflows(tmp_path))
+    assert "ok   " in capsys.readouterr().out
+
+
+def test_contexts_have_workflows_fails_closed_on_an_orphaned_context(tmp_path):
+    # A job rename orphans the context branch protection still requires: the
+    # check never arrives, so the PR blocks on a check that cannot go green.
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_contexts_have_workflows(
+            {"scripts/ pytest", "plugin contract pytest"}, _workflows(tmp_path)
+        )
+    msg = str(exc.value)
+    assert "plugin contract pytest" in msg
+    assert "scripts/ pytest" in msg  # named among the job names it did see
+
+
+def test_contexts_have_workflows_fails_closed_without_a_workflow_dir(tmp_path):
+    with pytest.raises(floor_anchor.AnchorError):
+        floor_anchor.check_contexts_have_workflows({"floor enforcement"}, tmp_path)
+
+
+def test_contexts_have_workflows_holds_against_this_repo(capsys):
+    # The live subset check, run against the checked-out workflows: every
+    # context this repo requires today is produced by a job name literal.
+    floor_anchor.check_contexts_have_workflows({
+        "skills/assess pytest",
+        "scripts/ pytest",
+        "plugin contract pytest",
+        "Validate PR title",
+        floor_anchor.FLOOR_CONTEXT,
+        floor_anchor.ANCHOR_CONTEXT,
+    })
+    assert "ok   " in capsys.readouterr().out
+
+
+def test_required_check_returns_the_contexts_it_saw(monkeypatch):
+    # main() feeds this set to the workflow check, so it has to carry every
+    # required context, not just the two floor ones.
+    monkeypatch.setattr(
+        floor_anchor,
+        "_get",
+        _stub_get(
+            {floor_anchor.FLOOR_CONTEXT, floor_anchor.ANCHOR_CONTEXT, "Validate PR title"}
+        ),
+    )
+    contexts = check_required_check(REPO, "main", "tok")
+    assert contexts == {
+        floor_anchor.FLOOR_CONTEXT,
+        floor_anchor.ANCHOR_CONTEXT,
+        "Validate PR title",
+    }
+
+
+def test_main_fails_closed_when_a_required_context_has_no_job(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_REPOSITORY", REPO)
+    monkeypatch.setenv("FLOOR_ANCHOR_TOKEN", "tok")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(
+        floor_anchor,
+        "_get",
+        _stub_get_full(
+            {floor_anchor.FLOOR_CONTEXT, floor_anchor.ANCHOR_CONTEXT, "no such job xyz"}
+        ),
+    )
+    rc = main()
+    assert rc == 1
+    assert "no such job xyz" in capsys.readouterr().err

--- a/skills/assess/tests/test_action_contract.py
+++ b/skills/assess/tests/test_action_contract.py
@@ -13,12 +13,23 @@ from pathlib import Path
 
 import pytest
 
-yaml = pytest.importorskip("yaml")
+try:  # PyYAML is not a declared dependency of this suite.
+    import yaml
+except ImportError:  # pragma: no cover - environment-dependent
+    yaml = None
 
 _ACTION_PATH = Path(__file__).resolve().parents[3] / "action.yml"
 
+# `working-directory: <value>` as a plain scalar, read from the text rather than
+# the parse tree so the guard below still runs where PyYAML is absent - which is
+# every CI run of this suite today, and the reason a module-level importorskip
+# would make that guard decorative.
+_WORKING_DIR_RE = re.compile(r"^\s*working-directory:[ \t]*(\S.*?)\s*$", re.MULTILINE)
+
 
 def _action() -> dict:
+    if yaml is None:
+        pytest.skip("PyYAML is not installed; the structural assertions need a parse tree")
     return yaml.safe_load(_ACTION_PATH.read_text(encoding="utf-8"))
 
 
@@ -162,9 +173,7 @@ def test_working_directories_exist():
     turns a moved directory into a red test in the PR that moves it.
     """
     action_root = _ACTION_PATH.parent
-    values = [
-        s["working-directory"] for s in _steps() if s.get("working-directory")
-    ]
+    values = _WORKING_DIR_RE.findall(_ACTION_PATH.read_text(encoding="utf-8"))
     assert values, "expected at least one working-directory in action.yml"
     for wd in values:
         resolved = Path(wd.replace("${{ github.action_path }}", str(action_root)))

--- a/skills/assess/tests/test_action_contract.py
+++ b/skills/assess/tests/test_action_contract.py
@@ -151,3 +151,21 @@ def test_action_description_fits_marketplace_limit():
     discovered live on the v1.42.0 release page. Pin publishability."""
     desc = _action()["description"]
     assert len(desc) < 125, f"{len(desc)} chars: {desc}"
+
+
+def test_working_directories_exist():
+    """Every `working-directory` in action.yml must resolve on disk.
+
+    A composite step's `working-directory` is only checked at run time, and a
+    miss there surfaces as a render failure the warn-only contract swallows as
+    a notice. Resolving `${{ github.action_path }}` to the checkout root here
+    turns a moved directory into a red test in the PR that moves it.
+    """
+    action_root = _ACTION_PATH.parent
+    values = [
+        s["working-directory"] for s in _steps() if s.get("working-directory")
+    ]
+    assert values, "expected at least one working-directory in action.yml"
+    for wd in values:
+        resolved = Path(wd.replace("${{ github.action_path }}", str(action_root)))
+        assert resolved.is_dir(), f"working-directory does not exist: {wd}"

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -66,10 +66,31 @@ def _fm_scalar(fm: str, key: str):
     return m.group(1).strip() if m else None
 
 
+def _ships(path: Path) -> bool:
+    """Is this an authored file that ships, rather than build output or an input?
+
+    Test fixtures are inputs to a test, not components: a deliberately flawed
+    sample skill must not be held to the contract the real skills are held to.
+    """
+    parts = path.relative_to(REPO).parts
+    if {".git", "dist", "node_modules"} & set(parts):
+        return False
+    return "fixtures" not in parts
+
+
+def skill_md_files():
+    """Every shipped SKILL.md, found by walking the repo rather than one level.
+
+    Discovery is by file, not by directory position, so a skill keeps its
+    coverage wherever it lives - ``skills/<x>/`` today, a nested plugin layout
+    tomorrow - and a component that moves out of the one directory this used to
+    read cannot silently drop out of the suite.
+    """
+    return sorted(p for p in REPO.rglob("SKILL.md") if _ships(p))
+
+
 def skill_dirs():
-    if not SKILLS.is_dir():
-        return []
-    return sorted(d for d in SKILLS.iterdir() if (d / "SKILL.md").is_file())
+    return [p.parent for p in skill_md_files()]
 
 
 def command_files():
@@ -77,7 +98,7 @@ def command_files():
 
 
 def shipped_md():
-    return [d / "SKILL.md" for d in skill_dirs()] + command_files()
+    return skill_md_files() + command_files()
 
 
 def all_authored_markdown():
@@ -90,15 +111,7 @@ def all_authored_markdown():
     """
     if not REPO.is_dir():
         return []
-    out = []
-    for p in sorted(REPO.rglob("*.md")):
-        parts = p.relative_to(REPO).parts
-        if {".git", "dist", "node_modules"} & set(parts):
-            continue
-        if "fixtures" in parts:
-            continue
-        out.append(p)
-    return out
+    return [p for p in sorted(REPO.rglob("*.md")) if _ships(p)]
 
 
 def known_skill_names():
@@ -152,13 +165,26 @@ def test_use_the_skill_references_resolve(p):
         assert name in known, f"{p.relative_to(REPO)}: 'Use the {name} skill' references unknown skill"
 
 
-@pytest.mark.parametrize("p", command_files(), ids=lambda p: p.name)
+@pytest.mark.parametrize("p", shipped_md(), ids=lambda p: str(p.relative_to(REPO)))
 def test_subagent_types_resolve(p):
     known = known_agent_names()
     for name in SUBAGENT_RE.findall(p.read_text(encoding="utf-8")):
         if "<" in name:  # template placeholder like task-<task-id>
             continue
-        assert name in known, f"{p.name}: subagent_type \"{name}\" has no agents/{name}.md"
+        assert name in known, (
+            f"{p.relative_to(REPO)}: subagent_type \"{name}\" has no agents/{name}.md"
+        )
+
+
+def test_subagent_types_has_cases():
+    """Parametrizing over an empty list is a silently green test.
+
+    The subagent check ran over ``commands/*.md`` alone before; a discovery
+    change that returns nothing would make it pass by collecting no cases at
+    all. Pin the floor so the regression is red instead of invisible.
+    """
+    found = shipped_md()
+    assert len(found) >= 20, f"expected >= 20 shipped markdown components, found {len(found)}"
 
 
 @pytest.mark.parametrize("p", all_authored_markdown(), ids=lambda p: str(p.relative_to(REPO)))


### PR DESCRIPTION
Throwaway probe for the FC12 evidence on #306. Every `working-directory` in `action.yml` points at a directory that does not exist, so the composite's render step fails and the new `Assert render did not fail` step must turn the `AI-readiness regression gate` job red rather than emitting a notice.

Do not merge. Closed as soon as the run id is recorded on #306.