### PR TITLE
fix: Collect only unnamed job ids in the required-context check

### DIFF
--- a/scripts/floor_anchor.py
+++ b/scripts/floor_anchor.py
@@ -52,10 +52,10 @@ FLOOR_PATH = ".github/workflows/floor.yml"
 # under ``jobs:``; their ``name:`` sits one level deeper, while steps sit
 # deeper still and behind a ``- ``, so a four-space ``name:`` is unambiguously a
 # job name. A job with no ``name:`` is still a real check context -- GitHub
-# falls back to the job *id* -- so the two-space id key is collected too. This
-# is a regex over lines rather than a YAML parse on purpose: the self-anchor job
-# runs bare ``python`` with no dependency install, so PyYAML is not available to
-# it.
+# falls back to the job *id* -- so the two-space id key is collected for those
+# jobs ONLY (see ``_workflow_job_names``). This is a regex over lines rather
+# than a YAML parse on purpose: the self-anchor job runs bare ``python`` with no
+# dependency install, so PyYAML is not available to it.
 WORKFLOW_DIR = ".github/workflows"
 WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 JOB_NAME_RE = re.compile(r"^\s{4}name: (.+)$")
@@ -290,15 +290,19 @@ def _workflow_files(base: Path) -> list[Path]:
 def _workflow_job_names(root: Path | None = None) -> set[str]:
     """Every check-run name a job in ``.github/workflows`` can produce.
 
-    That is both the job ``name:`` literals and the job *ids*: GitHub names a
-    check run after the job's ``name:`` when it has one and after the job id
-    when it does not, so a collector that reads only ``name:`` lines misses
-    every unnamed job (this repo has two) and would fail the caller closed on a
-    context that is in fact produced fine.
+    GitHub names a check run after the job's ``name:`` when the job has one and
+    after the job *id* when it does not, and never after both. So this is a
+    one-pass state machine over the same line scan, not a union of the two: at a
+    two-space job-id key the id is held pending; a four-space ``name:`` arriving
+    before the next two-space key resolves that job to its name and DROPS the
+    pending id; a job whose next two-space key (or the end of the ``jobs:``
+    block) arrives first is unnamed, so its id is added.
 
-    Collecting ids as well is strictly more permissive and cannot mask a
-    rename: every required context on this repo contains a space and no YAML
-    job id can, so an id never stands in for a renamed ``name:`` literal.
+    Collecting the id of a *named* job would be fail-open in exactly the case
+    the caller exists to catch: require the id ``contract-tests`` instead of the
+    name ``plugin contract pytest`` -- the natural id/name confusion when
+    editing branch protection by hand -- and the anchor would print ok while
+    that context never arrives and the PR sits pending forever.
 
     Read from the checked-out branch, so a rename is seen in the PR that makes
     it rather than after merge. An unreadable or absent workflow directory
@@ -312,22 +316,35 @@ def _workflow_job_names(root: Path | None = None) -> set[str]:
         except OSError:
             continue
         in_jobs = False
+        pending_id: str | None = None
         for line in text.splitlines():
             if JOBS_KEY_RE.match(line):
                 in_jobs = True
+                pending_id = None
                 continue
             # A new top-level key ends the jobs block; comments and blank lines
-            # inside it do not.
+            # inside it do not. The job open at that point had no ``name:``, so
+            # its id is the check-run name.
             if in_jobs and TOP_LEVEL_KEY_RE.match(line):
                 in_jobs = False
-            match = JOB_NAME_RE.match(line)
-            if match:
-                names.add(match.group(1).strip().strip("\"'"))
+                if pending_id is not None:
+                    names.add(pending_id)
+                    pending_id = None
+            if not in_jobs:
                 continue
-            if in_jobs:
-                job_id = JOB_ID_RE.match(line)
-                if job_id:
-                    names.add(job_id.group(1))
+            match = JOB_NAME_RE.match(line)
+            if match and pending_id is not None:
+                # The job is named: GitHub uses this literal, never the id.
+                names.add(match.group(1).strip().strip("\"'"))
+                pending_id = None
+                continue
+            job_id = JOB_ID_RE.match(line)
+            if job_id:
+                if pending_id is not None:
+                    names.add(pending_id)  # the previous job carried no name:
+                pending_id = job_id.group(1)
+        if pending_id is not None:  # last job in the file, unnamed
+            names.add(pending_id)
     return names
 
 

--- a/scripts/tests/test_floor_anchor.py
+++ b/scripts/tests/test_floor_anchor.py
@@ -305,9 +305,45 @@ def test_workflow_job_names_reads_job_names_not_step_names(tmp_path):
     names = floor_anchor._workflow_job_names(_workflows(tmp_path))
     # Job names come from the four-space `name:` lines; step names sit deeper
     # behind a `- `, and the workflow's own top-level name is at column zero.
-    # The two-space job ids come too - GitHub names an unnamed job's check run
-    # after its id - and no step name ("Run pytest", "Ruff") leaks in.
-    assert names == {"scripts/ pytest", "ruff + mypy gates", "pytest", "lint"}
+    # Both jobs carry a `name:`, so GitHub uses those literals and never the
+    # ids - `pytest` and `lint` are not check-run names and must not appear,
+    # and no step name ("Run pytest", "Ruff") leaks in either.
+    assert names == {"scripts/ pytest", "ruff + mypy gates"}
+
+
+def test_workflow_job_names_drops_the_id_of_a_named_job(tmp_path):
+    # The id/name pair the caller exists to disambiguate: require the id
+    # `contract-tests` instead of the name `plugin contract pytest` - the
+    # natural confusion when editing branch protection by hand - and a
+    # collector that kept both would print ok while the context never arrives.
+    body = """\
+jobs:
+  contract-tests:
+    name: plugin contract pytest
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+    names = floor_anchor._workflow_job_names(_workflows(tmp_path, body=body))
+    assert names == {"plugin contract pytest"}
+    assert "contract-tests" not in names
+
+
+def test_named_job_id_is_not_a_valid_required_context(tmp_path):
+    # The end-to-end consequence: requiring the id of a named job fails closed.
+    body = """\
+jobs:
+  contract-tests:
+    name: plugin contract pytest
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_contexts_have_workflows(
+            {"contract-tests"}, _workflows(tmp_path, body=body)
+        )
+    assert "contract-tests" in str(exc.value)
 
 
 def test_workflow_job_names_collects_the_id_of_an_unnamed_job(tmp_path):
@@ -315,7 +351,41 @@ def test_workflow_job_names_collects_the_id_of_an_unnamed_job(tmp_path):
     # to the job id. Missing it makes the fail-closed caller a false red the
     # moment such a context is required.
     root = _workflows(tmp_path, body=WORKFLOW_WITH_AN_UNNAMED_JOB, filename="review.yml")
-    assert "claude-review" in floor_anchor._workflow_job_names(root)
+    assert floor_anchor._workflow_job_names(root) == {"claude-review"}
+
+
+def test_workflow_job_names_separates_a_named_job_from_an_unnamed_neighbour(tmp_path):
+    # One pass, two outcomes: the named job resolves to its `name:` and drops
+    # its id; the unnamed job that follows keeps its id. Both shapes coexist in
+    # this repo's own workflows.
+    body = """\
+jobs:
+  contract-tests:
+    name: plugin contract pytest
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - run: review
+"""
+    names = floor_anchor._workflow_job_names(_workflows(tmp_path, body=body))
+    assert names == {"plugin contract pytest", "claude-review"}
+
+
+def test_workflow_job_names_collects_a_trailing_unnamed_job(tmp_path):
+    # The pending id must still be flushed when the file ends on an unnamed
+    # job - there is no following two-space key to close it.
+    body = """\
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: build
+"""
+    assert floor_anchor._workflow_job_names(_workflows(tmp_path, body=body)) == {"build"}
 
 
 def test_workflow_job_names_reads_yaml_as_well_as_yml(tmp_path):
@@ -348,13 +418,13 @@ jobs:
       - run: pytest
 """
     names = floor_anchor._workflow_job_names(_workflows(tmp_path, body=body))
-    assert names == {"scripts/ pytest", "pytest"}
+    assert names == {"scripts/ pytest"}
 
 
 def test_collected_job_ids_cannot_mask_a_renamed_context(tmp_path):
-    # The permissiveness has a hard bound: every required context carries a
-    # space and no YAML job id can, so a renamed `name:` still orphans its
-    # context even though the job's id is in the set.
+    # A renamed `name:` orphans the context it used to produce: the job is
+    # named, so its id never enters the set and cannot stand in for the old
+    # literal. This is FC13's probe in miniature.
     body = """\
 jobs:
   pytest:


### PR DESCRIPTION
## Summary

Follow-up to #309. `scripts/floor_anchor.py::_workflow_job_names` collected the job id of **every** job under `jobs:`, not only the jobs GitHub actually names after their id. Ids like `contract-tests`, `pytest`, `lint`, `floor` and `self-anchor` entered the set although no check run ever carries those strings.

That made `check_contexts_have_workflows` fail-open in exactly the case it exists to catch: require `contract-tests` (the id) instead of `plugin contract pytest` (the name) - the natural id/name confusion when editing branch protection by hand - and the anchor printed `ok` while the context never arrived and the PR sat pending forever.

## Changes

- `scripts/floor_anchor.py` - `_workflow_job_names` is now a one-pass state machine over the same line scan instead of a union of names and ids: a two-space job-id key holds the id pending; a four-space `name:` arriving before the next two-space key resolves the job to its name and **drops** the pending id; otherwise (next two-space key, end of the `jobs:` block, or end of file) the id is added. Same regexes, same `*.yml` + `*.yaml` glob, stdlib only - no PyYAML, which the bare-`python` self-anchor job does not have.
- The docstring's "strictly more permissive ... every required context contains a space" caveat is retired. It was a prose invariant with nothing enforcing it, and it is no longer needed: a named job's id is simply not a member.
- `scripts/tests/test_floor_anchor.py` - reverted the assertions that baked `pytest` and `lint` in as members, and added five cases: a named job's id is dropped (`contract-tests` absent, `plugin contract pytest` present), requiring a named job's id fails closed end-to-end, an unnamed job's id **is** collected, a named job and an unnamed neighbour resolve differently in one pass, and a trailing unnamed job is flushed at end of file.

Against this repo's real workflows the collector now returns exactly the 13 check-run names GitHub emits - 11 `name:` literals plus the two unnamed job ids (`build`, `claude-review`) - and none of `pytest`, `lint`, `contract-tests`, `floor`, `self-anchor`.

## Testing

- `cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q` - 195 passed.
- `ruff check` and `mypy` clean on both changed files.
- Live run against this repo exits 0: both floor contexts required, all 6 required contexts produced by a job.
- FC13 probe in a fresh scratch clone: renaming the `name: scripts/ pytest` literal in `.github/workflows/tests.yml` makes the anchor exit 1 and name the orphaned context `scripts/ pytest`. The "Job names seen" list in that failure now contains only real check-run names.

Touches only `scripts/floor_anchor.py` and `scripts/tests/test_floor_anchor.py` - inside the FC16 allowlist, no plugin version bump, no workflow edits.