### PR TITLE
chore: Probe weakened marker detection (throwaway, do not merge)

### DIFF
--- a/skills/pr-review-merge/SKILL.md
+++ b/skills/pr-review-merge/SKILL.md
@@ -9,7 +9,6 @@ description: >
   handling, merge ordering), or when the user asks to take a PR to green/merge it.
 ---
 
-<!-- floor:cold-verify-completion -->
 
 # PR Review-to-Green + Smart Merge
 


### PR DESCRIPTION
Throwaway probe for FC10. Deletes only the standalone floor anchor line from one marked file, so `floor enforcement` should go RED on its `Marker removal detection (base-vs-head)` step while `floor sign-off` stays skipped and `floor self-anchor` stays green. Never merged.