### PR TITLE
chore: Probe marked-only sign-off (throwaway, do not merge)

### DIFF
--- a/skills/marathon/probe-notes.md
+++ b/skills/marathon/probe-notes.md
@@ -1,0 +1,5 @@
+# Probe notes
+
+A throwaway file inside a marked component's directory, used once to observe
+that a marked-component change runs the canary layer without requesting the
+maintainer's floor sign-off. Never merged.


### PR DESCRIPTION
Throwaway probe for FC10. Adds a new file under a marked component's directory - protected, but not floor core - so the canary suite should run green while `floor sign-off` stays skipped. Never merged.