### PR TITLE
fix: Run the assess contract tests with PyYAML and collect unnamed job ids in the anchor check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update -q && sudo apt-get install -y -q ripgrep
 
+      # --with pyyaml: eight structural guards in tests/test_action_contract.py
+      # parse action.yml / assess-gate.yml and pytest.skip without PyYAML - a
+      # skipped guard is a decorative guard. skills/assess/pyproject.toml does
+      # not declare it, so the CI invocation supplies it.
       - name: Run pytest
-        run: uv run --with pytest pytest -v
+        run: uv run --with pytest --with pyyaml pytest -v
         working-directory: skills/assess
 
   pipeline-tests:
@@ -60,9 +64,13 @@ jobs:
 
       # fetch-depth: 0 deepens the merge ref, it does not create the base
       # branch ref locally. Fetch it explicitly so `origin/<base>` resolves.
+      # No --depth: a depth-limited fetch into a complete clone writes a
+      # .git/shallow graft at the fetched tip, cutting the base's ancestry so
+      # `git merge-base` cannot resolve past it. fetch-depth: 0 already paid
+      # for the full history.
       - name: Fetch the PR base ref
         if: github.event_name == 'pull_request'
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

--- a/scripts/floor_anchor.py
+++ b/scripts/floor_anchor.py
@@ -48,13 +48,20 @@ ANCHOR_CONTEXT = os.environ.get("ANCHOR_CONTEXT", "floor self-anchor")
 FLOOR_PATH = ".github/workflows/floor.yml"
 
 # Where the workflow definitions live, relative to the repository root, and the
-# line shape a job ``name:`` takes in them. Jobs sit at two levels of two-space
-# indentation under ``jobs:``; steps sit deeper and behind a ``- ``, so a
-# four-space ``name:`` is unambiguously a job name. This is a regex over lines
-# rather than a YAML parse on purpose: the self-anchor job runs bare ``python``
-# with no dependency install, so PyYAML is not available to it.
+# line shapes a job identity takes in them. Jobs sit at two-space indentation
+# under ``jobs:``; their ``name:`` sits one level deeper, while steps sit
+# deeper still and behind a ``- ``, so a four-space ``name:`` is unambiguously a
+# job name. A job with no ``name:`` is still a real check context -- GitHub
+# falls back to the job *id* -- so the two-space id key is collected too. This
+# is a regex over lines rather than a YAML parse on purpose: the self-anchor job
+# runs bare ``python`` with no dependency install, so PyYAML is not available to
+# it.
 WORKFLOW_DIR = ".github/workflows"
+WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 JOB_NAME_RE = re.compile(r"^\s{4}name: (.+)$")
+JOB_ID_RE = re.compile(r"^ {2}([A-Za-z0-9_-]+):\s*$")
+JOBS_KEY_RE = re.compile(r"^jobs:\s*$")
+TOP_LEVEL_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+:")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # --- E2 DESCOPE: floor.yml path lock (maintainer decision, 2026-07-10) --------
@@ -267,8 +274,31 @@ def _ruleset_required_contexts(repo: str, token: str) -> set[str]:
     return contexts
 
 
+def _workflow_files(base: Path) -> list[Path]:
+    """Every workflow definition under ``base``, both ``.yml`` and ``.yaml``.
+
+    GitHub reads either extension, so globbing only one leaves whole workflows
+    -- and every context they produce -- invisible to the subset check below.
+    """
+    directory = base / WORKFLOW_DIR
+    found: set[Path] = set()
+    for pattern in WORKFLOW_GLOBS:
+        found.update(directory.glob(pattern))
+    return sorted(found)
+
+
 def _workflow_job_names(root: Path | None = None) -> set[str]:
-    """Every job ``name:`` literal declared by ``.github/workflows/*.yml``.
+    """Every check-run name a job in ``.github/workflows`` can produce.
+
+    That is both the job ``name:`` literals and the job *ids*: GitHub names a
+    check run after the job's ``name:`` when it has one and after the job id
+    when it does not, so a collector that reads only ``name:`` lines misses
+    every unnamed job (this repo has two) and would fail the caller closed on a
+    context that is in fact produced fine.
+
+    Collecting ids as well is strictly more permissive and cannot mask a
+    rename: every required context on this repo contains a space and no YAML
+    job id can, so an id never stands in for a renamed ``name:`` literal.
 
     Read from the checked-out branch, so a rename is seen in the PR that makes
     it rather than after merge. An unreadable or absent workflow directory
@@ -276,15 +306,28 @@ def _workflow_job_names(root: Path | None = None) -> set[str]:
     """
     base = REPO_ROOT if root is None else Path(root)
     names: set[str] = set()
-    for workflow in sorted((base / WORKFLOW_DIR).glob("*.yml")):
+    for workflow in _workflow_files(base):
         try:
             text = workflow.read_text(encoding="utf-8")
         except OSError:
             continue
+        in_jobs = False
         for line in text.splitlines():
+            if JOBS_KEY_RE.match(line):
+                in_jobs = True
+                continue
+            # A new top-level key ends the jobs block; comments and blank lines
+            # inside it do not.
+            if in_jobs and TOP_LEVEL_KEY_RE.match(line):
+                in_jobs = False
             match = JOB_NAME_RE.match(line)
             if match:
                 names.add(match.group(1).strip().strip("\"'"))
+                continue
+            if in_jobs:
+                job_id = JOB_ID_RE.match(line)
+                if job_id:
+                    names.add(job_id.group(1))
     return names
 
 
@@ -296,8 +339,9 @@ def check_contexts_have_workflows(contexts: set[str], root: Path | None = None) 
     job rename orphans the context and the merge blocks on a check that can
     never turn green, or (where the context is dropped instead) a floor layer
     disarms with nothing red. Comparing the required set against the job
-    ``name:`` literals on the checked-out branch moves that discovery into the
-    PR that renames the job.
+    identities on the checked-out branch -- ``name:`` literals plus the job ids
+    GitHub falls back to for unnamed jobs -- moves that discovery into the PR
+    that renames the job.
     """
     job_names = _workflow_job_names(root)
     orphaned = sorted(ctx for ctx in contexts if ctx not in job_names)
@@ -305,14 +349,15 @@ def check_contexts_have_workflows(contexts: set[str], root: Path | None = None) 
         named = ", ".join(repr(ctx) for ctx in orphaned)
         raise AnchorError(
             f"required status check context(s) {named} are produced by no job "
-            f"name: in {WORKFLOW_DIR}/*.yml on this branch. A required context "
-            "no job emits never arrives, so the check it gates can never turn "
-            f"green. Job names seen: {sorted(job_names) or 'none'}. Rename the "
-            "job back, or update branch protection in the same change."
+            f"name: or job id in {WORKFLOW_DIR}/{{{','.join(WORKFLOW_GLOBS)}}} on "
+            "this branch. A required context no job emits never arrives, so the "
+            "check it gates can never turn green. Job names seen: "
+            f"{sorted(job_names) or 'none'}. Rename the job back, or update "
+            "branch protection in the same change."
         )
     print(
         f"ok   all {len(contexts)} required context(s) are produced by a job "
-        f"name: in {WORKFLOW_DIR}/*.yml."
+        f"name: or job id in {WORKFLOW_DIR}/{{{','.join(WORKFLOW_GLOBS)}}}."
     )
 
 

--- a/scripts/tests/test_floor_anchor.py
+++ b/scripts/tests/test_floor_anchor.py
@@ -286,11 +286,88 @@ def _workflows(tmp_path, body=WORKFLOW_WITH_TWO_JOBS, filename="tests.yml"):
     return tmp_path
 
 
+WORKFLOW_WITH_AN_UNNAMED_JOB = """\
+name: Review
+
+on:
+  pull_request:
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review
+        run: review
+"""
+
+
 def test_workflow_job_names_reads_job_names_not_step_names(tmp_path):
     names = floor_anchor._workflow_job_names(_workflows(tmp_path))
     # Job names come from the four-space `name:` lines; step names sit deeper
     # behind a `- `, and the workflow's own top-level name is at column zero.
-    assert names == {"scripts/ pytest", "ruff + mypy gates"}
+    # The two-space job ids come too - GitHub names an unnamed job's check run
+    # after its id - and no step name ("Run pytest", "Ruff") leaks in.
+    assert names == {"scripts/ pytest", "ruff + mypy gates", "pytest", "lint"}
+
+
+def test_workflow_job_names_collects_the_id_of_an_unnamed_job(tmp_path):
+    # A job with no `name:` still produces a check context - GitHub falls back
+    # to the job id. Missing it makes the fail-closed caller a false red the
+    # moment such a context is required.
+    root = _workflows(tmp_path, body=WORKFLOW_WITH_AN_UNNAMED_JOB, filename="review.yml")
+    assert "claude-review" in floor_anchor._workflow_job_names(root)
+
+
+def test_workflow_job_names_reads_yaml_as_well_as_yml(tmp_path):
+    root = _workflows(
+        tmp_path,
+        body="jobs:\n  build:\n    name: standalone build\n    runs-on: ubuntu-latest\n",
+        filename="build.yaml",
+    )
+    assert "standalone build" in floor_anchor._workflow_job_names(root)
+
+
+def test_workflow_job_names_does_not_collect_keys_outside_the_jobs_block(tmp_path):
+    # Two-space keys under `on:` or `permissions:` are not job ids. Only keys
+    # inside the `jobs:` block are.
+    body = """\
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: scripts/ pytest
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+    names = floor_anchor._workflow_job_names(_workflows(tmp_path, body=body))
+    assert names == {"scripts/ pytest", "pytest"}
+
+
+def test_collected_job_ids_cannot_mask_a_renamed_context(tmp_path):
+    # The permissiveness has a hard bound: every required context carries a
+    # space and no YAML job id can, so a renamed `name:` still orphans its
+    # context even though the job's id is in the set.
+    body = """\
+jobs:
+  pytest:
+    name: scripts pytest renamed
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_contexts_have_workflows(
+            {"scripts/ pytest"}, _workflows(tmp_path, body=body)
+        )
+    assert "scripts/ pytest" in str(exc.value)
 
 
 def test_workflow_job_names_reads_every_workflow_file(tmp_path):


### PR DESCRIPTION
## Summary

Three advisory findings from the `claude-review` on #306, all in the CI/anchor
layer that PR shipped. No behaviour change to the floor's deterministic checks
and no `.claude-plugin/` edit (no version bump this run).

## Changes

**`.github/workflows/tests.yml` - `plugin contract pytest`: drop `--depth=1`**

The base-ref fetch ran `git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"`
into a `fetch-depth: 0` clone. A depth-limited fetch into a complete clone writes
a `.git/shallow` graft at the fetched tip, so the base arrives with its ancestry
cut and `git merge-base` cannot resolve past the boundary - exactly the base-vs-head
reasoning the step exists to enable. Nothing consumes it today, so nothing was red;
the first test that does would have hit it. `--no-tags` and the `github.base_ref`
expression are unchanged.

**`.github/workflows/tests.yml` - `skills/assess pytest`: add `--with pyyaml`**

`skills/assess/pyproject.toml` declares `networkx` and `grimp`; neither pulls
PyYAML transitively, so the eight structural guards in
`skills/assess/tests/test_action_contract.py` that parse `action.yml` and
`assess-gate.yml` called `pytest.skip` on every CI run - including
`test_render_step_is_continue_on_error`, the only enforcement of the render-step
contract that #306's render assertion rests on. A skipped guard is a decorative
guard. Supplied at the CI invocation rather than in `pyproject.toml`; the lazy
import stays, so a bare-interpreter run still degrades honestly.

**`scripts/floor_anchor.py` - collect job ids, glob `*.yaml`**

`_workflow_job_names` read only four-space `name:` lines from `*.yml`. GitHub
names a check run after the job *id* when the job has no `name:`, so two real
contexts on this repo (`claude-review`, `build`) were invisible, and a `.yaml`
workflow file was unseen entirely. The caller is fail-closed, so a miss is a
false red on `floor self-anchor` the moment such a context is made required.
The collector now also takes the two-space job-id keys inside the `jobs:` block
and globs both extensions. This is strictly more permissive and cannot mask a
rename: every required context contains a space and no YAML job id can. The
function stays additive - no signature change, no job `name:` literal touched.

## Testing

- `cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q` - 175 passed
  (5 new/adjusted cases: job-id collection, `.yaml` globbing, keys outside the
  `jobs:` block are not job ids, and a renamed context still orphans).
- `GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest --with pyyaml pytest tests/test_action_contract.py -q -rs`
  from `skills/assess`: 15 passed, 0 skipped (was 7 passed, 8 skipped).
- `cd scripts && uv run --with ruff ruff check .` - clean.
- Live anchor run against this repo's settings: exit 0, `ok all 6 required
  context(s) are produced by a job name: or job id`.
- FC13 rename probe - fresh scratch clone of this branch with the `scripts/ pytest`
  job renamed: exit 1, output names the orphaned context `scripts/ pytest`, and the
  job-names-seen list now includes the previously invisible `claude-review` and
  `build` ids.
- FC14 probe: `plugin contract pytest` still found, `fetch_depth` 0, base-fetch run
  string still contains `base_ref`.

## Risk Assessment

Low. Two workflow invocation lines and one discovery function that only widens
what it accepts. The three remaining #306 threads (the enabling-intent comment
reword, the positive `outputs.rendered` check, the `>= 20` component floor) are
out of scope here.
