### PR TITLE
chore: Probe refused sign-off (throwaway, do not merge)

### DIFF
--- a/FLOOR.md
+++ b/FLOOR.md
@@ -82,3 +82,4 @@ from a file that previously carried it (base-vs-head removal detection). So a
 retro that guts the instructions while leaving the marker comment intact still
 goes red, and a marked file that moves is followed to its new path rather than
 read as a deletion.
+

--- a/FLOOR.md
+++ b/FLOOR.md
@@ -83,3 +83,4 @@ retro that guts the instructions while leaving the marker comment intact still
 goes red, and a marked file that moves is followed to its new path rather than
 read as a deletion.
 
+


### PR DESCRIPTION
Throwaway probe for FC10. Adds a blank line to `FLOOR.md` - floor core - so the `floor sign-off` job requests a deployment review. The maintainer REJECTS it, and the expected observation is `floor sign-off` failed with no failed step of its own plus `floor enforcement` failed on its `Fail on a refused sign-off` step, rather than either job being skipped. Never merged.