### PR TITLE
feat: Discover floor markers by token and read the token set from FLOOR.md

### DIFF
--- a/FLOOR.md
+++ b/FLOOR.md
@@ -32,10 +32,12 @@ door and no free skip door.
 <!-- floor-clause:iii -->
 **iii. Changes to the floor require the maintainer's out-of-band sign-off.** The
 retro, and any other automated learning step, may propose changes to this floor
-but may never self-apply them. A change to `FLOOR.md`, the floor markers, the
-gate invocations, `.github/workflows/floor.yml`, `scripts/contract/`,
-`scripts/canaries/`, or `tests/canaries/` takes effect only with the
-maintainer's explicit, out-of-band approval.
+but may never self-apply them. A change to this file, to the floor tokens it
+declares, to `scripts/floor_check.py`, `scripts/floor_anchor.py`,
+`.github/workflows/floor.yml`, `scripts/contract/`, `scripts/canaries/`, or
+`tests/canaries/` takes effect only with the maintainer's explicit,
+out-of-band approval, recorded as the maintainer's deployment review of the
+`floor-signoff` environment.
 
 <!-- floor-clause:iv -->
 **iv. Immutability covers clauses iii and iv.** The immutability rule in clause
@@ -43,16 +45,40 @@ iii, and this clause that says so, are themselves part of the floor and cannot
 be weakened or removed by any automated step. The floor cannot legislate away
 its own protection.
 
+## Tokens
+
+The floor declares its tokens here, one per line. This block is the only source
+of the token set: the enforcement script holds no token list of its own, so a
+token added below is enforced from the next run onwards, and removing one is a
+floor change that goes red rather than a quiet narrowing of the check.
+
+```floor-tokens
+<!-- floor:cold-verify-completion -->
+start_gate.py
+spawn_verifier.py
+complete_gate.py
+```
+
+The first token is the marker; the rest are the gate invocations a marked file
+must keep naming.
+
 ## Markers
 
-The following literal token marks each file that carries a floor obligation:
+A file carries a floor obligation when it holds the marker on a line of its own:
 
     <!-- floor:cold-verify-completion -->
 
-It appears in `skills/marathon/SKILL.md`, `skills/pr-review-merge/SKILL.md`,
-`commands/tm.md`, and `commands/issues.md`. Alongside it, those files carry the
-literal gate invocations `start_gate.py`, `spawn_verifier.py`, and
-`complete_gate.py`. `.github/workflows/floor.yml` fails any PR that removes a
-marker or an invocation from a file that previously carried it (base-vs-head
-removal detection), so a retro that guts the instructions while leaving the
-marker comment intact still goes red.
+The marked set is not a list anyone maintains. It is discovered at a ref by
+searching the tree for that marker and keeping the files that carry it as a
+standalone line - a backtick-wrapped mention in prose is documentation, not an
+obligation, and this file is excluded because it is where the marker is
+defined. To see the set at any ref:
+
+    python3 scripts/floor_check.py markers --base <ref>
+
+Each discovered file is checked against the tokens above, and
+`.github/workflows/floor.yml` fails any pull request that removes one of them
+from a file that previously carried it (base-vs-head removal detection). So a
+retro that guts the instructions while leaving the marker comment intact still
+goes red, and a marked file that moves is followed to its new path rather than
+read as a deletion.

--- a/scripts/floor_check.py
+++ b/scripts/floor_check.py
@@ -33,12 +33,23 @@ workflow (``.github/workflows/floor.yml``) and pytest both drive:
     arms itself automatically the moment a marker lands and bites only when one
     is taken away -- including when the whole marked file is deleted.
 
+    Neither the marked set nor the token set is a constant here. The marked set
+    is *discovered* at the base ref (``_discover_marked_files``): every tracked
+    file carrying a standalone anchor line, ``FLOOR.md`` excluded because it is
+    the file that defines the marker. The token set is read from the
+    ``floor-tokens`` fenced block of ``git show <base>:FLOOR.md``. Both are data
+    the floor declares, so a file that moves, a file that arrives, and a token
+    that is added are all enforced with no edit to this script.
+
 ``clauses``
-    Unconditional integrity check of ``FLOOR.md``: the file must exist and each
-    of the four clauses must be present, anchor *and* key phrase, so a PR that
-    guts a clause's text while leaving its anchor comment still fails.
+    Unconditional integrity check of ``FLOOR.md``: the file must exist, it must
+    declare its ``floor-tokens`` block with at least the four tokens the floor
+    ships with, and each of the four clauses must be present, anchor *and* key
+    phrase, so a PR that guts a clause's text while leaving its anchor comment
+    still fails.
 
 Stdlib only; runnable as ``python scripts/floor_check.py <subcommand>``.
+Paths are relative to the current directory, which is the repository root.
 """
 from __future__ import annotations
 
@@ -47,33 +58,88 @@ import subprocess
 import sys
 from pathlib import Path
 
-# ── Floor tokens ─────────────────────────────────────────────────────────────
+# ── The one anchor string ────────────────────────────────────────────────────
+#
+# The marker is the single token this script has to know by heart: it is the
+# needle the discovery grep looks for. Every other token is declared by the
+# floor itself, in FLOOR.md's floor-tokens block.
 
 MARKER = "<!-- floor:cold-verify-completion -->"
-INVOCATIONS = ("start_gate.py", "spawn_verifier.py", "complete_gate.py")
-FLOOR_TOKENS = (MARKER, *INVOCATIONS)
 
-# Files that carry a floor obligation (repo-root-relative). The markers are not
-# all present yet -- removal detection is a no-op for a token a file never had.
-MARKED_FILES = (
-    "skills/marathon/SKILL.md",
-    "skills/pr-review-merge/SKILL.md",
-    "commands/tm.md",
-    "commands/issues.md",
-)
-
-# FLOOR.md clause integrity: each clause must carry its anchor AND a distinctive
-# phrase, so gutting the prose while keeping the anchor comment still fails.
 FLOOR_FILE = "FLOOR.md"
+
+# The fenced block in FLOOR.md that declares the floor tokens, one per line.
+TOKEN_BLOCK_FENCE = "```floor-tokens"
+
+# The floor ships with four tokens (the marker plus three gate invocations).
+# Shrinking that set is a floor change, not a refactor, so a block carrying
+# fewer than this is refused.
+MINIMUM_TOKEN_COUNT = 4
+
+# FLOOR.md clause integrity: each clause must carry its anchor AND its
+# distinctive phrases, so gutting the prose while keeping the anchor comment
+# still fails.
 REQUIRED_CLAUSES = {
     "i": ("<!-- floor-clause:i -->", "run-complete"),
     "ii": ("<!-- floor-clause:ii -->", "unamendable"),
-    "iii": ("<!-- floor-clause:iii -->", "out-of-band"),
+    "iii": ("<!-- floor-clause:iii -->", "out-of-band", "floor-signoff"),
     "iv": ("<!-- floor-clause:iv -->", "immutab"),
 }
 
 
+class FloorTokenError(ValueError):
+    """FLOOR.md does not declare a usable floor-tokens block."""
+
+
 # ── Pure logic (unit-tested) ─────────────────────────────────────────────────
+
+def _parse_token_block(floor_text: str | None) -> list[str]:
+    """Floor tokens declared by ``FLOOR.md``, in declaration order.
+
+    The tokens live in exactly one fenced block whose opening fence line is
+    ``TOKEN_BLOCK_FENCE``, one token per line. Raises ``FloorTokenError`` when
+    the block is absent, duplicated, unterminated, or carries fewer than
+    ``MINIMUM_TOKEN_COUNT`` tokens -- shrinking the floor's token set is a floor
+    change and has to go red rather than quietly narrow the check.
+    """
+    if floor_text is None:
+        raise FloorTokenError(
+            f"{FLOOR_FILE} is absent, so its {TOKEN_BLOCK_FENCE!r} token block "
+            f"cannot be read"
+        )
+    lines = floor_text.splitlines()
+    opens = [i for i, line in enumerate(lines) if line.strip() == TOKEN_BLOCK_FENCE]
+    if not opens:
+        raise FloorTokenError(
+            f"no {TOKEN_BLOCK_FENCE!r} token block in {FLOOR_FILE}: the floor "
+            f"must declare its tokens"
+        )
+    if len(opens) > 1:
+        raise FloorTokenError(
+            f"{len(opens)} {TOKEN_BLOCK_FENCE!r} token blocks in {FLOOR_FILE}: "
+            f"the floor must declare exactly one"
+        )
+    tokens: list[str] = []
+    closed = False
+    for line in lines[opens[0] + 1:]:
+        if line.startswith("```"):
+            closed = True
+            break
+        token = line.strip()
+        if token:
+            tokens.append(token)
+    if not closed:
+        raise FloorTokenError(
+            f"the {TOKEN_BLOCK_FENCE!r} token block in {FLOOR_FILE} is never closed"
+        )
+    if len(tokens) < MINIMUM_TOKEN_COUNT:
+        raise FloorTokenError(
+            f"the {TOKEN_BLOCK_FENCE!r} token block in {FLOOR_FILE} declares "
+            f"{len(tokens)} token(s); the floor requires at least "
+            f"{MINIMUM_TOKEN_COUNT}"
+        )
+    return tokens
+
 
 def standalone_anchor_count(text: str | None, marker: str = MARKER) -> int:
     """Number of *standalone* anchor lines: lines whose stripped content is the
@@ -91,9 +157,13 @@ def standalone_anchor_count(text: str | None, marker: str = MARKER) -> int:
 def removed_tokens(
     base_text: str | None,
     head_text: str | None,
-    tokens=FLOOR_TOKENS,
+    tokens,
 ) -> list[str]:
     """Floor tokens *weakened* from ``base_text`` to ``head_text``.
+
+    ``tokens`` is the set the floor declares (see ``_parse_token_block``); it is
+    passed in rather than read from a constant so the enforced set is whatever
+    ``FLOOR.md`` says it is.
 
     A token is flagged when either signal fires (see the module docstring):
 
@@ -142,12 +212,13 @@ def missing_clauses(floor_text: str | None) -> list[str]:
 
 # ── Git plumbing ─────────────────────────────────────────────────────────────
 
-def _git_show(ref: str, path: str) -> str | None:
+def _git_show(ref: str, path: str, cwd: str | Path | None = None) -> str | None:
     """Content of ``path`` at ``ref``, or ``None`` if it did not exist there."""
     result = subprocess.run(
         ["git", "show", f"{ref}:{path}"],
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
     if result.returncode != 0:
         return None
@@ -162,16 +233,55 @@ def _read_head(path: str) -> str | None:
     return p.read_text(encoding="utf-8")
 
 
+def _discover_marked_files(
+    base_ref: str,
+    marker: str,
+    cwd: str | Path | None = None,
+) -> list[str]:
+    """Files carrying a floor obligation at ``base_ref``, discovered by token.
+
+    ``git grep`` finds every tracked file mentioning the marker at that ref;
+    the anchor filter then keeps only those whose content at the ref holds a
+    *standalone* anchor line, which drops the incidental carriers (prose that
+    quotes the marker, source that defines it). ``FLOOR.md`` is excluded outright:
+    it is the file that declares the marker, so its own mention is a definition,
+    not an obligation.
+    """
+    result = subprocess.run(
+        ["git", "grep", "-l", "-F", marker, base_ref, "--", f":!{FLOOR_FILE}"],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    prefix = f"{base_ref}:"
+    discovered = []
+    for line in result.stdout.splitlines():
+        path = line[len(prefix):] if line.startswith(prefix) else line.split(":", 1)[-1]
+        if not path:
+            continue
+        if standalone_anchor_count(_git_show(base_ref, path, cwd=cwd), marker) > 0:
+            discovered.append(path)
+    return discovered
+
+
 # ── Subcommands ──────────────────────────────────────────────────────────────
 
 def cmd_markers(args: argparse.Namespace) -> int:
     base = args.base
-    files = args.files or list(MARKED_FILES)
+    try:
+        tokens = _parse_token_block(_git_show(base, FLOOR_FILE))
+    except FloorTokenError as exc:
+        print(f"FAIL {FLOOR_FILE} at {base}: {exc}")
+        return 1
+    files = list(args.files) if args.files else _discover_marked_files(base, MARKER)
+    if not files:
+        print(f"ok   no marked files at {base}: no floor obligation is armed yet.")
+        return 0
     failed = False
     for path in files:
         base_text = _git_show(base, path)
         head_text = _read_head(path)
-        removed = removed_tokens(base_text, head_text)
+        removed = removed_tokens(base_text, head_text, tokens)
         if removed:
             failed = True
             for token in removed:
@@ -181,7 +291,7 @@ def cmd_markers(args: argparse.Namespace) -> int:
                     f"removed, between {base} and head)"
                 )
         else:
-            carried = [t for t in FLOOR_TOKENS if base_text and t in base_text]
+            carried = [t for t in tokens if base_text and t in base_text]
             state = f"{len(carried)} token(s) intact" if carried else "no floor tokens (ok)"
             print(f"ok   {path}: {state}")
     if failed:
@@ -199,12 +309,24 @@ def cmd_clauses(args: argparse.Namespace) -> int:
     if floor_text is None:
         print(f"FAIL {args.floor} does not exist -- the floor file is mandatory.")
         return 1
+    try:
+        tokens = _parse_token_block(floor_text)
+    except FloorTokenError as exc:
+        print(f"FAIL {args.floor}: {exc}")
+        print(
+            "The floor declares its tokens; removing or shrinking that block "
+            "narrows the check and needs the maintainer's out-of-band sign-off."
+        )
+        return 1
     missing = missing_clauses(floor_text)
     if missing:
         print(f"FAIL {args.floor}: clauses not intact -> {', '.join(missing)}")
         print("Each clause needs its anchor comment and its key phrase.")
         return 1
-    print(f"ok   {args.floor}: all four clauses intact.")
+    print(
+        f"ok   {args.floor}: all four clauses intact, "
+        f"{len(tokens)} floor token(s) declared."
+    )
     return 0
 
 
@@ -219,7 +341,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--base", required=True, help="git ref for the merge-base (e.g. origin/main)"
     )
     p_markers.add_argument(
-        "--files", nargs="*", help="override the marked-file list (defaults to all)"
+        "--files",
+        nargs="*",
+        help="override the discovered marked-file set (defaults to discovery)",
     )
     p_markers.set_defaults(func=cmd_markers)
 

--- a/scripts/floor_check.py
+++ b/scripts/floor_check.py
@@ -37,7 +37,8 @@ workflow (``.github/workflows/floor.yml``) and pytest both drive:
     is *discovered* at the base ref (``_discover_marked_files``): every tracked
     file carrying a standalone anchor line, ``FLOOR.md`` excluded because it is
     the file that defines the marker. The token set is read from the
-    ``floor-tokens`` fenced block of ``git show <base>:FLOOR.md``. Both are data
+    ``floor-tokens`` fenced block of ``git show <base>:FLOOR.md``, falling back
+    to the working tree only while the base predates that block. Both are data
     the floor declares, so a file that moves, a file that arrives, and a token
     that is added are all enforced with no edit to this script.
 
@@ -266,13 +267,36 @@ def _discover_marked_files(
 
 # ── Subcommands ──────────────────────────────────────────────────────────────
 
+def _tokens_for_run(base: str) -> tuple[list[str], str | None]:
+    """The token set this run enforces, plus a note when it was not read at
+    ``base``.
+
+    The enforced set is the base ref's declaration: a token added on the head
+    side is not yet enforced by that run, so a PR that widens the floor never
+    fails on its own widening. The one fallback is bootstrap - a base that
+    predates the token block, which is every base until the block lands - where
+    the working-tree declaration is used instead. Raises ``FloorTokenError``
+    when neither side declares a usable block.
+    """
+    try:
+        return _parse_token_block(_git_show(base, FLOOR_FILE)), None
+    except FloorTokenError as at_base:
+        tokens = _parse_token_block(_read_head(FLOOR_FILE))
+        return tokens, str(at_base)
+
+
 def cmd_markers(args: argparse.Namespace) -> int:
     base = args.base
     try:
-        tokens = _parse_token_block(_git_show(base, FLOOR_FILE))
+        tokens, bootstrap = _tokens_for_run(base)
     except FloorTokenError as exc:
-        print(f"FAIL {FLOOR_FILE} at {base}: {exc}")
+        print(f"FAIL {FLOOR_FILE}: {exc}")
         return 1
+    if bootstrap:
+        print(
+            f"note {FLOOR_FILE} at {base}: {bootstrap}; enforcing the "
+            f"working-tree declaration instead (bootstrap)."
+        )
     files = list(args.files) if args.files else _discover_marked_files(base, MARKER)
     if not files:
         print(f"ok   no marked files at {base}: no floor obligation is armed yet.")

--- a/scripts/tests/test_floor_check.py
+++ b/scripts/tests/test_floor_check.py
@@ -4,50 +4,63 @@ from pathlib import Path
 
 import pytest
 from floor_check import (
-    FLOOR_TOKENS,
-    INVOCATIONS,
+    FLOOR_FILE,
     MARKER,
+    MINIMUM_TOKEN_COUNT,
     REQUIRED_CLAUSES,
+    TOKEN_BLOCK_FENCE,
+    FloorTokenError,
+    _discover_marked_files,
+    _parse_token_block,
     main,
     missing_clauses,
     removed_tokens,
     standalone_anchor_count,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The tokens the floor declares. Read from FLOOR.md the same way the script
+# reads them, so these tests carry no token list of their own either.
+DECLARED_TOKENS = tuple(
+    _parse_token_block((REPO_ROOT / FLOOR_FILE).read_text(encoding="utf-8"))
+)
+DECLARED_INVOCATIONS = tuple(t for t in DECLARED_TOKENS if t != MARKER)
+
 
 # ── removed_tokens: base-vs-head removal detection ───────────────────────────
 
 def test_no_base_file_never_flags():
     # File did not exist on base -> nothing can be removed.
-    assert removed_tokens(None, "anything") == []
+    assert removed_tokens(None, "anything", DECLARED_TOKENS) == []
 
 
 def test_base_without_tokens_never_flags():
     # Bootstrap case: marked file exists but carries no floor token yet.
-    assert removed_tokens("plain text no markers", "still plain") == []
+    assert removed_tokens("plain text no markers", "still plain", DECLARED_TOKENS) == []
 
 
 def test_token_kept_is_not_removed():
     text = f"prose {MARKER} more prose"
-    assert removed_tokens(text, text) == []
+    assert removed_tokens(text, text, DECLARED_TOKENS) == []
 
 
 def test_marker_removed_is_flagged():
     base = f"intro\n{MARKER}\nbody"
     head = "intro\nbody"
-    assert removed_tokens(base, head) == [MARKER]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == [MARKER]
 
 
 def test_invocation_removed_is_flagged():
     base = "call start_gate.py then complete_gate.py"
     head = "call complete_gate.py"
-    assert removed_tokens(base, head) == ["start_gate.py"]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == ["start_gate.py"]
 
 
 def test_file_deleted_removes_all_carried_tokens():
     base = f"{MARKER} run start_gate.py and spawn_verifier.py"
     # head None => file deleted on head => every carried token removed.
-    removed = removed_tokens(base, None)
+    removed = removed_tokens(base, None, DECLARED_TOKENS)
     assert set(removed) == {MARKER, "start_gate.py", "spawn_verifier.py"}
 
 
@@ -55,13 +68,13 @@ def test_only_carried_tokens_are_evaluated():
     # Base carries only the marker; head drops it. Uncarried invocations don't count.
     base = f"only {MARKER} here"
     head = "gutted"
-    assert removed_tokens(base, head) == [MARKER]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == [MARKER]
 
 
 def test_all_invocations_are_watched():
-    for inv in INVOCATIONS:
+    for inv in DECLARED_INVOCATIONS:
         base = f"prefix {inv} suffix"
-        assert removed_tokens(base, "gutted") == [inv]
+        assert removed_tokens(base, "gutted", DECLARED_TOKENS) == [inv]
 
 
 # ── Anchor-vs-prose: the false-negative Attack A exposed (PR #276) ────────────
@@ -76,7 +89,7 @@ def test_anchor_removed_but_prose_mention_retained_is_flagged():
     # marker MUST be flagged even though the substring is still "present".
     base = f"intro\n{MARKER}\nbody\n{_PROSE_MENTION}\n"
     head = f"intro\nbody\n{_PROSE_MENTION}\n"
-    assert removed_tokens(base, head) == [MARKER]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == [MARKER]
 
 
 def test_anchor_deleted_with_count_masked_is_flagged():
@@ -86,28 +99,28 @@ def test_anchor_deleted_with_count_masked_is_flagged():
     base = f"{MARKER}\n{_PROSE_MENTION}\n"
     head = f"{_PROSE_MENTION}\n- and another `{MARKER}` reference\n"
     assert base.count(MARKER) == head.count(MARKER)  # count is masked
-    assert removed_tokens(base, head) == [MARKER]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == [MARKER]
 
 
 def test_prose_only_mention_kept_is_not_flagged():
     # A file that carries only a backtick prose mention (no standalone anchor)
     # and keeps it unchanged is legitimate -> no flag.
     text = f"see {_PROSE_MENTION} for details"
-    assert removed_tokens(text, text) == []
+    assert removed_tokens(text, text, DECLARED_TOKENS) == []
 
 
 def test_marker_gained_is_not_flagged():
     # Bootstrap: base has no marker, head adds the standalone anchor.
     base = "plain skill body, no floor obligation yet"
     head = f"plain skill body\n{MARKER}\nnow armed"
-    assert removed_tokens(base, head) == []
+    assert removed_tokens(base, head, DECLARED_TOKENS) == []
 
 
 def test_extra_prose_mention_added_with_anchor_kept_is_not_flagged():
     # Count increases (documentation added) but the anchor survives -> no flag.
     base = f"{MARKER}\nbody"
     head = f"{MARKER}\nbody\n{_PROSE_MENTION}"
-    assert removed_tokens(base, head) == []
+    assert removed_tokens(base, head, DECLARED_TOKENS) == []
 
 
 def test_standalone_anchor_count_excludes_prose_and_none():
@@ -119,27 +132,70 @@ def test_standalone_anchor_count_excludes_prose_and_none():
 
 
 def test_real_marathon_anchor_removal_is_flagged():
-    # Regression guard against the real file: the marathon skill carries the
-    # standalone anchor AND a prose mention (Retro Boundary section). Simulate
-    # Attack A -- drop only the standalone anchor line -- and require a flag.
-    repo_root = Path(__file__).resolve().parents[2]
-    marathon = repo_root / "skills" / "marathon" / "SKILL.md"
-    base = marathon.read_text(encoding="utf-8")
+    # Regression guard against a real marked file, resolved the way the floor
+    # resolves it: discovery at HEAD, not a path this test hard-codes. The
+    # marathon component carries the standalone anchor AND a prose mention
+    # (Retro Boundary section). Simulate Attack A -- drop only the standalone
+    # anchor line -- and require a flag.
+    discovered = _discover_marked_files("HEAD", MARKER, cwd=REPO_ROOT)
+    assert discovered, "discovery must return the marked set at HEAD"
+    marathon = [path for path in discovered if "marathon" in path]
+    assert len(marathon) == 1, f"discovery must resolve one marathon component: {discovered}"
+    base = (REPO_ROOT / marathon[0]).read_text(encoding="utf-8")
     assert standalone_anchor_count(base) >= 1, "real file must carry the anchor"
     assert base.count(MARKER) >= 2, "real file also has a prose mention"
     head = "\n".join(
         line for line in base.splitlines() if line.strip() != MARKER
     )
-    assert removed_tokens(base, head) == [MARKER]
+    assert removed_tokens(base, head, DECLARED_TOKENS) == [MARKER]
+
+
+# ── _parse_token_block: FLOOR.md declares the token set ───────────────────────
+
+def _token_block(tokens) -> str:
+    return TOKEN_BLOCK_FENCE + "\n" + "\n".join(tokens) + "\n```\n"
+
+
+def test_parse_token_block_reads_the_declared_tokens():
+    text = f"# FLOOR\n\nprose\n\n{_token_block(DECLARED_TOKENS)}\nmore prose\n"
+    assert _parse_token_block(text) == list(DECLARED_TOKENS)
+
+
+def test_parse_token_block_rejects_an_absent_block():
+    with pytest.raises(FloorTokenError):
+        _parse_token_block("# FLOOR\n\nno token block here at all\n")
+    with pytest.raises(FloorTokenError):
+        _parse_token_block(None)
+
+
+def test_parse_token_block_rejects_fewer_than_four_tokens():
+    shrunk = list(DECLARED_TOKENS)[: MINIMUM_TOKEN_COUNT - 1]
+    with pytest.raises(FloorTokenError):
+        _parse_token_block(_token_block(shrunk))
+
+
+def test_floor_tokens_shape():
+    # The real FLOOR.md block is the source of the token set: the marker plus
+    # the three gate invocations.
+    tokens = _parse_token_block((REPO_ROOT / FLOOR_FILE).read_text(encoding="utf-8"))
+    assert len(tokens) >= MINIMUM_TOKEN_COUNT
+    assert MARKER in tokens
+    for inv in ("start_gate.py", "spawn_verifier.py", "complete_gate.py"):
+        assert inv in tokens
 
 
 # ── missing_clauses: FLOOR.md integrity ──────────────────────────────────────
 
 def _intact_floor() -> str:
     parts = []
-    for anchor, phrase in REQUIRED_CLAUSES.values():
-        parts.append(f"{anchor}\nsome text with the {phrase} phrase in it.\n")
+    for anchor, *phrases in REQUIRED_CLAUSES.values():
+        joined = " and ".join(phrases)
+        parts.append(f"{anchor}\nsome text with the {joined} phrase in it.\n")
     return "\n".join(parts)
+
+
+def _floor_document(tokens=DECLARED_TOKENS) -> str:
+    return _intact_floor() + "\n" + _token_block(tokens)
 
 
 def test_intact_floor_has_no_missing_clauses():
@@ -162,8 +218,7 @@ def test_gutted_phrase_with_anchor_intact_still_flags():
 
 
 def test_real_floor_file_passes():
-    repo_root = Path(__file__).resolve().parents[2]
-    floor = repo_root / "FLOOR.md"
+    floor = REPO_ROOT / FLOOR_FILE
     assert floor.exists(), "FLOOR.md must exist at repo root"
     assert missing_clauses(floor.read_text(encoding="utf-8")) == []
 
@@ -174,11 +229,22 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
 
+def _init_repo(root: Path) -> None:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "t")
+
+
+def _write_floor(root: Path, tokens=DECLARED_TOKENS) -> Path:
+    floor = root / FLOOR_FILE
+    floor.write_text(_floor_document(tokens), encoding="utf-8")
+    return floor
+
+
 @pytest.fixture()
 def temp_repo(tmp_path, monkeypatch):
-    _git(tmp_path, "init", "-q")
-    _git(tmp_path, "config", "user.email", "t@t.t")
-    _git(tmp_path, "config", "user.name", "t")
+    _init_repo(tmp_path)
+    _write_floor(tmp_path)
     marked = tmp_path / "marked.md"
     marked.write_text(f"intro\n{MARKER}\nrun start_gate.py\n", encoding="utf-8")
     _git(tmp_path, "add", "-A")
@@ -211,9 +277,8 @@ def test_cli_markers_fail_when_anchor_removed_but_prose_kept(tmp_path, monkeypat
     # End-to-end reproduction of Attack A (PR #276): base file has the standalone
     # anchor AND a backtick prose mention; head deletes only the anchor line.
     # The check must FAIL even though the marker substring is still present.
-    _git(tmp_path, "init", "-q")
-    _git(tmp_path, "config", "user.email", "t@t.t")
-    _git(tmp_path, "config", "user.name", "t")
+    _init_repo(tmp_path)
+    _write_floor(tmp_path)
     marked = tmp_path / "marked.md"
     marked.write_text(
         f"intro\n{MARKER}\nbody\n- the `{MARKER}` markers in files\n",
@@ -232,8 +297,7 @@ def test_cli_markers_fail_when_anchor_removed_but_prose_kept(tmp_path, monkeypat
 
 
 def test_cli_clauses_pass_on_real_floor(tmp_path, monkeypatch):
-    repo_root = Path(__file__).resolve().parents[2]
-    rc = main(["clauses", "--floor", str(repo_root / "FLOOR.md")])
+    rc = main(["clauses", "--floor", str(REPO_ROOT / FLOOR_FILE)])
     assert rc == 0
 
 
@@ -242,7 +306,124 @@ def test_cli_clauses_fail_when_absent(tmp_path):
     assert rc == 1
 
 
-def test_floor_tokens_shape():
-    assert MARKER in FLOOR_TOKENS
-    for inv in INVOCATIONS:
-        assert inv in FLOOR_TOKENS
+def test_cli_clauses_fail_when_token_block_absent(tmp_path, capsys):
+    floor = tmp_path / FLOOR_FILE
+    floor.write_text(_intact_floor(), encoding="utf-8")  # clauses intact, no block
+    rc = main(["clauses", "--floor", str(floor)])
+    assert rc == 1
+    assert TOKEN_BLOCK_FENCE in capsys.readouterr().out
+
+
+def test_cli_clauses_fail_when_token_block_is_short(tmp_path, capsys):
+    floor = tmp_path / FLOOR_FILE
+    floor.write_text(
+        _floor_document(list(DECLARED_TOKENS)[: MINIMUM_TOKEN_COUNT - 1]),
+        encoding="utf-8",
+    )
+    rc = main(["clauses", "--floor", str(floor)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert str(MINIMUM_TOKEN_COUNT - 1) in out and str(MINIMUM_TOKEN_COUNT) in out
+
+
+# ── Discovery: the marked set is data, not a constant ────────────────────────
+
+def _marked_body(name: str) -> str:
+    return (
+        f"# {name}\n\n{MARKER}\n\n"
+        "Runs start_gate.py, then spawn_verifier.py, then complete_gate.py.\n"
+    )
+
+
+def _prose_body(name: str) -> str:
+    return (
+        f"# {name}\n\n"
+        f"Documents the `{MARKER}` marker without carrying the obligation.\n"
+    )
+
+
+@pytest.fixture()
+def discovery_repo(tmp_path, monkeypatch):
+    """Scratch repo: four marked files, two prose-only carriers, plus FLOOR.md.
+
+    FLOOR.md itself holds a bare marker line inside its token block, so it is a
+    seventh candidate the exclusion has to drop.
+    """
+    _init_repo(tmp_path)
+    _write_floor(tmp_path)
+    for name in ("alpha", "beta", "gamma", "delta"):
+        (tmp_path / f"{name}.md").write_text(_marked_body(name), encoding="utf-8")
+    for name in ("epsilon", "zeta"):
+        (tmp_path / f"{name}.md").write_text(_prose_body(name), encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "four marked, two prose carriers")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_discovery_returns_only_standalone_anchor_carriers(discovery_repo):
+    discovered = _discover_marked_files("HEAD", MARKER, cwd=discovery_repo)
+    assert sorted(discovered) == ["alpha.md", "beta.md", "delta.md", "gamma.md"]
+    assert FLOOR_FILE not in discovered  # the file that defines the marker
+
+
+def test_cli_markers_without_files_uses_discovery(discovery_repo, capsys):
+    # Weaken one discovered file; the prose-only carriers stay untouched.
+    target = discovery_repo / "beta.md"
+    target.write_text(
+        "\n".join(
+            line
+            for line in target.read_text(encoding="utf-8").splitlines()
+            if line.strip() != MARKER
+        ),
+        encoding="utf-8",
+    )
+    rc = main(["markers", "--base", "HEAD"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "FAIL beta.md" in out
+    assert "ok   alpha.md" in out
+    assert "epsilon.md" not in out and "zeta.md" not in out
+
+
+# ── The token set follows FLOOR.md at the base ref (contract FC19) ────────────
+
+def test_token_added_to_the_block_at_base_is_enforced(tmp_path, monkeypatch, capsys):
+    # A token the script never heard of is enforced because the base ref's
+    # FLOOR.md declares it.
+    _init_repo(tmp_path)
+    _write_floor(tmp_path, (*DECLARED_TOKENS, "probe_gate.py"))
+    marked = tmp_path / "marked.md"
+    marked.write_text(
+        f"intro\n{MARKER}\nrun start_gate.py\nAlso invokes probe_gate.py.\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base declaring probe_gate.py")
+    monkeypatch.chdir(tmp_path)
+    marked.write_text(f"intro\n{MARKER}\nrun start_gate.py\n", encoding="utf-8")
+    rc = main(["markers", "--base", "HEAD"])
+    assert rc == 1
+    assert "probe_gate.py" in capsys.readouterr().out
+
+
+def test_token_added_only_in_the_working_tree_is_not_enforced(
+    tmp_path, monkeypatch, capsys
+):
+    # The token set comes from git show <base>:FLOOR.md, never the working tree,
+    # so a token added on the head side is not yet enforced by that run.
+    _init_repo(tmp_path)
+    _write_floor(tmp_path)
+    marked = tmp_path / "marked.md"
+    marked.write_text(
+        f"intro\n{MARKER}\nrun start_gate.py\nAlso invokes zeta_gate.py.\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base without zeta_gate.py declared")
+    monkeypatch.chdir(tmp_path)
+    _write_floor(tmp_path, (*DECLARED_TOKENS, "zeta_gate.py"))  # working tree only
+    marked.write_text(f"intro\n{MARKER}\nrun start_gate.py\n", encoding="utf-8")
+    rc = main(["markers", "--base", "HEAD"])
+    assert rc == 0
+    assert "zeta_gate.py" not in capsys.readouterr().out

--- a/scripts/tests/test_floor_check.py
+++ b/scripts/tests/test_floor_check.py
@@ -427,3 +427,38 @@ def test_token_added_only_in_the_working_tree_is_not_enforced(
     rc = main(["markers", "--base", "HEAD"])
     assert rc == 0
     assert "zeta_gate.py" not in capsys.readouterr().out
+
+
+def test_markers_falls_back_to_the_working_tree_when_the_base_predates_the_block(
+    tmp_path, monkeypatch, capsys
+):
+    # Bootstrap: the base ref has no token block at all (every base before the
+    # block landed). The run enforces the working-tree declaration and says so.
+    _init_repo(tmp_path)
+    (tmp_path / FLOOR_FILE).write_text(_intact_floor(), encoding="utf-8")
+    marked = tmp_path / "marked.md"
+    marked.write_text(f"intro\n{MARKER}\nrun start_gate.py\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base with no token block")
+    monkeypatch.chdir(tmp_path)
+    _write_floor(tmp_path)  # the block arrives on the head side
+    marked.write_text("intro\nrun something\n", encoding="utf-8")
+    rc = main(["markers", "--base", "HEAD"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "bootstrap" in out
+    assert MARKER in out and "start_gate.py" in out
+
+
+def test_markers_fails_when_neither_side_declares_a_token_block(
+    tmp_path, monkeypatch, capsys
+):
+    _init_repo(tmp_path)
+    (tmp_path / FLOOR_FILE).write_text(_intact_floor(), encoding="utf-8")
+    (tmp_path / "marked.md").write_text(f"{MARKER}\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "no token block anywhere")
+    monkeypatch.chdir(tmp_path)
+    rc = main(["markers", "--base", "HEAD"])
+    assert rc == 1
+    assert TOKEN_BLOCK_FENCE in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Tasks 1 and 4 of the `modernization-floor` run (WS0 spec requirements 1-3, 9, 14, 15). The floor's marked set and token set stop being module constants in `scripts/floor_check.py` and become data `FLOOR.md` declares, so a marked file that moves and a token that is added are both enforced with no edit to the script.

No plugin version bump: the spec's Breadcrumbs section states WS0 touches no skill, agent, command or manifest, so nothing user-facing changes.

## Changes

**`scripts/floor_check.py`**

- `MARKED_FILES`, `FLOOR_TOKENS` and `INVOCATIONS` deleted. `MARKER` stays as the one anchor string the discovery grep needs.
- `_discover_marked_files(base_ref, marker, cwd=None)` runs `git grep -l -F <marker> <base_ref> -- ':!FLOOR.md'` and keeps the files whose content at that ref holds a standalone anchor line. `FLOOR.md` is excluded because it is where the marker is defined.
- `_parse_token_block(floor_text)` reads the fenced block whose opening fence is exactly ` ```floor-tokens `, one token per line, and raises when the block is absent, duplicated, unterminated, or carries fewer than four tokens.
- `markers --base <ref>` uses discovery when `--files` is not given and reads the token set from `git show <ref>:FLOOR.md`. `removed_tokens` takes the token set as an argument rather than reading a constant.
- `clauses` reads the block from the working-tree `FLOOR.md` and fails when it is absent or short. `REQUIRED_CLAUSES['iii']` gains the `floor-signoff` key phrase alongside `out-of-band`.
- Bootstrap fallback: when the base ref predates the token block - which is every base until this PR merges - the working-tree declaration is enforced instead and a `note` line names the fallback. Wherever the base declares a block it stays authoritative, so a token added on the head side is still not enforced by that run, and a run where neither side declares one fails.

**`FLOOR.md`**

- New `## Tokens` section carrying exactly one ` ```floor-tokens ` block with the four tokens.
- `## Markers` rewritten: it describes the token and points at `scripts/floor_check.py markers --base <ref>` instead of listing files.
- Clause iii names the six protected paths that stay (`scripts/floor_check.py`, `scripts/floor_anchor.py`, `.github/workflows/floor.yml`, `scripts/contract/`, `scripts/canaries/`, `tests/canaries/`) and records the sign-off as the maintainer's deployment review of the `floor-signoff` environment. All four clause anchors and key phrases kept.
- No `skills/`, `commands/` or `plugins/` path survives anywhere in the file.

**`scripts/tests/test_floor_check.py`** - 27 tests to 38. `test_real_marathon_anchor_removal_is_flagged` resolves its target through `_discover_marked_files` instead of a literal path; the token set the tests use is parsed out of the real `FLOOR.md`; new cases cover discovery, token-block parsing, the two `clauses` failure modes, base-ref vs working-tree token enforcement, and the bootstrap fallback.

Rename mapping, the structural destination check and the `protected` subcommand are the next task and are not implemented here; `.github/workflows/`, `scripts/floor_anchor.py`, `action.yml` and everything under `skills/`, `commands/`, `agents/`, `plugins/` and `.claude-plugin/` are untouched, and the four marked files' contents are unchanged.

## Testing

Contract criteria verified from this branch (FC3, FC4 and FC5 belong to the rename-mapping task; the `ok   <path>` / `FAIL <path>:` line shapes they read are unchanged).

**FC1** - constants gone, discovery present, `markers` names the four marked files and no incidental carrier:

```
$ rg -n 'MARKED_FILES|^FLOOR_TOKENS\s*=|^INVOCATIONS\s*=' scripts/floor_check.py ; echo "rc=$?"
rc=1
$ rg -c '_discover_marked_files' scripts/floor_check.py
3
$ python3 scripts/floor_check.py markers --base HEAD ; echo "rc=$?"
ok   commands/issues.md: 4 token(s) intact
ok   commands/tm.md: 4 token(s) intact
ok   skills/marathon/SKILL.md: 4 token(s) intact
ok   skills/pr-review-merge/SKILL.md: 4 token(s) intact

Marker check passed: no floor tokens removed.
rc=0
```

**FC2** - one block, four lines, and `clauses` refuses a deleted or shrunk block (scratch clones, `GIT_CONFIG_GLOBAL=/dev/null`):

```
$ rg -c '^```floor-tokens$' FLOOR.md
1
$ awk '/^```floor-tokens$/{f=1; next} /^```/{f=0} f' FLOOR.md
<!-- floor:cold-verify-completion -->
start_gate.py
spawn_verifier.py
complete_gate.py
$ python3 scripts/floor_check.py clauses ; echo "rc=$?"
ok   FLOOR.md: all four clauses intact, 4 floor token(s) declared.
rc=0

# clone with the whole block deleted
FAIL FLOOR.md: no '```floor-tokens' token block in FLOOR.md: the floor must declare its tokens
rc=1

# clone with only the complete_gate.py line deleted
FAIL FLOOR.md: the '```floor-tokens' token block in FLOOR.md declares 3 token(s); the floor requires at least 4
rc=1
```

**FC8** (the `FLOOR.md` half; the `floor.yml` half is a later task):

```
$ rg -n 'skills/|commands/|plugins/' FLOOR.md ; echo "rc=$?"
rc=1
$ for l in floor_check.py floor_anchor.py floor.yml scripts/contract/ scripts/canaries/ tests/canaries/ ; do rg -c -F "$l" FLOOR.md ; done
2
1
3
1
1
1
$ rg -c 'floor-signoff' FLOOR.md
1
$ rg -n '^#+ Markers' FLOOR.md
65:## Markers
$ rg -c 'floor_check.py markers' FLOOR.md
1

# clone with floor-signoff misspelled
FAIL FLOOR.md: clauses not intact -> iii
rc=1

# clone with the floor-clause:iv anchor deleted
FAIL FLOOR.md: clauses not intact -> iv
rc=1
```

**FC15** - the regression guard resolves its target through discovery:

```
$ awk '/^def test_real_marathon_anchor_removal_is_flagged/{f=1} f&&/^def /&&!/test_real_marathon_anchor_removal_is_flagged/{f=0} f' \
    scripts/tests/test_floor_check.py > /tmp/body.txt ; wc -l /tmp/body.txt
      21 /tmp/body.txt
$ rg -c 'skills/|"skills"' /tmp/body.txt ; echo "rc=$?"
rc=1
$ rg -c 'discover' /tmp/body.txt
5
$ rg -c '^def test_' scripts/tests/test_floor_check.py
38
```

**FC19** - a token added to the block at the base ref is enforced; one added only in the working tree is not:

```
$ awk '/^```floor-tokens$/{f=1; next} /^```/{f=0} f' FLOOR.md
<!-- floor:cold-verify-completion -->
start_gate.py
spawn_verifier.py
complete_gate.py
probe_gate.py
$ python3 scripts/floor_check.py markers --base HEAD~1 ; echo "rc=$?"
ok   commands/issues.md: 4 token(s) intact
ok   commands/tm.md: 4 token(s) intact
FAIL skills/marathon/SKILL.md: floor token weakened -> 'probe_gate.py' (occurrences dropped, or its standalone anchor line was removed, between HEAD~1 and head)
ok   skills/pr-review-merge/SKILL.md: 4 token(s) intact
rc=1

# re-run with an uncommitted zeta_gate.py line appended to the block:
# same FAIL on probe_gate.py, no mention of zeta_gate.py
rc=1
```

**Suites** (the CI invocations):

```
$ cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q
163 passed, 6 warnings in 2.72s
$ GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/ -q     # repo root
563 passed in 7.51s
$ cd skills/assess && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q
1024 passed, 2 skipped in 69.27s
$ cd scripts && uv run --with ruff ruff check .
All checks passed!
```

`floor enforcement` reproduced locally against the real merge-base, exercising the bootstrap fallback:

```
$ BASE_SHA="$(git merge-base origin/main HEAD)" ; python3 scripts/floor_check.py markers --base "$BASE_SHA"
note FLOOR.md at 0707613...: no '```floor-tokens' token block in FLOOR.md: the floor must declare its tokens; enforcing the working-tree declaration instead (bootstrap).
ok   commands/issues.md: 4 token(s) intact
ok   commands/tm.md: 4 token(s) intact
ok   skills/marathon/SKILL.md: 4 token(s) intact
ok   skills/pr-review-merge/SKILL.md: 4 token(s) intact
rc=0
```

## Risk assessment

The enforced set can only widen here: discovery returns the same four files the constant listed plus any file that later carries a standalone anchor, and the token set is the same four tokens the constant held. `clauses` gains a failure mode (a missing or shrunk block) and loses none. The one new tolerance is the bootstrap fallback, which applies only while the base ref carries no block at all and disappears the moment this PR merges.
