### PR TITLE
feat: Add the floor sign-off environment job and anchor assertions

### DIFF
--- a/.github/workflows/floor.yml
+++ b/.github/workflows/floor.yml
@@ -102,8 +102,11 @@ jobs:
           fetch-depth: 0  # full history so the merge-base is resolvable
           persist-credentials: false
 
+      # NO --depth=1 here. The checkout above is unshallow on purpose, and a
+      # shallow fetch into it writes a graft that truncates the base branch's
+      # ancestry at its tip -- exactly where `git merge-base` below has to walk.
       - name: Fetch the PR base branch
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
 
       - name: Marker removal detection (base-vs-head)
         run: |
@@ -184,8 +187,11 @@ jobs:
           fetch-depth: 0  # full history so the merge-base is resolvable
           persist-credentials: false
 
+      # NO --depth=1 here. The checkout above is unshallow on purpose, and a
+      # shallow fetch into it writes a graft that truncates the base branch's
+      # ancestry at its tip -- exactly where `git merge-base` below has to walk.
       - name: Fetch the PR base branch
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
 
       - name: Detect changes to protected paths
         id: filter

--- a/.github/workflows/floor.yml
+++ b/.github/workflows/floor.yml
@@ -12,6 +12,22 @@
 #     2. FLOOR.md four-clause integrity (unconditional -- FLOOR.md exists from the
 #        PR that introduced this workflow onward).
 #
+#   floor sign-off (clause iii, the named approval artefact):
+#     A deployment-review gate on the `floor-signoff` GitHub Environment, whose
+#     sole required reviewer is the repository owner. It is requested only when
+#     the path filter reports that the PR changes the floor's own core -- the
+#     same classification call the canary layer keys off, asked for one role, so
+#     this file still learns no path. The approval is a click in the deployments
+#     UI with an actor and a timestamp GitHub records OUTSIDE the diff, which is
+#     what makes it an artefact the PR under review cannot forge.
+#     It adds no required status check. `floor enforcement` needs it and runs on
+#     every non-cancelled outcome (`if: ${{ !cancelled() }}`, no result
+#     conjunct): a skipped `needs` job would otherwise propagate and let a PR go
+#     green with the deterministic layer never having run, and a `!= 'failure'`
+#     conjunct would do the same in exactly the case the sign-off exists to
+#     stop. So a refusal is converted into a RED required context by the first
+#     step of `floor enforcement` rather than an absent one.
+#
 #   floor self-anchor (E2, fail-closed on repo settings):
 #     Query the live GitHub API and FAIL (fail-closed) if either floor check
 #     (floor enforcement / floor self-anchor) is no longer required on the
@@ -66,8 +82,20 @@ permissions:
 jobs:
   floor:
     name: floor enforcement
+    # The sign-off gate runs first when the floor core changed. `!cancelled()`
+    # alone is deliberate: a skipped or failed sign-off must never skip this
+    # required context, because branch protection reads an absent context as
+    # satisfied. Refusal is turned into a job failure by the first step below.
+    needs: [signoff]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      - name: Fail on a refused sign-off
+        if: needs.signoff.result == 'failure'
+        run: |
+          echo "::error::The maintainer REFUSED the floor sign-off deployment review for this pull request. A change to the floor core takes effect only with that approval (FLOOR.md clause iii), so this required check is red rather than absent."
+          exit 1
+
       - name: Check out the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -95,6 +123,27 @@ jobs:
             echo "Marker-removal detection and FLOOR.md four-clause integrity both hold."
             echo "The repo-settings anchor is checked separately by the \`floor self-anchor\` job."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ------------------------------------------------------------------------- #
+  # Clause-iii layer: the named sign-off artefact. `environment:` makes GitHub
+  # request a deployment review from that environment's required reviewers (the
+  # repository owner, its sole reviewer) and hold this job until one of them
+  # approves or rejects. The condition comes from the `canary path filter` job
+  # defined below, asked for the floor-core role alone -- so the decision is the
+  # script's, not this file's. On every other pull request this job is skipped
+  # and no review is requested.
+  signoff:
+    name: floor sign-off
+    needs: [canary-changes]
+    if: needs.canary-changes.outputs.floor_core_changed == 'true'
+    environment: floor-signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record the approval
+        run: |
+          echo "Floor sign-off APPROVED by the maintainer's deployment review."
+          echo "That review -- its actor and timestamp recorded by GitHub outside"
+          echo "the diff -- is the out-of-band approval FLOOR.md clause iii requires."
 
   self-anchor:
     name: floor self-anchor
@@ -127,6 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_canaries: ${{ steps.filter.outputs.run_canaries }}
+      floor_core_changed: ${{ steps.filter.outputs.floor_core_changed }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -146,8 +196,10 @@ jobs:
           # script classifies each changed path by directory role and echoes back
           # the protected subset. Whether that subset is empty is the only thing
           # read here, so this file never learns a path.
-          PROTECTED="$(git diff --name-only "${BASE_SHA}" HEAD \
-            | python scripts/floor_check.py protected --base "${BASE_SHA}" --changed)"
+          CHANGED="${RUNNER_TEMP}/floor-changed-paths.txt"
+          git diff --name-only "${BASE_SHA}" HEAD > "${CHANGED}"
+          PROTECTED="$(python scripts/floor_check.py protected \
+            --base "${BASE_SHA}" --changed < "${CHANGED}")"
           if printf '%s\n' "${PROTECTED}" | grep -q .; then
             echo "run_canaries=true" >> "$GITHUB_OUTPUT"
             echo "Protected paths changed: canary suite WILL run."
@@ -155,6 +207,19 @@ jobs:
           else
             echo "run_canaries=false" >> "$GITHUB_OUTPUT"
             echo "No protected paths changed: canary suite will be skipped."
+          fi
+          # The same delegated decision, asked for one role: a change to the
+          # floor's own core is what needs the maintainer's sign-off (clause
+          # iii). Same script, same base, so the two answers cannot drift.
+          FLOOR_CORE="$(python scripts/floor_check.py protected \
+            --base "${BASE_SHA}" --changed --role floor-core < "${CHANGED}")"
+          if printf '%s\n' "${FLOOR_CORE}" | grep -q .; then
+            echo "floor_core_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Floor core changed: a maintainer sign-off WILL be requested."
+            printf '%s\n' "${FLOOR_CORE}"
+          else
+            echo "floor_core_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Floor core untouched: no sign-off requested."
           fi
 
   canary-suite:

--- a/scripts/floor_anchor.py
+++ b/scripts/floor_anchor.py
@@ -7,9 +7,15 @@ This script closes that gap: it queries the live GitHub API on every run and
 HARD-FAILS (fail-closed) unless BOTH of these hold:
 
   1. both floor status checks (``floor enforcement`` and ``floor self-anchor``)
-     are still required on the default branch, and
+     are still required on the default branch,
   2. branch protection is readable at all -- i.e. an anchor token with
-     admin:read is present, so requirement 1 can actually be confirmed.
+     admin:read is present, so requirement 1 can actually be confirmed, and
+  3. clause iii's sign-off artefact is intact: the ``floor-signoff`` deployment
+     environment exists with the repository owner as a required reviewer, and
+     the checked-out ``floor.yml`` still wires that environment into a job the
+     ``floor enforcement`` job needs. Either half alone is decorative -- an
+     environment nothing references never asks for a review, and a job pointing
+     at an environment with no required reviewer approves itself.
 
 These two are fail-CLOSED: any inability to confirm them (missing token,
 insufficient permissions) is a failure, never a pass. Reading branch protection
@@ -46,6 +52,10 @@ FLOOR_CONTEXT = os.environ.get("FLOOR_CONTEXT", "floor enforcement")
 # anchor would go red without gating, and the floor would silently disarm (E2).
 ANCHOR_CONTEXT = os.environ.get("ANCHOR_CONTEXT", "floor self-anchor")
 FLOOR_PATH = ".github/workflows/floor.yml"
+# The deployment environment that carries clause iii's sign-off artefact. Read
+# from the environment like the two contexts above, so the fail-closed branches
+# below can be driven against a name that deliberately does not exist.
+SIGNOFF_ENVIRONMENT = os.environ.get("FLOOR_SIGNOFF_ENVIRONMENT", "floor-signoff")
 
 # Where the workflow definitions live, relative to the repository root, and the
 # line shapes a job identity takes in them. Jobs sit at two-space indentation
@@ -62,6 +72,12 @@ JOB_NAME_RE = re.compile(r"^\s{4}name: (.+)$")
 JOB_ID_RE = re.compile(r"^ {2}([A-Za-z0-9_-]+):\s*$")
 JOBS_KEY_RE = re.compile(r"^jobs:\s*$")
 TOP_LEVEL_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+:")
+# Job-level keys the wiring check reads, at the same four-space depth as
+# ``name:``. ``needs:`` takes three shapes (a bare id, an inline list, or a
+# block list), so its value is captured raw and split below.
+JOB_ENVIRONMENT_RE = re.compile(r"^\s{4}environment:\s*(.+?)\s*$")
+JOB_NEEDS_RE = re.compile(r"^\s{4}needs:\s*(.*?)\s*$")
+BLOCK_LIST_ITEM_RE = re.compile(r"^\s{6}-\s*(.+?)\s*$")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # --- E2 DESCOPE: floor.yml path lock (maintainer decision, 2026-07-10) --------
@@ -95,7 +111,7 @@ class AnchorError(Exception):
 
 
 def remediation(repo: str) -> str:
-    """The two maintainer-only, out-of-band commands that arm the anchor.
+    """The three maintainer-only, out-of-band steps that arm the anchor.
 
     Named verbatim so the red is actionable without opening the proof doc. These
     require owner/admin and a fine-grained PAT with 'Administration: read' -- the
@@ -128,6 +144,21 @@ Missing configuration (maintainer-only, run out-of-band -- see docs/floor-anchor
      Both are needed. Actions secrets and Dependabot secrets are separate
      stores, so a rotation that sets only the first leaves every
      Dependabot-triggered run without a token and red on this check.
+
+  3. Create clause iii's sign-off artefact: a deployment environment named
+     {SIGNOFF_ENVIRONMENT} whose SOLE required reviewer is the repository
+     owner, and no deployment branch policy. It is a settings object, not a
+     file, which is the point -- the approval it records lives outside the diff
+     under review:
+
+     gh api "repos/{repo}/environments/{SIGNOFF_ENVIRONMENT}" --method PUT \\
+       --input - <<'JSON'
+     {{"reviewers": [{{"type": "User", "id": <the owner's numeric user id>}}]}}
+     JSON
+
+     The owner's numeric id comes from: gh api "repos/{repo}" --jq .owner.id
+     An environment with no required reviewer auto-approves its own deployment,
+     so the 'floor sign-off' job would go green with no maintainer click.
 
 Note: the floor.yml path lock (a push ruleset with file_path_restriction over
 {FLOOR_PATH}) is DESCOPED per the maintainer's PRD-E2 decision \
@@ -378,6 +409,202 @@ def check_contexts_have_workflows(contexts: set[str], root: Path | None = None) 
     )
 
 
+def _repo_owner(repo: str, token: str) -> str:
+    """The repository owner's login, or fail closed.
+
+    The owner is the identity clause iii names as the signer, so an inability
+    to resolve it is an inability to confirm the sign-off artefact.
+    """
+    status, data = _get(f"/repos/{repo}", token)
+    if status != 200 or not isinstance(data, dict):
+        raise AnchorError(f"cannot read repo metadata (HTTP {status}): {data}")
+    owner = (data.get("owner") or {}).get("login")
+    if not owner:
+        raise AnchorError(f"repo metadata for {repo!r} names no owner login: {data}")
+    return str(owner)
+
+
+def _required_reviewer_logins(data: dict) -> set[str]:
+    """Every USER login listed by a ``required_reviewers`` protection rule.
+
+    Team reviewers are deliberately ignored: clause iii names the maintainer,
+    and a team the maintainer may later leave is not the same guarantee.
+    """
+    logins: set[str] = set()
+    for rule in data.get("protection_rules", []) or []:
+        if not isinstance(rule, dict) or rule.get("type") != "required_reviewers":
+            continue
+        for entry in rule.get("reviewers", []) or []:
+            if not isinstance(entry, dict) or entry.get("type") != "User":
+                continue
+            login = (entry.get("reviewer") or {}).get("login")
+            if login:
+                logins.add(str(login))
+    return logins
+
+
+def check_signoff_environment(repo: str, token: str) -> None:
+    """Fail unless clause iii's sign-off environment exists and gates on the owner.
+
+    The environment is the artefact clause iii names: a deployment review with
+    an actor and a timestamp GitHub records OUTSIDE the diff, so the pull
+    request under review cannot forge it. Deleting the environment, or dropping
+    the owner from its required reviewers, would turn the ``floor sign-off``
+    job into a no-op that auto-approves every floor change -- green, silent, and
+    exactly the disarm this script exists to catch. So every branch here fails
+    CLOSED: a 404, any other non-200, and an unreadable or owner-less reviewer
+    list are all failures, never passes.
+    """
+    env = SIGNOFF_ENVIRONMENT
+    status, data = _get(f"/repos/{repo}/environments/{env}", token)
+    if status == 404:
+        raise AnchorError(
+            f"the {env!r} deployment environment does not exist on {repo}. "
+            "FLOOR.md clause iii records the maintainer's out-of-band approval "
+            f"as a deployment review of {env!r}; with no such environment the "
+            "'floor sign-off' job requests no review and a floor change "
+            "approves itself."
+        )
+    if status != 200 or not isinstance(data, dict):
+        raise AnchorError(
+            f"cannot read the {env!r} deployment environment (HTTP {status}): "
+            f"{data}. The anchor cannot confirm clause iii's sign-off artefact, "
+            "so it fails closed."
+        )
+    owner = _repo_owner(repo, token)
+    reviewers = _required_reviewer_logins(data)
+    if owner not in reviewers:
+        raise AnchorError(
+            f"the {env!r} environment does not require a review from the "
+            f"repository owner {owner!r}. Required user reviewers seen: "
+            f"{sorted(reviewers) or 'none'}. An environment with no required "
+            "reviewer approves its own deployment, so the 'floor sign-off' job "
+            "would go green with no maintainer click (FLOOR.md clause iii)."
+        )
+    print(
+        f"ok   the {env!r} environment exists and requires a review from the "
+        f"repository owner ({owner!r})."
+    )
+
+
+def _floor_workflow_jobs(text: str) -> dict[str, list[str]]:
+    """Split ``floor.yml`` into ``{job id: its lines}``.
+
+    A line scan rather than a YAML parse, for the same reason
+    ``_workflow_job_names`` is one: the self-anchor job runs bare ``python``
+    with no dependency install, so PyYAML is not available to it.
+    """
+    jobs: dict[str, list[str]] = {}
+    in_jobs = False
+    current: str | None = None
+    for line in text.splitlines():
+        if JOBS_KEY_RE.match(line):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        if TOP_LEVEL_KEY_RE.match(line):
+            break  # a new top-level key ends the jobs block
+        job_id = JOB_ID_RE.match(line)
+        if job_id:
+            current = job_id.group(1)
+            jobs[current] = []
+            continue
+        if current is not None:
+            jobs[current].append(line)
+    return jobs
+
+
+def _job_needs(lines: list[str]) -> set[str]:
+    """The job ids a job's ``needs:`` names, across all three YAML shapes."""
+    needs: set[str] = set()
+    for index, line in enumerate(lines):
+        match = JOB_NEEDS_RE.match(line)
+        if not match:
+            continue
+        inline = match.group(1).strip()
+        if inline:
+            needs.update(
+                part.strip().strip("\"'[]")
+                for part in inline.strip("[]").split(",")
+                if part.strip().strip("\"'[]")
+            )
+            continue
+        for follow in lines[index + 1:]:  # a block list under `needs:`
+            item = BLOCK_LIST_ITEM_RE.match(follow)
+            if not item:
+                break
+            needs.add(item.group(1).strip().strip("\"'"))
+    return needs
+
+
+def check_workflow_wiring(root: Path | None = None) -> None:
+    """Fail unless the checked-out ``floor.yml`` still wires the environment in.
+
+    An existing environment proves nothing on its own: if no job carries
+    ``environment: <name>``, no deployment review is ever requested, and if the
+    job that carries it is not in ``floor enforcement``'s ``needs``, a refusal
+    cannot reach the required context. Reading the CHECKED-OUT file (not the
+    default branch) moves that discovery into the pull request that unwires it,
+    which is the same reason ``check_contexts_have_workflows`` reads this branch.
+    """
+    env = SIGNOFF_ENVIRONMENT
+    base = REPO_ROOT if root is None else Path(root)
+    path = base / FLOOR_PATH
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AnchorError(
+            f"cannot read {FLOOR_PATH} to confirm the {env!r} environment is "
+            f"still wired into the floor jobs ({exc}). Fails closed."
+        ) from exc
+
+    jobs = _floor_workflow_jobs(text)
+    quoted = {env, f"'{env}'", f'"{env}"'}
+    env_jobs = {
+        job_id
+        for job_id, lines in jobs.items()
+        for line in lines
+        if (m := JOB_ENVIRONMENT_RE.match(line)) and m.group(1) in quoted
+    }
+    if not env_jobs:
+        raise AnchorError(
+            f"no job in {FLOOR_PATH} carries `environment: {env}`. Without it "
+            "GitHub requests no deployment review, so a floor change merges "
+            "with no maintainer approval (FLOOR.md clause iii)."
+        )
+
+    enforcement = [
+        job_id
+        for job_id, lines in jobs.items()
+        for line in lines
+        if (m := JOB_NAME_RE.match(line))
+        and m.group(1).strip().strip("\"'") == FLOOR_CONTEXT
+    ]
+    if not enforcement:
+        raise AnchorError(
+            f"no job in {FLOOR_PATH} is named {FLOOR_CONTEXT!r}, so the "
+            f"{env!r} sign-off cannot be wired into the required context. "
+            "Fails closed."
+        )
+    needs = set()
+    for job_id in enforcement:
+        needs |= _job_needs(jobs[job_id])
+    wired = sorted(env_jobs & needs)
+    if not wired:
+        raise AnchorError(
+            f"the {FLOOR_CONTEXT!r} job does not declare any {env!r} job in "
+            f"`needs:` (job(s) carrying the environment: {sorted(env_jobs)}; "
+            f"needs seen: {sorted(needs) or 'none'}). A sign-off the required "
+            "context does not depend on cannot turn a refusal red, and branch "
+            "protection reads an absent context as satisfied."
+        )
+    print(
+        f"ok   {FLOOR_PATH} wires the {env!r} environment into job "
+        f"{wired[0]!r}, which the {FLOOR_CONTEXT!r} job needs."
+    )
+
+
 def _descope_warning() -> str:
     """The loud, non-failing warning for the DESCOPED floor.yml path lock (E2).
 
@@ -460,15 +687,18 @@ def main() -> int:
         branch = _default_branch(repo, token)
         contexts = check_required_check(repo, branch, token)
         check_contexts_have_workflows(contexts)
+        check_signoff_environment(repo, token)
+        check_workflow_wiring()
     except AnchorError as exc:
         return _fail(str(exc), repo)
     # E2 descope: the floor.yml path lock is a documented capability gap on this
     # public, user-owned repo (org-only GitHub feature). Warn loudly, never fail.
     warn_path_lock_descoped()
     print(
-        "\nSelf-anchor check passed: both hard requirements hold (both floor "
-        "checks required + branch protection readable). The floor.yml path lock "
-        "is descoped (see the warning above)."
+        "\nSelf-anchor check passed: all three hard requirements hold (both "
+        "floor checks required + branch protection readable + clause iii's "
+        f"{SIGNOFF_ENVIRONMENT!r} sign-off environment present and wired). The "
+        "floor.yml path lock is descoped (see the warning above)."
     )
     return 0
 

--- a/scripts/tests/test_floor_anchor.py
+++ b/scripts/tests/test_floor_anchor.py
@@ -35,13 +35,38 @@ def _stub_get(required_contexts):
     return _get
 
 
-def _stub_get_full(required_contexts, default_branch="main"):
-    """Like ``_stub_get`` but also answers the repo-metadata call so ``main`` can
-    resolve the default branch and run end-to-end offline."""
+OWNER = "bjcoombs"
+
+
+def _environment_payload(reviewers=(OWNER,)):
+    """A GitHub environment body whose required reviewers are ``reviewers``."""
+    return {
+        "name": floor_anchor.SIGNOFF_ENVIRONMENT,
+        "protection_rules": [
+            {
+                "type": "required_reviewers",
+                "reviewers": [
+                    {"type": "User", "reviewer": {"login": login}}
+                    for login in reviewers
+                ],
+            }
+        ],
+    }
+
+
+def _stub_get_full(
+    required_contexts, default_branch="main", environment=None, env_status=200
+):
+    """Like ``_stub_get`` but also answers the repo-metadata and environment
+    calls, so ``main`` can resolve the default branch, the owner and clause
+    iii's sign-off environment and run end-to-end offline."""
+    env_body = _environment_payload() if environment is None else environment
 
     def _get(path, token):
         if path == f"/repos/{REPO}":
-            return 200, {"default_branch": default_branch}
+            return 200, {"default_branch": default_branch, "owner": {"login": OWNER}}
+        if "/environments/" in path:
+            return env_status, env_body
         if "required_status_checks" in path:
             return 200, {"contexts": sorted(required_contexts)}
         if path.endswith("/rulesets"):
@@ -518,3 +543,177 @@ def test_main_fails_closed_when_a_required_context_has_no_job(monkeypatch, capsy
     rc = main()
     assert rc == 1
     assert "no such job xyz" in capsys.readouterr().err
+
+
+# ── clause iii's sign-off artefact: environment + workflow wiring (fail-closed) ─
+#
+# Three disarm paths, each of which leaves the `floor sign-off` job LOOKING
+# present while approving nothing: the environment is deleted, its required
+# reviewer is dropped (an environment with none auto-approves its own
+# deployment), or floor.yml stops wiring the environment into the job the
+# required context needs. Each must fail closed rather than pass quietly.
+
+FLOOR_YML_WIRED = """\
+name: Floor
+
+on:
+  pull_request:
+
+jobs:
+  floor:
+    name: floor enforcement
+    needs: [signoff]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on a refused sign-off
+        run: exit 1
+
+  signoff:
+    name: floor sign-off
+    needs: [canary-changes]
+    environment: floor-signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record the approval
+        run: echo ok
+"""
+
+
+def _floor_yml(tmp_path, body=FLOOR_YML_WIRED):
+    """Materialize a repo root whose .github/workflows holds one floor.yml."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    (wf_dir / "floor.yml").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def test_signoff_environment_passes_when_the_owner_is_a_required_reviewer(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(floor_anchor, "_get", _stub_get_full(set()))
+    floor_anchor.check_signoff_environment(REPO, "tok")
+    out = capsys.readouterr().out
+    assert "ok   " in out
+    assert floor_anchor.SIGNOFF_ENVIRONMENT in out
+    assert OWNER in out
+
+
+def test_signoff_environment_fails_closed_when_the_environment_is_absent(monkeypatch):
+    # Disarm path 1: the environment is deleted in repo settings. The job still
+    # names it, GitHub requests no review, and every floor change self-approves.
+    monkeypatch.setattr(
+        floor_anchor, "_get", _stub_get_full(set(), env_status=404, environment={})
+    )
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_signoff_environment(REPO, "tok")
+    msg = str(exc.value)
+    assert floor_anchor.SIGNOFF_ENVIRONMENT in msg
+    assert "does not exist" in msg
+
+
+def test_signoff_environment_fails_closed_when_the_owner_is_not_a_reviewer(monkeypatch):
+    # Disarm path 2: the environment survives but its required-reviewer rule no
+    # longer lists the owner, so the deployment approves itself.
+    monkeypatch.setattr(
+        floor_anchor,
+        "_get",
+        _stub_get_full(set(), environment=_environment_payload(reviewers=())),
+    )
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_signoff_environment(REPO, "tok")
+    msg = str(exc.value)
+    assert OWNER in msg
+    assert floor_anchor.SIGNOFF_ENVIRONMENT in msg
+
+
+def test_signoff_environment_fails_closed_when_only_a_team_reviews(monkeypatch):
+    # A team is not the maintainer clause iii names, and membership can change
+    # without any floor edit, so a team-only rule is not the artefact.
+    team_rule = {
+        "protection_rules": [
+            {
+                "type": "required_reviewers",
+                "reviewers": [{"type": "Team", "reviewer": {"slug": "maintainers"}}],
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        floor_anchor, "_get", _stub_get_full(set(), environment=team_rule)
+    )
+    with pytest.raises(floor_anchor.AnchorError):
+        floor_anchor.check_signoff_environment(REPO, "tok")
+
+
+def test_signoff_environment_fails_closed_on_an_unreadable_response(monkeypatch):
+    # A 403 (token without the scope) is an inability to confirm, never a pass.
+    monkeypatch.setattr(
+        floor_anchor,
+        "_get",
+        _stub_get_full(set(), env_status=403, environment={"message": "Forbidden"}),
+    )
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_signoff_environment(REPO, "tok")
+    assert "403" in str(exc.value)
+
+
+def test_signoff_workflow_wiring_passes_on_a_wired_floor_yml(tmp_path, capsys):
+    floor_anchor.check_workflow_wiring(_floor_yml(tmp_path))
+    out = capsys.readouterr().out
+    assert "ok   " in out
+    assert "signoff" in out
+
+
+def test_signoff_workflow_wiring_fails_closed_without_the_environment_line(tmp_path):
+    # Disarm path 3a: the environment survives in settings but no job names it,
+    # so no deployment review is ever requested.
+    body = FLOOR_YML_WIRED.replace("    environment: floor-signoff\n", "")
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_workflow_wiring(_floor_yml(tmp_path, body))
+    msg = str(exc.value)
+    assert floor_anchor.SIGNOFF_ENVIRONMENT in msg
+    assert floor_anchor.FLOOR_PATH in msg
+
+
+def test_signoff_workflow_wiring_fails_closed_when_enforcement_drops_needs(tmp_path):
+    # Disarm path 3b: the job still requests the review, but the required
+    # context no longer depends on it, so a refusal cannot turn it red.
+    body = FLOOR_YML_WIRED.replace("    needs: [signoff]\n", "")
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_workflow_wiring(_floor_yml(tmp_path, body))
+    msg = str(exc.value)
+    assert "needs" in msg
+    assert floor_anchor.FLOOR_CONTEXT in msg
+
+
+def test_signoff_workflow_wiring_reads_a_block_list_needs(tmp_path, capsys):
+    # `needs:` takes three YAML shapes; a block list must not read as unwired.
+    body = FLOOR_YML_WIRED.replace(
+        "    needs: [signoff]\n", "    needs:\n      - signoff\n"
+    )
+    floor_anchor.check_workflow_wiring(_floor_yml(tmp_path, body))
+    assert "ok   " in capsys.readouterr().out
+
+
+def test_signoff_workflow_wiring_fails_closed_without_a_floor_yml(tmp_path):
+    with pytest.raises(floor_anchor.AnchorError):
+        floor_anchor.check_workflow_wiring(tmp_path)
+
+
+def test_signoff_wiring_holds_against_this_repo(capsys):
+    # The live assertion, run against the checked-out floor.yml: this branch
+    # still wires the environment into the job the required context needs.
+    floor_anchor.check_workflow_wiring()
+    assert "ok   " in capsys.readouterr().out
+
+
+def test_signoff_environment_name_is_read_from_the_environment(monkeypatch):
+    # The name is an env var (like FLOOR_CONTEXT/ANCHOR_CONTEXT) so the
+    # fail-closed branch can be driven live against a name that cannot exist.
+    monkeypatch.setattr(floor_anchor, "SIGNOFF_ENVIRONMENT", "no-such-environment-probe")
+    monkeypatch.setattr(
+        floor_anchor, "_get", _stub_get_full(set(), env_status=404, environment={})
+    )
+    with pytest.raises(floor_anchor.AnchorError) as exc:
+        floor_anchor.check_signoff_environment(REPO, "tok")
+    assert "no-such-environment-probe" in str(exc.value)


### PR DESCRIPTION
## Summary

Clause iii's "explicit, out-of-band approval" gains its named artefact: a
deployment review of the `floor-signoff` GitHub Environment, whose sole
required reviewer is the repository owner. The approval is a click with an
actor and a timestamp GitHub records **outside** the diff, which is what makes
it something the pull request under review cannot forge.

No job `name:` literal changed, no new required status check was registered,
and no branch protection was touched. Merge stays blocked by the two floor
contexts that already gate it.

## Changes

**`.github/workflows/floor.yml`**

- `canary path filter` gains an output `floor_core_changed`, derived from the
  same `floor_check.py protected` call the canary layer keys off, asked for the
  `floor-core` role alone. The two answers come from one script, one base and
  one changed-path list, so they cannot drift, and this file still makes no
  path decision of its own.
- New job `signoff` / `name: floor sign-off`, `needs: [canary-changes]`,
  `if: needs.canary-changes.outputs.floor_core_changed == 'true'`,
  `environment: floor-signoff`. On every other PR it is skipped and no review is
  requested.
- `floor enforcement` gains `needs: [signoff]` and `if: ${{ !cancelled() }}` -
  the bare guard, no result conjunct. A skipped `needs` job propagates, and
  branch protection reads a skipped required context as satisfied, so an
  unguarded `needs` would let a nothing-protected PR go green with the
  deterministic layer never having run. Adding `!= 'failure'` reopens the same
  hole from the other end: GitHub records a refused review as a `failure`, so
  the conjunct would skip the required context in exactly the case the sign-off
  exists to stop. Instead the job's FIRST step, `Fail on a refused sign-off`,
  converts `needs.signoff.result == 'failure'` into a red job.
- `floor self-anchor` keeps no `needs` and no signoff-referencing `if`, so the
  second required context can never be skipped through the sign-off job.

- Both `Fetch the PR base branch` steps drop `--depth=1` (a reviewer finding on
  #309, folded in here because this PR already owns the file). Each job checks
  out with `fetch-depth: 0` so the merge-base is resolvable, then fetched the
  base shallow - which writes a graft truncating the base branch's ancestry at
  its tip, precisely the history `git merge-base` walks in the next step.
  `--no-tags` and the `base_ref` expression are unchanged.

- `floor enforcement` also needs `canary-changes`, with a second step
  `Fail on an unclassified path filter` (`if: needs.canary-changes.result !=
  'success'`). Without it a failed filter job leaves `signoff` **skipped** -
  not `failure` - so the refusal step waves it through and the required context
  goes green with no sign-off at all. That was reachable from the PR under
  review: dropping a role from `ROLES` in `floor_check.py` makes argparse exit
  2, the filter step dies under `set -e`, and the gate this PR adds is gone on
  a clean merge.

**`scripts/floor_anchor.py`** - a third fail-closed requirement, stdlib only:

- `check_signoff_environment(repo, token)` - GETs
  `/repos/{repo}/environments/{FLOOR_SIGNOFF_ENVIRONMENT}` (default
  `floor-signoff`) and fails closed on 404, on any other non-200, and when no
  `required_reviewers` rule names the repository owner **and no one else**.
  Membership is the wrong test: an environment review is satisfied by any ONE
  of its reviewers, so `{owner, someone-else}` - or a team beside the owner -
  passes a membership check while the owner's click is no longer required. An
  environment with no required reviewer approves its own deployment.
- `check_workflow_wiring()` - reads the CHECKED-OUT `floor.yml` and fails closed
  unless a job carries `environment: <name>`, `floor enforcement`'s `needs`
  includes that job's id, **and** a refusal still lands as red: the job guard
  must carry no `needs.<signoff>.result` conjunct (one would make the required
  context skip, which branch protection reads as satisfied) and some step must
  guard on that result being `failure`. Wiring without the conversion is an
  environment that requests a review nothing acts on. An environment nothing references requests no review;
  a sign-off the required context does not depend on cannot turn a refusal red.
  A line scan, not a YAML parse, for the same reason `_workflow_job_names` is
  one: the self-anchor job runs bare `python` with no dependency install.
- `remediation()` gains step 3, the environment setup, and step 2 now names
  `Environments: read` beside `Administration: read` - requirement 3 reads a
  different endpoint, so a rotation following the printed text literally would
  produce a 403 with no hint which permission was missing.

**`scripts/tests/test_floor_anchor.py`** - 12 tests carrying `signoff` in their
names, covering five disarm paths - environment absent, owner not a reviewer,
an extra user reviewer, a team reviewer beside the owner, `floor.yml` unwired,
the refusal step deleted, and a result conjunct on the job guard - plus a
team-only rule, a 403, a block-list `needs:`, a missing `floor.yml`, and the
live assertions against this branch. 19 -> 35 tests in the file.

`FLOOR.md` and `REQUIRED_CLAUSES['iii']` already carried `floor-signoff` from
tasks 1 and 4; FC8 re-verified below and needed no change.

## Testing

```
$ cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest -q
211 passed

$ GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest --with pyyaml pytest tests/ -q
576 passed

$ cd scripts && uv run --with ruff ruff check .
All checks passed!
```

### FC9 - workflow shape and the required-check set

```
$ uv run --with pyyaml python - <<'PY' … (the contract's own reader)
{"anchor_needs": null, "anchor_if": "None", "signoff_id": "signoff",
 "signoff_env": "floor-signoff",
 "signoff_if": "needs.canary-changes.outputs.floor_core_changed == 'true'",
 "floor_needs": ["signoff", "canary-changes"], "floor_if": "${{ !cancelled() }}",
 "floor_step0": "Fail on a refused sign-off",
 "names": ["canary path filter", "canary suite (semantic layer)",
           "floor enforcement", "floor self-anchor", "floor sign-off"]}

$ gh api repos/bjcoombs/ai-native-toolkit/environments/floor-signoff \
    | jq -c '[.protection_rules[] | select(.type=="required_reviewers") | .reviewers[] | .reviewer.login]'
["bjcoombs"]

$ gh api repos/bjcoombs/ai-native-toolkit/branches/main/protection/required_status_checks | jq -c '[.checks[].context]|sort'
["Validate PR title","floor enforcement","floor self-anchor","plugin contract pytest","scripts/ pytest","skills/assess pytest"]
```

Six contexts, unchanged - no new required check.

### FC11 - the anchor's four branches, run live

```
$ GITHUB_REPOSITORY=… GITHUB_TOKEN=… FLOOR_ANCHOR_TOKEN=… uv run python scripts/floor_anchor.py
ok   both floor status checks ('floor enforcement', 'floor self-anchor') are required on 'main'.
ok   all 6 required context(s) are produced by a job name: or job id in .github/workflows/{*.yml,*.yaml}.
ok   the 'floor-signoff' environment exists and requires a review from the repository owner ('bjcoombs') and no one else.
ok   .github/workflows/floor.yml wires the 'floor-signoff' environment into job 'signoff', which the 'floor enforcement' job needs, and turns a refused review into a red required context.
rc=0

$ … FLOOR_SIGNOFF_ENVIRONMENT=no-such-environment-probe uv run python scripts/floor_anchor.py
FAIL floor self-anchor: the 'no-such-environment-probe' deployment environment does not exist on bjcoombs/ai-native-toolkit. …
rc=1

$ # fresh scratch clone with the `environment: floor-signoff` line deleted
FAIL floor self-anchor: no job in .github/workflows/floor.yml carries `environment: floor-signoff`. …
rc=1

$ cd scripts && GIT_CONFIG_GLOBAL=/dev/null uv run --with pytest pytest tests/test_floor_anchor.py -k signoff -q
16 passed, 35 deselected
```

### FC6 - the workflow still holds no path literal

```
$ rg -n 'grep -q?E|skills/marathon|skills/pr-review-merge|commands/tm|commands/issues|contract/\||canaries/\||\|scripts/contract|\|scripts/canaries|\|tests/canaries' .github/workflows/floor.yml
rc=1                      (no lines)
$ rg -c 'floor_check.py protected' .github/workflows/floor.yml   # 2
$ rg -c 'floor_check.py markers'   .github/workflows/floor.yml   # 1
$ rg -c 'floor_check.py clauses'   .github/workflows/floor.yml   # 1
```

### FC8 - FLOOR.md unchanged and still intact

```
$ rg -n 'skills/|commands/|plugins/' FLOOR.md ; echo rc=$?
rc=1
$ rg -c -F <each of the six literals> FLOOR.md   # floor_check.py 2, floor_anchor.py 1, floor.yml 3,
                                                 # scripts/contract/ 1, scripts/canaries/ 1, tests/canaries/ 1
$ rg -c 'floor-signoff' FLOOR.md                 # 1
$ rg -n '^#+ Markers' FLOOR.md                   # 65:## Markers
$ rg -c 'floor_check.py markers' FLOOR.md        # 1
$ python3 scripts/floor_check.py clauses ; echo rc=$?
ok   FLOOR.md: all four clauses intact, 4 floor token(s) declared.
rc=0
```

### FC16 - files touched

`.github/workflows/floor.yml`, `scripts/floor_anchor.py`,
`scripts/tests/test_floor_anchor.py`. Nothing under `skills/`, `agents/`,
`commands/`, `plugins/` or `.claude-plugin/`.

## Recorded sign-off runs (FC10)

Skipped sign-off run: 34225438130
Marked-only sign-off run: 34225463034
Weakened marker run: 34225470830
Refused sign-off run: 34256754313
Approved sign-off run: 34759388786

## Risk assessment

The sign-off adds a human gate to floor-core PRs and nothing else: on every
other PR `floor sign-off` is skipped and the two required contexts run exactly
as before. The riskiest shape here is the guard on `floor enforcement`, and it
is the one the recorded runs above exercise from all three directions - skipped,
refused, approved.

## Deployment notes

None. No version bump, no release, no branch-protection change. The
`floor-signoff` environment already exists in repo settings.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment review sign-off for changes affecting the floor core.
  * Floor enforcement now verifies sign-off approval and change classification before proceeding.
  * Added fail-closed validation for required environment reviewers and workflow safeguards.

* **Tests**
  * Expanded coverage for sign-off configuration, workflow dependencies, refusal handling, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
