### PR TITLE
chore: Probe skipped sign-off (throwaway, do not merge)

### DIFF
--- a/docs/floor-anchor-proof.md
+++ b/docs/floor-anchor-proof.md
@@ -227,3 +227,5 @@ HTTP 422
 ```
 
 That evidence is what grounds this descope; it is the same failure quoted above.
+
+Probe sentence: this line exercises the nothing-protected path of the floor sign-off gate; it is never merged.


### PR DESCRIPTION
Throwaway probe for FC10. Touches only `docs/floor-anchor-proof.md`, which the floor classifies as unprotected: `floor sign-off` should be skipped, both required floor jobs should run green, and the canary suite should be skipped. Never merged.